### PR TITLE
feat(skills): add criativo-gerador-calendario

### DIFF
--- a/.agents/skills/criativo-gerador-calendario/SKILL.md
+++ b/.agents/skills/criativo-gerador-calendario/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: criativo-gerador-calendario
+description: Gera uma planilha Excel formatada com o calendario visual anual de 12 meses (mesclando celulas e cores) para os clientes colarem copys. Use sempre que o usuario pedir para gerar a "grade", "planilha estrutural", ou "calendario" de um cliente novo ou para um ano especifico.
+area: criativo
+author: v4er
+version: 1.0.0
+---
+
+# Gerador de Calendário Editorial Visual
+
+Essa skill constrói uma planilha Excel nativa (`.xlsx`) com toda a estrutura visual de 12 meses de um ano. Ela é formatada perfeitamente com células mescladas (2 colunas por dia), cores vermelhas no cabeçalho e 5 linhas extras para suportar textos longos de social media (copys) de cada dia.
+
+## Quando utilizar
+Utilize essa skill sempre que o usuário pedir:
+- "Gera a grade de calendário pro cliente X"
+- "Monta o excel do ano de 2026 pro cliente Y"
+- "Cria aquele calendário estrutural de social media"
+
+## Fluxo de Execução
+
+1. **Descubra o destino**: Pergunte ao usuário em qual pasta de cliente (ex: `clientes/nome-do-cliente/docs/`) o arquivo deve ser salvo e com qual nome (ex: `Calendario_2026.xlsx`). Se ele não especificar, sugira criar na pasta principal de `docs/` do cliente que ele estiver focado no momento.
+2. **Descubra o ano**: Se o usuário não disser, assuma o ano atual.
+3. **Execute o script**:
+   Rode o script em Python utilizando o `run_command` da seguinte forma:
+   
+   ```bash
+   python .agents/skills/criativo-gerador-calendario/scripts/gerar_calendario.py "clientes/nome-do-cliente/docs/Calendario_2026.xlsx" 2026
+   ```
+
+   *(Nota: O script Python está tanto na pasta `.agents` quanto na `.claude` e eles são idênticos. Você pode referenciar qualquer um dos dois.)*
+
+4. **Entregue o resultado**: Se o comando retornar "Excel gerado com sucesso!", avise o usuário onde o arquivo está salvo. Recomende que ele arraste o arquivo gerado para dentro do Google Drive (em *Arquivo > Importar*) para visualizar a grade completa.
+
+## Dependências
+Esta skill requer a biblioteca `openpyxl`. Se durante a execução do comando aparecer um erro de `ModuleNotFoundError`, rode `python -m pip install openpyxl` primeiro e então tente novamente.

--- a/.agents/skills/criativo-gerador-calendario/scripts/gerar_calendario.py
+++ b/.agents/skills/criativo-gerador-calendario/scripts/gerar_calendario.py
@@ -1,0 +1,96 @@
+import calendar
+import sys
+from openpyxl import Workbook
+from openpyxl.styles import Alignment, Font, PatternFill, Border, Side
+
+def create_excel_calendar(output_path, year=2026):
+    wb = Workbook()
+    ws = wb.active
+    ws.title = f"Calendario {year}"
+    
+    font_bold = Font(bold=True, size=11)
+    font_title = Font(bold=True, size=14, color="FFFFFF")
+    
+    fill_header = PatternFill(start_color="C00000", end_color="C00000", fill_type="solid")
+    fill_month = PatternFill(start_color="FF0000", end_color="FF0000", fill_type="solid")
+    
+    alignment_center = Alignment(horizontal="center", vertical="center")
+    alignment_top = Alignment(horizontal="left", vertical="top", wrap_text=True)
+    
+    thin = Side(border_style="thin", color="000000")
+    box_border = Border(left=thin, right=thin, top=thin, bottom=thin)
+    
+    for i in range(1, 15):
+        ws.column_dimensions[chr(64+i)].width = 20
+        
+    ws.merge_cells('A1:N1')
+    ws['A1'] = str(year)
+    ws['A1'].font = font_title
+    ws['A1'].fill = fill_header
+    ws['A1'].alignment = alignment_center
+    
+    days = ["DOMINGO", "SEGUNDA-FEIRA", "TERCA-FEIRA", "QUARTA-FEIRA", "QUINTA-FEIRA", "SEXTA-FEIRA", "SABADO"]
+    col = 1
+    for day in days:
+        ws.merge_cells(start_row=3, start_column=col, end_row=3, end_column=col+1)
+        cell = ws.cell(row=3, column=col)
+        cell.value = day
+        cell.font = font_bold
+        cell.alignment = alignment_center
+        cell.border = box_border
+        ws.cell(row=3, column=col+1).border = box_border
+        col += 2
+        
+    current_row = 4
+    cal = calendar.Calendar(firstweekday=6)
+    months = ["JANEIRO", "FEVEREIRO", "MARCO", "ABRIL", "MAIO", "JUNHO", 
+              "JULHO", "AGOSTO", "SETEMBRO", "OUTUBRO", "NOVEMBRO", "DEZEMBRO"]
+              
+    for month_idx, month_name in enumerate(months):
+        ws.merge_cells(start_row=current_row, start_column=1, end_row=current_row, end_column=14)
+        cell = ws.cell(row=current_row, column=1)
+        cell.value = month_name
+        cell.font = font_title
+        cell.fill = fill_month
+        cell.alignment = alignment_center
+        
+        for c in range(1, 15):
+            ws.cell(row=current_row, column=c).border = box_border
+
+        current_row += 1
+        
+        weeks = cal.monthdayscalendar(int(year), month_idx + 1)
+        for week in weeks:
+            col = 1
+            for day in week:
+                ws.merge_cells(start_row=current_row, start_column=col, end_row=current_row, end_column=col+1)
+                cell = ws.cell(row=current_row, column=col)
+                if day != 0:
+                    cell.value = day
+                cell.font = font_bold
+                cell.alignment = alignment_center
+                
+                cell.border = box_border
+                ws.cell(row=current_row, column=col+1).border = box_border
+                
+                ws.merge_cells(start_row=current_row+1, start_column=col, end_row=current_row+6, end_column=col+1)
+                content_cell = ws.cell(row=current_row+1, column=col)
+                content_cell.alignment = alignment_top
+                
+                for r in range(current_row+1, current_row+7):
+                    ws.cell(row=r, column=col).border = box_border
+                    ws.cell(row=r, column=col+1).border = box_border
+                
+                col += 2
+            current_row += 7
+
+    wb.save(output_path)
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        out = sys.argv[1]
+        yr = sys.argv[2] if len(sys.argv) > 2 else 2026
+        create_excel_calendar(out, int(yr))
+        print("Excel gerado com sucesso!")
+    else:
+        print("Uso: python gerar_calendario.py <caminho_saida.xlsx> [ano]")

--- a/.claude/skills/criativo-gerador-calendario/SKILL.md
+++ b/.claude/skills/criativo-gerador-calendario/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: criativo-gerador-calendario
+description: Gera uma planilha Excel formatada com o calendario visual anual de 12 meses (mesclando celulas e cores) para os clientes colarem copys. Use sempre que o usuario pedir para gerar a "grade", "planilha estrutural", ou "calendario" de um cliente novo ou para um ano especifico.
+area: criativo
+author: v4er
+version: 1.0.0
+---
+
+# Gerador de Calendário Editorial Visual
+
+Essa skill constrói uma planilha Excel nativa (`.xlsx`) com toda a estrutura visual de 12 meses de um ano. Ela é formatada perfeitamente com células mescladas (2 colunas por dia), cores vermelhas no cabeçalho e 5 linhas extras para suportar textos longos de social media (copys) de cada dia.
+
+## Quando utilizar
+Utilize essa skill sempre que o usuário pedir:
+- "Gera a grade de calendário pro cliente X"
+- "Monta o excel do ano de 2026 pro cliente Y"
+- "Cria aquele calendário estrutural de social media"
+
+## Fluxo de Execução
+
+1. **Descubra o destino**: Pergunte ao usuário em qual pasta de cliente (ex: `clientes/nome-do-cliente/docs/`) o arquivo deve ser salvo e com qual nome (ex: `Calendario_2026.xlsx`). Se ele não especificar, sugira criar na pasta principal de `docs/` do cliente que ele estiver focado no momento.
+2. **Descubra o ano**: Se o usuário não disser, assuma o ano atual.
+3. **Execute o script**:
+   Rode o script em Python utilizando o `run_command` da seguinte forma:
+   
+   ```bash
+   python .agents/skills/criativo-gerador-calendario/scripts/gerar_calendario.py "clientes/nome-do-cliente/docs/Calendario_2026.xlsx" 2026
+   ```
+
+   *(Nota: O script Python está tanto na pasta `.agents` quanto na `.claude` e eles são idênticos. Você pode referenciar qualquer um dos dois.)*
+
+4. **Entregue o resultado**: Se o comando retornar "Excel gerado com sucesso!", avise o usuário onde o arquivo está salvo. Recomende que ele arraste o arquivo gerado para dentro do Google Drive (em *Arquivo > Importar*) para visualizar a grade completa.
+
+## Dependências
+Esta skill requer a biblioteca `openpyxl`. Se durante a execução do comando aparecer um erro de `ModuleNotFoundError`, rode `python -m pip install openpyxl` primeiro e então tente novamente.

--- a/.claude/skills/criativo-gerador-calendario/scripts/gerar_calendario.py
+++ b/.claude/skills/criativo-gerador-calendario/scripts/gerar_calendario.py
@@ -1,0 +1,96 @@
+import calendar
+import sys
+from openpyxl import Workbook
+from openpyxl.styles import Alignment, Font, PatternFill, Border, Side
+
+def create_excel_calendar(output_path, year=2026):
+    wb = Workbook()
+    ws = wb.active
+    ws.title = f"Calendario {year}"
+    
+    font_bold = Font(bold=True, size=11)
+    font_title = Font(bold=True, size=14, color="FFFFFF")
+    
+    fill_header = PatternFill(start_color="C00000", end_color="C00000", fill_type="solid")
+    fill_month = PatternFill(start_color="FF0000", end_color="FF0000", fill_type="solid")
+    
+    alignment_center = Alignment(horizontal="center", vertical="center")
+    alignment_top = Alignment(horizontal="left", vertical="top", wrap_text=True)
+    
+    thin = Side(border_style="thin", color="000000")
+    box_border = Border(left=thin, right=thin, top=thin, bottom=thin)
+    
+    for i in range(1, 15):
+        ws.column_dimensions[chr(64+i)].width = 20
+        
+    ws.merge_cells('A1:N1')
+    ws['A1'] = str(year)
+    ws['A1'].font = font_title
+    ws['A1'].fill = fill_header
+    ws['A1'].alignment = alignment_center
+    
+    days = ["DOMINGO", "SEGUNDA-FEIRA", "TERCA-FEIRA", "QUARTA-FEIRA", "QUINTA-FEIRA", "SEXTA-FEIRA", "SABADO"]
+    col = 1
+    for day in days:
+        ws.merge_cells(start_row=3, start_column=col, end_row=3, end_column=col+1)
+        cell = ws.cell(row=3, column=col)
+        cell.value = day
+        cell.font = font_bold
+        cell.alignment = alignment_center
+        cell.border = box_border
+        ws.cell(row=3, column=col+1).border = box_border
+        col += 2
+        
+    current_row = 4
+    cal = calendar.Calendar(firstweekday=6)
+    months = ["JANEIRO", "FEVEREIRO", "MARCO", "ABRIL", "MAIO", "JUNHO", 
+              "JULHO", "AGOSTO", "SETEMBRO", "OUTUBRO", "NOVEMBRO", "DEZEMBRO"]
+              
+    for month_idx, month_name in enumerate(months):
+        ws.merge_cells(start_row=current_row, start_column=1, end_row=current_row, end_column=14)
+        cell = ws.cell(row=current_row, column=1)
+        cell.value = month_name
+        cell.font = font_title
+        cell.fill = fill_month
+        cell.alignment = alignment_center
+        
+        for c in range(1, 15):
+            ws.cell(row=current_row, column=c).border = box_border
+
+        current_row += 1
+        
+        weeks = cal.monthdayscalendar(int(year), month_idx + 1)
+        for week in weeks:
+            col = 1
+            for day in week:
+                ws.merge_cells(start_row=current_row, start_column=col, end_row=current_row, end_column=col+1)
+                cell = ws.cell(row=current_row, column=col)
+                if day != 0:
+                    cell.value = day
+                cell.font = font_bold
+                cell.alignment = alignment_center
+                
+                cell.border = box_border
+                ws.cell(row=current_row, column=col+1).border = box_border
+                
+                ws.merge_cells(start_row=current_row+1, start_column=col, end_row=current_row+6, end_column=col+1)
+                content_cell = ws.cell(row=current_row+1, column=col)
+                content_cell.alignment = alignment_top
+                
+                for r in range(current_row+1, current_row+7):
+                    ws.cell(row=r, column=col).border = box_border
+                    ws.cell(row=r, column=col+1).border = box_border
+                
+                col += 2
+            current_row += 7
+
+    wb.save(output_path)
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        out = sys.argv[1]
+        yr = sys.argv[2] if len(sys.argv) > 2 else 2026
+        create_excel_calendar(out, int(yr))
+        print("Excel gerado com sucesso!")
+    else:
+        print("Uso: python gerar_calendario.py <caminho_saida.xlsx> [ano]")


### PR DESCRIPTION
Skill de geracao de grade de calendario editorial em Excel.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is additive, self-contained documentation plus a standalone script that writes a new `.xlsx` file; impact is limited to requiring `openpyxl` when executed.
> 
> **Overview**
> Adds a new `criativo-gerador-calendario` skill (duplicated under both `.agents` and `.claude`) with usage instructions and a Python script to generate a *visual 12-month* `.xlsx` calendar template.
> 
> The script (`gerar_calendario.py`) builds a year sheet with merged day cells, month headers, borders, and extra rows per day for long copy text, and supports CLI args for output path and optional year (defaulting to `2026`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fe0a5233671d7b464bea88e4bee7c6dd0b68761. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->