### PR TITLE
feat(skills): upgrade gestao-checkin-analysis to v2.1.0

### DIFF
--- a/.agents/skills-lock.json
+++ b/.agents/skills-lock.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "skills": {
+    "frontend-design": {
+      "source": "anthropics/skills",
+      "sourceType": "github",
+      "computedHash": "516bd2154eb843a8240e43d5b285229129853114ad7075a5e141e1c08e408c84"
+    }
+  }
+}

--- a/.agents/skills/frontend-design/LICENSE.txt
+++ b/.agents/skills/frontend-design/LICENSE.txt
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/.agents/skills/frontend-design/SKILL.md
+++ b/.agents/skills/frontend-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: frontend-design
-description: Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, or applications. Generates creative, polished code that avoids generic AI aesthetics.
+description: Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics.
 license: Complete terms in LICENSE.txt
 ---
 

--- a/.agents/skills/gestao-checkin-analysis/SKILL.md
+++ b/.agents/skills/gestao-checkin-analysis/SKILL.md
@@ -1,0 +1,278 @@
+---
+name: gestao-checkin-analysis
+description: >
+  Esta skill deve ser usada quando o usuário pedir para "analisar check-ins",
+  "ver check-ins de ontem", "rodar análise diária de check-ins", "como estão os
+  clientes hoje", "o que os accounts reportaram", "novos check-ins",
+  "análise de tendências dos clientes" ou qualquer leitura dos check-ins
+  preenchidos pelos accounts da unidade.
+metadata:
+  version: "2.0.0"
+---
+
+# Análise Diária de Check-ins
+
+Leia os check-ins preenchidos pelos accounts desde a última análise, identifique tendências por cliente, extraia os pontos-chave dos comentários e sugira planos de ação proativos.
+
+> **Importante:** Os check-ins refletem um touch point frequente de relacionamento. Eles NÃO representam a avaliação final do cliente, que é composta também por NPS, Quality Check e Retrospectivas. Use esses dados para identificar tendências e agir antes que problemas se consolidem.
+
+---
+
+## Configurações fixas
+
+- **Pasta dos arquivos:** `./bases/gestao-checkins/dados`
+- **Arquivo de estado:** `./bases/gestao-checkins/dados/.checkin_state.json`
+- **Pasta de saída:** `./bases/gestao-checkins/dados/`
+
+---
+
+## Passo 1 — Determinar o período de análise
+
+Use a ferramenta de leitura adequada para ler o arquivo de estado em:
+`./bases/gestao-checkins/dados/.checkin_state.json`
+
+- Se o arquivo **existir**, leia o campo `ultima_analise` (formato `YYYY-MM-DD`). Esse será a data de corte.
+- Se o arquivo **não existir**, use a data de ontem como ponto de partida.
+
+Guarde essa data como `[DATA_CORTE]` (formato `DD/MM/YYYY` para comparar com o CSV).
+
+---
+
+## Passo 2 — Encontrar o CSV mais recente
+
+Analise o diretório:
+`./bases/gestao-checkins/dados`
+
+Encontre todos os arquivos `.csv` e utilize o que possuir a data de modificação mais recente. Guarde o caminho completo do arquivo como `[ARQUIVO_CSV]`.
+
+---
+
+## Passo 3 — Ler e processar o CSV com Python
+
+### 3.1 — Ler o arquivo (ou parte dele)
+
+Abra e leia o arquivo `[ARQUIVO_CSV]`. Este arquivo CSV pode conter descrições longas contendo quebras de linha (multiline fields).
+
+### 3.2 — Salvar em formato temporário para parsing ou rodar script
+
+Execute o seguinte script em Python para extrair e filtrar os resultados. Ele cruza o histórico com os dados novos a partir do corte:
+
+```python
+import csv
+import json
+import os
+import sys
+from datetime import datetime
+from collections import defaultdict
+
+# Pegar argumentos caso o agent queira passar, senão substitui via prompt
+ARQUIVO = r"[ARQUIVO_CSV]"
+DATA_CORTE_STR = "[DATA_CORTE_DD/MM/YYYY]"
+
+try:
+    data_corte = datetime.strptime(DATA_CORTE_STR, "%d/%m/%Y")
+except ValueError:
+    print("Formato de data inválido. Use DD/MM/YYYY")
+    sys.exit(1)
+
+registros = []
+with open(ARQUIVO, newline='', encoding='utf-8') as f:
+    reader = csv.DictReader(f)
+    for row in reader:
+        try:
+            data_str = row.get("Data da Reunião", "").strip()
+            if not data_str:
+                continue
+            data = datetime.strptime(data_str, "%d/%m/%Y")
+            registros.append({
+                "data": data,
+                "data_str": data_str,
+                "cliente": row.get("Cliente", "").strip(),
+                "account": row.get("Gestor do Projeto", "").strip(),
+                "nota_resultado": float(row.get("Nota Resultado", 0) or 0),
+                "nota_entrega": float(row.get("Nota Entrega", 0) or 0),
+                "nota_relacionamento": float(row.get("Nota Relacionamento", 0) or 0),
+                "nota_checkin": float(row.get("Nota Checkin", 0) or 0),
+                "media": float(row.get("Média das notas", 0) or 0),
+                "observacao": row.get("Observação sobre o Check-in:", "").strip(),
+            })
+        except Exception:
+            continue
+
+# Separar novos e histórico
+novos = [r for r in registros if r["data"] >= data_corte]
+clientes_novos = {r["cliente"] for r in novos}
+
+historico = [r for r in registros if r["data"] < data_corte and r["cliente"] in clientes_novos]
+
+# Pegar últimos 3 históricos por cliente
+historico_por_cliente = defaultdict(list)
+for r in sorted(historico, key=lambda x: x["data"], reverse=True):
+    if len(historico_por_cliente[r["cliente"]]) < 3:
+        historico_por_cliente[r["cliente"]].append(r)
+
+# Médias dos novos
+if novos:
+    media_nota = sum(r["nota_checkin"] for r in novos) / len(novos)
+    media_resultado = sum(r["nota_resultado"] for r in novos) / len(novos)
+    media_entrega = sum(r["nota_entrega"] for r in novos) / len(novos)
+    media_relacionamento = sum(r["nota_relacionamento"] for r in novos) / len(novos)
+else:
+    media_nota = media_resultado = media_entrega = media_relacionamento = 0
+
+resultado = {
+    "total_novos": len(novos),
+    "clientes_analisados": len(clientes_novos),
+    "accounts_envolvidos": len({r["account"] for r in novos}),
+    "media_nota": round(media_nota, 2),
+    "media_resultado": round(media_resultado, 2),
+    "media_entrega": round(media_entrega, 2),
+    "media_relacionamento": round(media_relacionamento, 2),
+    "novos": novos,
+    "historico_por_cliente": {k: v for k, v in historico_por_cliente.items()},
+    "clientes_atencao": [r for r in novos if r["nota_checkin"] < 3.0],
+}
+
+# Serializar datas para JSON
+def serialize(obj):
+    if isinstance(obj, datetime):
+        return obj.strftime("%d/%m/%Y")
+    raise TypeError(f"Type {type(obj)} not serializable")
+
+print(json.dumps(resultado, default=serialize, ensure_ascii=False, indent=2))
+```
+
+Salve a saída JSON no buffer da sessão ou arquivo e use os dados extraídos para o próximo passo.
+
+---
+
+## Passo 4 — Montar o relatório HTML
+
+Com base na saída do Python e da sua interpretação inteligente dos comentários, gere o relatório seguindo um design em **HTML responsivo e limpo** para facilitar a leitura. Use a estrutura abaixo como base, mantendo um visual moderno:
+
+```html
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+<meta charset="UTF-8">
+<style>
+  body { font-family: 'Segoe UI', system-ui, sans-serif; line-height: 1.6; color: #333; max-width: 900px; margin: 0 auto; padding: 20px; background-color: #f8fafc; }
+  h1 { color: #0f172a; border-bottom: 2px solid #e2e8f0; padding-bottom: 0.5rem; }
+  h2 { color: #1e293b; margin-top: 2rem; }
+  table { width: 100%; border-collapse: collapse; margin: 1rem 0; background: #fff; border-radius: 8px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+  th, td { padding: 12px 16px; text-align: left; border-bottom: 1px solid #e2e8f0; }
+  th { background-color: #f1f5f9; font-weight: 600; }
+  .alert { background: #fffbeb; border-left: 4px solid #f59e0b; padding: 1rem; margin: 1rem 0; border-radius: 4px; }
+  .danger { background: #fef2f2; border-left: 4px solid #ef4444; padding: 1rem; margin: 1rem 0; border-radius: 4px; }
+  .quote { background: #eff6ff; border-left: 4px solid #3b82f6; padding: 1rem; font-style: italic; margin: 1rem 0; }
+  .badge { display: inline-block; padding: 0.25rem 0.5rem; border-radius: 9999px; font-size: 0.875rem; font-weight: 600; }
+  .badge-alta { background: #fee2e2; color: #991b1b; }
+  .badge-media { background: #fef3c7; color: #92400e; }
+  .badge-baixa { background: #d1fae5; color: #065f46; }
+</style>
+</head>
+<body>
+
+<h1>Análise de Check-ins — [DATA DE HOJE]</h1>
+<p><strong>Período:</strong> [DATA_CORTE] a [DATA DE HOJE]<br>
+<strong>Check-ins:</strong> N | <strong>Clientes:</strong> X | <strong>Accounts:</strong> Y</p>
+
+<div class="alert">
+  ⚠️ Lembrete: check-ins são um indicador de tendência. A avaliação final inclui NPS, Quality Check e Retrospectivas.
+</div>
+
+<h2>📊 Panorama Geral</h2>
+<table>
+  <tr><th>Métrica</th><th>Média do Período</th></tr>
+  <tr><td>Nota Geral</td><td>X.X</td></tr>
+  <tr><td>Resultado</td><td>X.X</td></tr>
+  <tr><td>Entregas</td><td>X.X</td></tr>
+  <tr><td>Relacionamento</td><td>X.X</td></tr>
+</table>
+<p>[Síntese executiva analítica sobre o que o período revela]</p>
+
+<h2>🔴 Clientes em Atenção (Notas < 3.0)</h2>
+<div class="danger">Atenção imediata para clientes com sinais críticos.</div>
+<table>
+  <tr><th>Cliente</th><th>Account</th><th>Data</th><th>Nota</th></tr>
+  <!-- iterar clientes em atenção -->
+  <tr><td>...</td><td>...</td><td>...</td><td>...</td></tr>
+</table>
+
+<h2>📈 Evolução por Cliente</h2>
+<!-- Para CADA cliente novo -->
+<h3>[Nome do Cliente] — Account: [Nome do Account]</h3>
+<table>
+  <tr><th>Data</th><th>Nota</th><th>Δ</th></tr>
+  <tr><td>[hist -1]</td><td>...</td><td>—</td></tr>
+  <tr><td><strong>[NOVO]</strong></td><td>...</td><td>↑/→/↓</td></tr>
+</table>
+<p><strong>Tendência:</strong> [Frase direta resumindo a tendência de performance técnica vs percepção]</p>
+
+<h2>💬 Destaques</h2>
+<!-- Para CADA check-in com observação significativa -->
+<h3>[Nome do Cliente]</h3>
+<p><strong>Account:</strong> [Account] | <strong>Data:</strong> [Data]</p>
+<div class="quote">"[Trecho mais crítico/insight real]"</div>
+<ul>
+  <li><strong>Pontos:</strong> [Ponto positivo/negativo]</li>
+  <li><strong>Leitura:</strong> [SEU diagnóstico de gestor]</li>
+</ul>
+
+<h2>✅ Planos de Ação Recomendados</h2>
+<table>
+  <tr><th>Prioridade</th><th>Cliente</th><th>Ação</th></tr>
+  <!-- iterar acoes -->
+  <tr><td><span class="badge badge-alta">🔴 Alta</span></td><td>...</td><td>...</td></tr>
+</table>
+
+<p style="text-align: center; color: #64748b; margin-top: 3rem; font-size: 0.875rem;">
+  Análise gerada em [DATA_HOJE] • Fonte: Arquivo de Check-ins
+</p>
+
+</body>
+</html>
+```
+
+---
+
+## Passo 5 — Salvar o relatório localmente
+
+Escreva e grave o relatório na sua íntegra em formato HTML:
+`./bases/gestao-checkins/dados/checkin-[YYYY-MM-DD].html`
+(Use a data de hoje para compor o nome).
+
+---
+
+## Passo 6 — Atualizar o estado do Check-in
+
+Salve/Atualize o arquivo de log JSON:
+`./bases/gestao-checkins/dados/.checkin_state.json`
+
+```json
+{
+  "ultima_analise": "YYYY-MM-DD (apenas se executou até hoje com sucesso)",
+  "ultimo_arquivo": "checkin-[YYYY-MM-DD].html",
+  "csv_utilizado": "[nome completo do arquivo csv usado]",
+  "total_checkins_analisados": "[A quantidade de checkins NO RECORTE]"
+}
+```
+
+---
+
+## Passo 7 — Entrega e Feedback no Chat para Mim (Usuário)
+
+No chat da nossa conversa, não jogue o relatório inteiro. Apenas me entregue de forma condensada:
+
+1. **Resumo em 3 a 4 frases** explicando o sentimento geral da análise.
+2. **Planos de ação apenas de 🔴 Alta prioridade** em destaque, dizendo o que eu preciso fazer hoje.
+3. **Link rápido para leitura:** Mostre o path clicável para o arquivo HTML usando `file:///` e o caminho absoluto originado a partir de `./bases/gestao-checkins/dados/...`.
+4. Pergunte: "Deseja que eu te traga algum detalhamento de algum dos clientes médios/baixos agora?"
+
+---
+
+## 📌 Recomendações e Boas Práticas Comportamentais (Importantíssimo):
+- **Não minta informações ou invente clientes.** Extraia apenas dos dados.
+- **Ajude nas Entrelinhas:** Os accounts costumam suavizar problemas ("tivemos bons insights mas sem vendas" = inércia comercial / possível churn). Traduza de forma fria para o gestor.
+- **Se o campo "observação" de um check-in estiver em branco ou genérico**, não o coloque na aba destaques. Use apenas a tendência fria das notas.
+- **Evite planos genéricos** como "Acompanhar de perto". Recomende "Agendar call quinta com Account Fulano para revisar funnel da etapa 3". Tente ser pragmático.

--- a/.agents/skills/gestao-checkin-analysis/SKILL.md
+++ b/.agents/skills/gestao-checkin-analysis/SKILL.md
@@ -7,7 +7,7 @@ description: >
   "análise de tendências dos clientes" ou qualquer leitura dos check-ins
   preenchidos pelos accounts da unidade.
 metadata:
-  version: "2.0.0"
+  version: "2.1.0"
 ---
 
 # Análise Diária de Check-ins
@@ -33,6 +33,7 @@ Use a ferramenta de leitura adequada para ler o arquivo de estado em:
 
 - Se o arquivo **existir**, leia o campo `ultima_analise` (formato `YYYY-MM-DD`). Esse será a data de corte.
 - Se o arquivo **não existir**, use a data de ontem como ponto de partida.
+- **Atenção:** Se o `total_checkins_analisados` do estado for `0` e o arquivo HTML correspondente estiver vazio (0 bytes), significa que a última execução falhou. Nesse caso, recue a data de corte para o dia anterior ao `ultima_analise` registrado, para garantir que check-ins recentes não sejam perdidos.
 
 Guarde essa data como `[DATA_CORTE]` (formato `DD/MM/YYYY` para comparar com o CSV).
 
@@ -53,19 +54,17 @@ Encontre todos os arquivos `.csv` e utilize o que possuir a data de modificaçã
 
 Abra e leia o arquivo `[ARQUIVO_CSV]`. Este arquivo CSV pode conter descrições longas contendo quebras de linha (multiline fields).
 
-### 3.2 — Salvar em formato temporário para parsing ou rodar script
+### 3.2 — Rodar o script de processamento
 
-Execute o seguinte script em Python para extrair e filtrar os resultados. Ele cruza o histórico com os dados novos a partir do corte:
+Execute o seguinte script em Python. Ele cruza o histórico com os dados novos a partir do corte. Use `safe_float()` para evitar falhas silenciosas na conversão de notas, e tente múltiplos formatos de data:
 
 ```python
 import csv
 import json
-import os
 import sys
 from datetime import datetime
 from collections import defaultdict
 
-# Pegar argumentos caso o agent queira passar, senão substitui via prompt
 ARQUIVO = r"[ARQUIVO_CSV]"
 DATA_CORTE_STR = "[DATA_CORTE_DD/MM/YYYY]"
 
@@ -75,6 +74,13 @@ except ValueError:
     print("Formato de data inválido. Use DD/MM/YYYY")
     sys.exit(1)
 
+def safe_float(val, default=0.0):
+    try:
+        v = str(val).strip().replace(",", ".")
+        return float(v) if v else default
+    except:
+        return default
+
 registros = []
 with open(ARQUIVO, newline='', encoding='utf-8') as f:
     reader = csv.DictReader(f)
@@ -83,17 +89,25 @@ with open(ARQUIVO, newline='', encoding='utf-8') as f:
             data_str = row.get("Data da Reunião", "").strip()
             if not data_str:
                 continue
-            data = datetime.strptime(data_str, "%d/%m/%Y")
+            data = None
+            for fmt in ["%d/%m/%Y", "%Y-%m-%d", "%d-%m-%Y"]:
+                try:
+                    data = datetime.strptime(data_str, fmt)
+                    break
+                except:
+                    pass
+            if data is None:
+                continue
             registros.append({
                 "data": data,
-                "data_str": data_str,
+                "data_str": data.strftime("%d/%m/%Y"),
                 "cliente": row.get("Cliente", "").strip(),
                 "account": row.get("Gestor do Projeto", "").strip(),
-                "nota_resultado": float(row.get("Nota Resultado", 0) or 0),
-                "nota_entrega": float(row.get("Nota Entrega", 0) or 0),
-                "nota_relacionamento": float(row.get("Nota Relacionamento", 0) or 0),
-                "nota_checkin": float(row.get("Nota Checkin", 0) or 0),
-                "media": float(row.get("Média das notas", 0) or 0),
+                "nota_resultado": safe_float(row.get("Nota Resultado", 0)),
+                "nota_entrega": safe_float(row.get("Nota Entrega", 0)),
+                "nota_relacionamento": safe_float(row.get("Nota Relacionamento", 0)),
+                "nota_checkin": safe_float(row.get("Nota Checkin", 0)),
+                "media": safe_float(row.get("Média das notas", 0)),
                 "observacao": row.get("Observação sobre o Check-in:", "").strip(),
             })
         except Exception:
@@ -105,11 +119,13 @@ clientes_novos = {r["cliente"] for r in novos}
 
 historico = [r for r in registros if r["data"] < data_corte and r["cliente"] in clientes_novos]
 
-# Pegar últimos 3 históricos por cliente
+# Pegar últimos 3 históricos por cliente em ordem cronológica crescente (para exibir na tabela)
 historico_por_cliente = defaultdict(list)
 for r in sorted(historico, key=lambda x: x["data"], reverse=True):
     if len(historico_por_cliente[r["cliente"]]) < 3:
         historico_por_cliente[r["cliente"]].append(r)
+for k in historico_por_cliente:
+    historico_por_cliente[k] = list(reversed(historico_por_cliente[k]))
 
 # Médias dos novos
 if novos:
@@ -131,9 +147,9 @@ resultado = {
     "novos": novos,
     "historico_por_cliente": {k: v for k, v in historico_por_cliente.items()},
     "clientes_atencao": [r for r in novos if r["nota_checkin"] < 3.0],
+    "clientes_resultado_critico": [r for r in novos if r["nota_resultado"] < 3.0],
 }
 
-# Serializar datas para JSON
 def serialize(obj):
     if isinstance(obj, datetime):
         return obj.strftime("%d/%m/%Y")
@@ -148,91 +164,199 @@ Salve a saída JSON no buffer da sessão ou arquivo e use os dados extraídos pa
 
 ## Passo 4 — Montar o relatório HTML
 
-Com base na saída do Python e da sua interpretação inteligente dos comentários, gere o relatório seguindo um design em **HTML responsivo e limpo** para facilitar a leitura. Use a estrutura abaixo como base, mantendo um visual moderno:
+Com base na saída do Python e da sua interpretação inteligente dos comentários, gere o relatório seguindo um design em **HTML responsivo e limpo**. Use a estrutura abaixo como base:
 
 ```html
 <!DOCTYPE html>
 <html lang="pt-BR">
 <head>
 <meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Análise de Check-ins — [DATA DE HOJE]</title>
 <style>
-  body { font-family: 'Segoe UI', system-ui, sans-serif; line-height: 1.6; color: #333; max-width: 900px; margin: 0 auto; padding: 20px; background-color: #f8fafc; }
-  h1 { color: #0f172a; border-bottom: 2px solid #e2e8f0; padding-bottom: 0.5rem; }
-  h2 { color: #1e293b; margin-top: 2rem; }
-  table { width: 100%; border-collapse: collapse; margin: 1rem 0; background: #fff; border-radius: 8px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
-  th, td { padding: 12px 16px; text-align: left; border-bottom: 1px solid #e2e8f0; }
-  th { background-color: #f1f5f9; font-weight: 600; }
-  .alert { background: #fffbeb; border-left: 4px solid #f59e0b; padding: 1rem; margin: 1rem 0; border-radius: 4px; }
-  .danger { background: #fef2f2; border-left: 4px solid #ef4444; padding: 1rem; margin: 1rem 0; border-radius: 4px; }
-  .quote { background: #eff6ff; border-left: 4px solid #3b82f6; padding: 1rem; font-style: italic; margin: 1rem 0; }
-  .badge { display: inline-block; padding: 0.25rem 0.5rem; border-radius: 9999px; font-size: 0.875rem; font-weight: 600; }
+  body { font-family: 'Segoe UI', system-ui, sans-serif; line-height: 1.6; color: #333; max-width: 920px; margin: 0 auto; padding: 24px; background-color: #f8fafc; }
+  h1 { color: #0f172a; border-bottom: 2px solid #e2e8f0; padding-bottom: 0.5rem; margin-bottom: 0.4rem; }
+  h2 { color: #1e293b; margin-top: 2rem; margin-bottom: 0.5rem; }
+  h3 { color: #334155; margin-top: 1.5rem; margin-bottom: 0.3rem; }
+  p { margin: 0.4rem 0 0.8rem; }
+  table { width: 100%; border-collapse: collapse; margin: 0.8rem 0 1.4rem; background: #fff; border-radius: 8px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+  th, td { padding: 11px 15px; text-align: left; border-bottom: 1px solid #e2e8f0; font-size: 0.93rem; }
+  th { background-color: #f1f5f9; font-weight: 600; color: #475569; }
+  tr:last-child td { border-bottom: none; }
+  .alert { background: #fffbeb; border-left: 4px solid #f59e0b; padding: 0.85rem 1rem; margin: 1rem 0; border-radius: 4px; font-size: 0.9rem; color: #78350f; }
+  .danger { background: #fef2f2; border-left: 4px solid #ef4444; padding: 0.85rem 1rem; margin: 0.5rem 0 1rem; border-radius: 4px; }
+  .info { background: #f0fdf4; border-left: 4px solid #22c55e; padding: 0.85rem 1rem; margin: 0.5rem 0 1rem; border-radius: 4px; }
+  .quote { background: #eff6ff; border-left: 4px solid #3b82f6; padding: 0.9rem 1rem; font-style: italic; margin: 0.8rem 0; border-radius: 4px; color: #1e3a8a; }
+  .badge { display: inline-block; padding: 0.2rem 0.6rem; border-radius: 9999px; font-size: 0.82rem; font-weight: 600; }
   .badge-alta { background: #fee2e2; color: #991b1b; }
   .badge-media { background: #fef3c7; color: #92400e; }
   .badge-baixa { background: #d1fae5; color: #065f46; }
+  .nota-critica { color: #dc2626; font-weight: 700; }
+  .nota-ok { color: #16a34a; font-weight: 600; }
+  .nota-media { color: #d97706; font-weight: 600; }
+  .kpi-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; margin: 1rem 0 1.5rem; }
+  .kpi-card { background: #fff; border-radius: 8px; padding: 14px 16px; box-shadow: 0 1px 3px rgba(0,0,0,0.1); text-align: center; }
+  .kpi-label { font-size: 0.78rem; color: #64748b; text-transform: uppercase; letter-spacing: 0.04em; }
+  .kpi-value { font-size: 1.9rem; font-weight: 700; color: #0f172a; margin: 4px 0 0; }
+  .section-card { background: #fff; border-radius: 8px; padding: 18px 20px; box-shadow: 0 1px 3px rgba(0,0,0,0.1); margin: 1rem 0; }
+  /* Linhas de observação inline nas tabelas de evolução */
+  .obs-row td { background: #f8fafc; font-size: 0.83rem; color: #475569; font-style: italic; padding: 6px 15px 10px 15px; border-bottom: 1px solid #e2e8f0; }
+  .obs-row td span { font-style: normal; font-weight: 600; color: #94a3b8; margin-right: 4px; }
+  .obs-vazia td { background: #f8fafc; font-size: 0.83rem; color: #cbd5e1; font-style: italic; padding: 6px 15px 10px 15px; border-bottom: 1px solid #e2e8f0; }
+  .trend-stable { color: #64748b; }
+  .footer { text-align: center; color: #94a3b8; margin-top: 3rem; font-size: 0.82rem; border-top: 1px solid #e2e8f0; padding-top: 1.2rem; }
 </style>
 </head>
 <body>
 
-<h1>Análise de Check-ins — [DATA DE HOJE]</h1>
-<p><strong>Período:</strong> [DATA_CORTE] a [DATA DE HOJE]<br>
-<strong>Check-ins:</strong> N | <strong>Clientes:</strong> X | <strong>Accounts:</strong> Y</p>
+<h1>📋 Análise de Check-ins — [DATA DE HOJE]</h1>
+<p style="color:#64748b; font-size:0.9rem;">
+  <strong>Período:</strong> [DATA_CORTE] a [DATA DE HOJE] &nbsp;|&nbsp;
+  <strong>Check-ins:</strong> N &nbsp;|&nbsp;
+  <strong>Clientes:</strong> X &nbsp;|&nbsp;
+  <strong>Accounts:</strong> Y
+</p>
 
 <div class="alert">
-  ⚠️ Lembrete: check-ins são um indicador de tendência. A avaliação final inclui NPS, Quality Check e Retrospectivas.
+  ⚠️ <strong>Lembrete:</strong> Check-ins são um indicador de tendência. A avaliação final do cliente inclui NPS, Quality Check e Retrospectivas. Use estes dados para agir preventivamente.
 </div>
 
+<!-- PANORAMA GERAL — usar cards KPI, não tabela simples -->
 <h2>📊 Panorama Geral</h2>
-<table>
-  <tr><th>Métrica</th><th>Média do Período</th></tr>
-  <tr><td>Nota Geral</td><td>X.X</td></tr>
-  <tr><td>Resultado</td><td>X.X</td></tr>
-  <tr><td>Entregas</td><td>X.X</td></tr>
-  <tr><td>Relacionamento</td><td>X.X</td></tr>
-</table>
-<p>[Síntese executiva analítica sobre o que o período revela]</p>
+<div class="kpi-grid">
+  <div class="kpi-card">
+    <div class="kpi-label">Nota Check-in</div>
+    <div class="kpi-value" style="color:[COR_CHECKIN];">[MEDIA_CHECKIN]</div>
+  </div>
+  <div class="kpi-card">
+    <div class="kpi-label">Resultado</div>
+    <div class="kpi-value" style="color:[COR_RESULTADO];">[MEDIA_RESULTADO]</div>
+  </div>
+  <div class="kpi-card">
+    <div class="kpi-label">Entregas</div>
+    <div class="kpi-value" style="color:[COR_ENTREGA];">[MEDIA_ENTREGA]</div>
+  </div>
+  <div class="kpi-card">
+    <div class="kpi-label">Relacionamento</div>
+    <div class="kpi-value" style="color:[COR_RELAC];">[MEDIA_RELAC]</div>
+  </div>
+</div>
+<div class="section-card">
+  <p>[Síntese executiva analítica: o que o período revela, incluindo divergências entre notas de check-in e resultado]</p>
+</div>
 
-<h2>🔴 Clientes em Atenção (Notas < 3.0)</h2>
-<div class="danger">Atenção imediata para clientes com sinais críticos.</div>
+<!-- RADAR DE ATENÇÃO — inclui check-in < 3.0 E resultado < 3.0 mesmo com check-in OK -->
+<h2>🔴 Radar de Atenção</h2>
+<div class="danger">
+  [Descreva os casos críticos: check-in baixo OU resultado crítico. Nota de resultado < 3.0 deve ser destacada mesmo que a nota de check-in esteja OK.]
+</div>
 <table>
-  <tr><th>Cliente</th><th>Account</th><th>Data</th><th>Nota</th></tr>
-  <!-- iterar clientes em atenção -->
-  <tr><td>...</td><td>...</td><td>...</td><td>...</td></tr>
+  <tr>
+    <th>Cliente</th><th>Account</th><th>Data</th>
+    <th>Nota Check-in</th><th>Nota Resultado</th><th>Nota Entrega</th><th>Nota Relac.</th>
+  </tr>
+  <!-- iterar clientes_atencao + clientes_resultado_critico (deduplizados) -->
+  <tr>
+    <td>...</td><td>...</td><td>...</td>
+    <td class="nota-[ok|media|critica]">X,X</td>
+    <td class="nota-[ok|media|critica]">X,X [🔴|🟡]</td>
+    <td>X,X</td><td>X,X</td>
+  </tr>
 </table>
 
+<!-- EVOLUÇÃO POR CLIENTE — com comentários históricos inline -->
 <h2>📈 Evolução por Cliente</h2>
-<!-- Para CADA cliente novo -->
-<h3>[Nome do Cliente] — Account: [Nome do Account]</h3>
-<table>
-  <tr><th>Data</th><th>Nota</th><th>Δ</th></tr>
-  <tr><td>[hist -1]</td><td>...</td><td>—</td></tr>
-  <tr><td><strong>[NOVO]</strong></td><td>...</td><td>↑/→/↓</td></tr>
-</table>
-<p><strong>Tendência:</strong> [Frase direta resumindo a tendência de performance técnica vs percepção]</p>
+<!-- Para CADA cliente novo, criar um section-card -->
+<div class="section-card">
+  <h3>[Nome do Cliente] — Account: [Nome do Account]</h3>
+  <table>
+    <tr><th>Data</th><th>Check-in</th><th>Resultado</th><th>Entrega</th><th>Relac.</th><th>Δ Resultado</th></tr>
 
-<h2>💬 Destaques</h2>
-<!-- Para CADA check-in com observação significativa -->
-<h3>[Nome do Cliente]</h3>
-<p><strong>Account:</strong> [Account] | <strong>Data:</strong> [Data]</p>
-<div class="quote">"[Trecho mais crítico/insight real]"</div>
-<ul>
-  <li><strong>Pontos:</strong> [Ponto positivo/negativo]</li>
-  <li><strong>Leitura:</strong> [SEU diagnóstico de gestor]</li>
-</ul>
+    <!-- Para cada check-in histórico (ordem cronológica crescente): -->
+    <tr>
+      <td>[DATA_HIST]</td>
+      <td>[nota_checkin]</td>
+      <td class="nota-[ok|media|critica]">[nota_resultado]</td>
+      <td>[nota_entrega]</td>
+      <td>[nota_relacionamento]</td>
+      <td class="trend-stable">— / ↑ / → / ↓</td>
+    </tr>
+    <!-- SEMPRE adicionar linha de observação após cada linha de dados -->
+    <!-- Se a observação existir: -->
+    <tr class="obs-row">
+      <td colspan="6">
+        <span>Obs:</span> "[texto da observação]" — <em>[seu comentário editorial se relevante]</em>
+      </td>
+    </tr>
+    <!-- Se a observação estiver vazia: -->
+    <tr class="obs-vazia">
+      <td colspan="6"><span>Obs:</span> sem observação registrada. <em style="color:#dc2626;">[adicionar nota se a queda de nota coincidir com ausência de obs]</em></td>
+    </tr>
 
+    <!-- Linha do check-in NOVO (destacada) -->
+    <tr style="background:#fef2f2;"><!-- ou #f0fdf4 se positivo -->
+      <td><strong>[DATA_NOVO] ★</strong></td>
+      <td class="nota-ok"><strong>[nota_checkin]</strong></td>
+      <td class="nota-critica"><strong>[nota_resultado] 🔴</strong></td>
+      <td class="nota-ok"><strong>[nota_entrega]</strong></td>
+      <td class="nota-ok"><strong>[nota_relacionamento]</strong></td>
+      <td style="color:#dc2626; font-weight:700;">↓↓</td>
+    </tr>
+    <tr class="obs-row" style="background:#fef2f2;">
+      <td colspan="6"><span>Obs:</span> "[observação do check-in novo]" — <em>[seu diagnóstico]</em></td>
+    </tr>
+  </table>
+  <p><strong>Tendência:</strong> [Frase direta resumindo a trajetória das notas ao longo do histórico, conectando os comentários à evolução das métricas]</p>
+</div>
+
+<!-- DESTAQUES — apenas check-ins com observações significativas -->
+<h2>💬 Destaques dos Comentários</h2>
+<!-- Para CADA check-in novo com observação não-vazia e não-genérica -->
+<div class="section-card">
+  <h3>[Nome do Cliente]</h3>
+  <p><strong>Account:</strong> [Account] &nbsp;|&nbsp; <strong>Data:</strong> [Data]</p>
+  <div class="quote">"[Trecho mais crítico ou revelador da observação]"</div>
+  <ul>
+    <li><strong>Leitura fria:</strong> [Seu diagnóstico de gestor — traduza suavizações em linguagem direta]</li>
+    <li><strong>Risco:</strong> [O que pode acontecer se não houver ação]</li>
+  </ul>
+</div>
+
+<!-- PLANOS DE AÇÃO -->
 <h2>✅ Planos de Ação Recomendados</h2>
 <table>
-  <tr><th>Prioridade</th><th>Cliente</th><th>Ação</th></tr>
-  <!-- iterar acoes -->
-  <tr><td><span class="badge badge-alta">🔴 Alta</span></td><td>...</td><td>...</td></tr>
+  <tr><th style="width:110px;">Prioridade</th><th>Cliente</th><th>Account</th><th>Ação Específica</th></tr>
+  <!-- iterar ações ordenadas por prioridade -->
+  <tr>
+    <td><span class="badge badge-alta">🔴 Alta</span></td>
+    <td>...</td><td>...</td>
+    <td>[Ação concreta com dia, pessoa e objetivo — nunca "acompanhar de perto"]</td>
+  </tr>
+  <tr>
+    <td><span class="badge badge-media">🟡 Média</span></td>
+    <td>...</td><td>...</td><td>...</td>
+  </tr>
 </table>
 
-<p style="text-align: center; color: #64748b; margin-top: 3rem; font-size: 0.875rem;">
-  Análise gerada em [DATA_HOJE] • Fonte: Arquivo de Check-ins
-</p>
+<div class="footer">
+  Análise gerada em [DATA_HOJE] &nbsp;•&nbsp; Fonte: [nome do CSV] &nbsp;•&nbsp; [N] check-ins analisados
+</div>
 
 </body>
 </html>
 ```
+
+### Regras de cor para os KPI cards:
+- Nota ≥ 4,0 → `#16a34a` (verde)
+- Nota 3,0–3,9 → `#d97706` (amarelo)
+- Nota < 3,0 → `#dc2626` (vermelho)
+
+### Regras para a coluna Δ Resultado:
+- Primeira linha → `—`
+- Subiu → `↑` (verde)
+- Estável → `→` (cinza)
+- Caiu 1 ponto → `↓` (vermelho)
+- Caiu 2+ pontos → `↓↓` (vermelho negrito)
 
 ---
 
@@ -266,7 +390,7 @@ No chat da nossa conversa, não jogue o relatório inteiro. Apenas me entregue d
 
 1. **Resumo em 3 a 4 frases** explicando o sentimento geral da análise.
 2. **Planos de ação apenas de 🔴 Alta prioridade** em destaque, dizendo o que eu preciso fazer hoje.
-3. **Link rápido para leitura:** Mostre o path clicável para o arquivo HTML usando `file:///` e o caminho absoluto originado a partir de `./bases/gestao-checkins/dados/...`.
+3. **Link rápido para leitura:** Mostre o path clicável usando `computer://` e o caminho absoluto do arquivo HTML.
 4. Pergunte: "Deseja que eu te traga algum detalhamento de algum dos clientes médios/baixos agora?"
 
 ---
@@ -274,5 +398,7 @@ No chat da nossa conversa, não jogue o relatório inteiro. Apenas me entregue d
 ## 📌 Recomendações e Boas Práticas Comportamentais (Importantíssimo):
 - **Não minta informações ou invente clientes.** Extraia apenas dos dados.
 - **Ajude nas Entrelinhas:** Os accounts costumam suavizar problemas ("tivemos bons insights mas sem vendas" = inércia comercial / possível churn). Traduza de forma fria para o gestor.
-- **Se o campo "observação" de um check-in estiver em branco ou genérico**, não o coloque na aba destaques. Use apenas a tendência fria das notas.
-- **Evite planos genéricos** como "Acompanhar de perto". Recomende "Agendar call quinta com Account Fulano para revisar funnel da etapa 3". Tente ser pragmático.
+- **Se o campo "observação" de um check-in estiver em branco ou genérico**, não o coloque na seção de Destaques. Use apenas a tendência fria das notas.
+- **Exiba SEMPRE as observações inline nas tabelas de evolução**, linha por linha — tanto para check-ins históricos quanto para o novo. Se a observação estiver vazia, use a classe `obs-vazia` e indique explicitamente "sem observação registrada". Se a ausência coincide com queda de nota, adicione nota editorial em vermelho.
+- **Monitore o Resultado independentemente da nota de check-in.** Um cliente com check-in 4,0 mas resultado 2,0 é crítico e deve aparecer no Radar de Atenção.
+- **Evite planos genéricos** como "Acompanhar de perto". Recomende "Agendar call quinta com Account Fulano para revisar funnel da etapa 3". Tente ser pragmático e específico.

--- a/.claude/skills/frontend-design/LICENSE.txt
+++ b/.claude/skills/frontend-design/LICENSE.txt
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/.claude/skills/frontend-design/SKILL.md
+++ b/.claude/skills/frontend-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: frontend-design
-description: Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, or applications. Generates creative, polished code that avoids generic AI aesthetics.
+description: Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics.
 license: Complete terms in LICENSE.txt
 ---
 

--- a/.claude/skills/gestao-checkin-analysis/SKILL.md
+++ b/.claude/skills/gestao-checkin-analysis/SKILL.md
@@ -1,0 +1,278 @@
+---
+name: gestao-checkin-analysis
+description: >
+  Esta skill deve ser usada quando o usuário pedir para "analisar check-ins",
+  "ver check-ins de ontem", "rodar análise diária de check-ins", "como estão os
+  clientes hoje", "o que os accounts reportaram", "novos check-ins",
+  "análise de tendências dos clientes" ou qualquer leitura dos check-ins
+  preenchidos pelos accounts da unidade.
+metadata:
+  version: "2.0.0"
+---
+
+# Análise Diária de Check-ins
+
+Leia os check-ins preenchidos pelos accounts desde a última análise, identifique tendências por cliente, extraia os pontos-chave dos comentários e sugira planos de ação proativos.
+
+> **Importante:** Os check-ins refletem um touch point frequente de relacionamento. Eles NÃO representam a avaliação final do cliente, que é composta também por NPS, Quality Check e Retrospectivas. Use esses dados para identificar tendências e agir antes que problemas se consolidem.
+
+---
+
+## Configurações fixas
+
+- **Pasta dos arquivos:** `./bases/gestao-checkins/dados`
+- **Arquivo de estado:** `./bases/gestao-checkins/dados/.checkin_state.json`
+- **Pasta de saída:** `./bases/gestao-checkins/dados/`
+
+---
+
+## Passo 1 — Determinar o período de análise
+
+Use a ferramenta de leitura adequada para ler o arquivo de estado em:
+`./bases/gestao-checkins/dados/.checkin_state.json`
+
+- Se o arquivo **existir**, leia o campo `ultima_analise` (formato `YYYY-MM-DD`). Esse será a data de corte.
+- Se o arquivo **não existir**, use a data de ontem como ponto de partida.
+
+Guarde essa data como `[DATA_CORTE]` (formato `DD/MM/YYYY` para comparar com o CSV).
+
+---
+
+## Passo 2 — Encontrar o CSV mais recente
+
+Analise o diretório:
+`./bases/gestao-checkins/dados`
+
+Encontre todos os arquivos `.csv` e utilize o que possuir a data de modificação mais recente. Guarde o caminho completo do arquivo como `[ARQUIVO_CSV]`.
+
+---
+
+## Passo 3 — Ler e processar o CSV com Python
+
+### 3.1 — Ler o arquivo (ou parte dele)
+
+Abra e leia o arquivo `[ARQUIVO_CSV]`. Este arquivo CSV pode conter descrições longas contendo quebras de linha (multiline fields).
+
+### 3.2 — Salvar em formato temporário para parsing ou rodar script
+
+Execute o seguinte script em Python para extrair e filtrar os resultados. Ele cruza o histórico com os dados novos a partir do corte:
+
+```python
+import csv
+import json
+import os
+import sys
+from datetime import datetime
+from collections import defaultdict
+
+# Pegar argumentos caso o agent queira passar, senão substitui via prompt
+ARQUIVO = r"[ARQUIVO_CSV]"
+DATA_CORTE_STR = "[DATA_CORTE_DD/MM/YYYY]"
+
+try:
+    data_corte = datetime.strptime(DATA_CORTE_STR, "%d/%m/%Y")
+except ValueError:
+    print("Formato de data inválido. Use DD/MM/YYYY")
+    sys.exit(1)
+
+registros = []
+with open(ARQUIVO, newline='', encoding='utf-8') as f:
+    reader = csv.DictReader(f)
+    for row in reader:
+        try:
+            data_str = row.get("Data da Reunião", "").strip()
+            if not data_str:
+                continue
+            data = datetime.strptime(data_str, "%d/%m/%Y")
+            registros.append({
+                "data": data,
+                "data_str": data_str,
+                "cliente": row.get("Cliente", "").strip(),
+                "account": row.get("Gestor do Projeto", "").strip(),
+                "nota_resultado": float(row.get("Nota Resultado", 0) or 0),
+                "nota_entrega": float(row.get("Nota Entrega", 0) or 0),
+                "nota_relacionamento": float(row.get("Nota Relacionamento", 0) or 0),
+                "nota_checkin": float(row.get("Nota Checkin", 0) or 0),
+                "media": float(row.get("Média das notas", 0) or 0),
+                "observacao": row.get("Observação sobre o Check-in:", "").strip(),
+            })
+        except Exception:
+            continue
+
+# Separar novos e histórico
+novos = [r for r in registros if r["data"] >= data_corte]
+clientes_novos = {r["cliente"] for r in novos}
+
+historico = [r for r in registros if r["data"] < data_corte and r["cliente"] in clientes_novos]
+
+# Pegar últimos 3 históricos por cliente
+historico_por_cliente = defaultdict(list)
+for r in sorted(historico, key=lambda x: x["data"], reverse=True):
+    if len(historico_por_cliente[r["cliente"]]) < 3:
+        historico_por_cliente[r["cliente"]].append(r)
+
+# Médias dos novos
+if novos:
+    media_nota = sum(r["nota_checkin"] for r in novos) / len(novos)
+    media_resultado = sum(r["nota_resultado"] for r in novos) / len(novos)
+    media_entrega = sum(r["nota_entrega"] for r in novos) / len(novos)
+    media_relacionamento = sum(r["nota_relacionamento"] for r in novos) / len(novos)
+else:
+    media_nota = media_resultado = media_entrega = media_relacionamento = 0
+
+resultado = {
+    "total_novos": len(novos),
+    "clientes_analisados": len(clientes_novos),
+    "accounts_envolvidos": len({r["account"] for r in novos}),
+    "media_nota": round(media_nota, 2),
+    "media_resultado": round(media_resultado, 2),
+    "media_entrega": round(media_entrega, 2),
+    "media_relacionamento": round(media_relacionamento, 2),
+    "novos": novos,
+    "historico_por_cliente": {k: v for k, v in historico_por_cliente.items()},
+    "clientes_atencao": [r for r in novos if r["nota_checkin"] < 3.0],
+}
+
+# Serializar datas para JSON
+def serialize(obj):
+    if isinstance(obj, datetime):
+        return obj.strftime("%d/%m/%Y")
+    raise TypeError(f"Type {type(obj)} not serializable")
+
+print(json.dumps(resultado, default=serialize, ensure_ascii=False, indent=2))
+```
+
+Salve a saída JSON no buffer da sessão ou arquivo e use os dados extraídos para o próximo passo.
+
+---
+
+## Passo 4 — Montar o relatório HTML
+
+Com base na saída do Python e da sua interpretação inteligente dos comentários, gere o relatório seguindo um design em **HTML responsivo e limpo** para facilitar a leitura. Use a estrutura abaixo como base, mantendo um visual moderno:
+
+```html
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+<meta charset="UTF-8">
+<style>
+  body { font-family: 'Segoe UI', system-ui, sans-serif; line-height: 1.6; color: #333; max-width: 900px; margin: 0 auto; padding: 20px; background-color: #f8fafc; }
+  h1 { color: #0f172a; border-bottom: 2px solid #e2e8f0; padding-bottom: 0.5rem; }
+  h2 { color: #1e293b; margin-top: 2rem; }
+  table { width: 100%; border-collapse: collapse; margin: 1rem 0; background: #fff; border-radius: 8px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+  th, td { padding: 12px 16px; text-align: left; border-bottom: 1px solid #e2e8f0; }
+  th { background-color: #f1f5f9; font-weight: 600; }
+  .alert { background: #fffbeb; border-left: 4px solid #f59e0b; padding: 1rem; margin: 1rem 0; border-radius: 4px; }
+  .danger { background: #fef2f2; border-left: 4px solid #ef4444; padding: 1rem; margin: 1rem 0; border-radius: 4px; }
+  .quote { background: #eff6ff; border-left: 4px solid #3b82f6; padding: 1rem; font-style: italic; margin: 1rem 0; }
+  .badge { display: inline-block; padding: 0.25rem 0.5rem; border-radius: 9999px; font-size: 0.875rem; font-weight: 600; }
+  .badge-alta { background: #fee2e2; color: #991b1b; }
+  .badge-media { background: #fef3c7; color: #92400e; }
+  .badge-baixa { background: #d1fae5; color: #065f46; }
+</style>
+</head>
+<body>
+
+<h1>Análise de Check-ins — [DATA DE HOJE]</h1>
+<p><strong>Período:</strong> [DATA_CORTE] a [DATA DE HOJE]<br>
+<strong>Check-ins:</strong> N | <strong>Clientes:</strong> X | <strong>Accounts:</strong> Y</p>
+
+<div class="alert">
+  ⚠️ Lembrete: check-ins são um indicador de tendência. A avaliação final inclui NPS, Quality Check e Retrospectivas.
+</div>
+
+<h2>📊 Panorama Geral</h2>
+<table>
+  <tr><th>Métrica</th><th>Média do Período</th></tr>
+  <tr><td>Nota Geral</td><td>X.X</td></tr>
+  <tr><td>Resultado</td><td>X.X</td></tr>
+  <tr><td>Entregas</td><td>X.X</td></tr>
+  <tr><td>Relacionamento</td><td>X.X</td></tr>
+</table>
+<p>[Síntese executiva analítica sobre o que o período revela]</p>
+
+<h2>🔴 Clientes em Atenção (Notas < 3.0)</h2>
+<div class="danger">Atenção imediata para clientes com sinais críticos.</div>
+<table>
+  <tr><th>Cliente</th><th>Account</th><th>Data</th><th>Nota</th></tr>
+  <!-- iterar clientes em atenção -->
+  <tr><td>...</td><td>...</td><td>...</td><td>...</td></tr>
+</table>
+
+<h2>📈 Evolução por Cliente</h2>
+<!-- Para CADA cliente novo -->
+<h3>[Nome do Cliente] — Account: [Nome do Account]</h3>
+<table>
+  <tr><th>Data</th><th>Nota</th><th>Δ</th></tr>
+  <tr><td>[hist -1]</td><td>...</td><td>—</td></tr>
+  <tr><td><strong>[NOVO]</strong></td><td>...</td><td>↑/→/↓</td></tr>
+</table>
+<p><strong>Tendência:</strong> [Frase direta resumindo a tendência de performance técnica vs percepção]</p>
+
+<h2>💬 Destaques</h2>
+<!-- Para CADA check-in com observação significativa -->
+<h3>[Nome do Cliente]</h3>
+<p><strong>Account:</strong> [Account] | <strong>Data:</strong> [Data]</p>
+<div class="quote">"[Trecho mais crítico/insight real]"</div>
+<ul>
+  <li><strong>Pontos:</strong> [Ponto positivo/negativo]</li>
+  <li><strong>Leitura:</strong> [SEU diagnóstico de gestor]</li>
+</ul>
+
+<h2>✅ Planos de Ação Recomendados</h2>
+<table>
+  <tr><th>Prioridade</th><th>Cliente</th><th>Ação</th></tr>
+  <!-- iterar acoes -->
+  <tr><td><span class="badge badge-alta">🔴 Alta</span></td><td>...</td><td>...</td></tr>
+</table>
+
+<p style="text-align: center; color: #64748b; margin-top: 3rem; font-size: 0.875rem;">
+  Análise gerada em [DATA_HOJE] • Fonte: Arquivo de Check-ins
+</p>
+
+</body>
+</html>
+```
+
+---
+
+## Passo 5 — Salvar o relatório localmente
+
+Escreva e grave o relatório na sua íntegra em formato HTML:
+`./bases/gestao-checkins/dados/checkin-[YYYY-MM-DD].html`
+(Use a data de hoje para compor o nome).
+
+---
+
+## Passo 6 — Atualizar o estado do Check-in
+
+Salve/Atualize o arquivo de log JSON:
+`./bases/gestao-checkins/dados/.checkin_state.json`
+
+```json
+{
+  "ultima_analise": "YYYY-MM-DD (apenas se executou até hoje com sucesso)",
+  "ultimo_arquivo": "checkin-[YYYY-MM-DD].html",
+  "csv_utilizado": "[nome completo do arquivo csv usado]",
+  "total_checkins_analisados": "[A quantidade de checkins NO RECORTE]"
+}
+```
+
+---
+
+## Passo 7 — Entrega e Feedback no Chat para Mim (Usuário)
+
+No chat da nossa conversa, não jogue o relatório inteiro. Apenas me entregue de forma condensada:
+
+1. **Resumo em 3 a 4 frases** explicando o sentimento geral da análise.
+2. **Planos de ação apenas de 🔴 Alta prioridade** em destaque, dizendo o que eu preciso fazer hoje.
+3. **Link rápido para leitura:** Mostre o path clicável para o arquivo HTML usando `file:///` e o caminho absoluto originado a partir de `./bases/gestao-checkins/dados/...`.
+4. Pergunte: "Deseja que eu te traga algum detalhamento de algum dos clientes médios/baixos agora?"
+
+---
+
+## 📌 Recomendações e Boas Práticas Comportamentais (Importantíssimo):
+- **Não minta informações ou invente clientes.** Extraia apenas dos dados.
+- **Ajude nas Entrelinhas:** Os accounts costumam suavizar problemas ("tivemos bons insights mas sem vendas" = inércia comercial / possível churn). Traduza de forma fria para o gestor.
+- **Se o campo "observação" de um check-in estiver em branco ou genérico**, não o coloque na aba destaques. Use apenas a tendência fria das notas.
+- **Evite planos genéricos** como "Acompanhar de perto". Recomende "Agendar call quinta com Account Fulano para revisar funnel da etapa 3". Tente ser pragmático.

--- a/.claude/skills/gestao-checkin-analysis/SKILL.md
+++ b/.claude/skills/gestao-checkin-analysis/SKILL.md
@@ -7,7 +7,7 @@ description: >
   "análise de tendências dos clientes" ou qualquer leitura dos check-ins
   preenchidos pelos accounts da unidade.
 metadata:
-  version: "2.0.0"
+  version: "2.1.0"
 ---
 
 # Análise Diária de Check-ins
@@ -33,6 +33,7 @@ Use a ferramenta de leitura adequada para ler o arquivo de estado em:
 
 - Se o arquivo **existir**, leia o campo `ultima_analise` (formato `YYYY-MM-DD`). Esse será a data de corte.
 - Se o arquivo **não existir**, use a data de ontem como ponto de partida.
+- **Atenção:** Se o `total_checkins_analisados` do estado for `0` e o arquivo HTML correspondente estiver vazio (0 bytes), significa que a última execução falhou. Nesse caso, recue a data de corte para o dia anterior ao `ultima_analise` registrado, para garantir que check-ins recentes não sejam perdidos.
 
 Guarde essa data como `[DATA_CORTE]` (formato `DD/MM/YYYY` para comparar com o CSV).
 
@@ -53,19 +54,17 @@ Encontre todos os arquivos `.csv` e utilize o que possuir a data de modificaçã
 
 Abra e leia o arquivo `[ARQUIVO_CSV]`. Este arquivo CSV pode conter descrições longas contendo quebras de linha (multiline fields).
 
-### 3.2 — Salvar em formato temporário para parsing ou rodar script
+### 3.2 — Rodar o script de processamento
 
-Execute o seguinte script em Python para extrair e filtrar os resultados. Ele cruza o histórico com os dados novos a partir do corte:
+Execute o seguinte script em Python. Ele cruza o histórico com os dados novos a partir do corte. Use `safe_float()` para evitar falhas silenciosas na conversão de notas, e tente múltiplos formatos de data:
 
 ```python
 import csv
 import json
-import os
 import sys
 from datetime import datetime
 from collections import defaultdict
 
-# Pegar argumentos caso o agent queira passar, senão substitui via prompt
 ARQUIVO = r"[ARQUIVO_CSV]"
 DATA_CORTE_STR = "[DATA_CORTE_DD/MM/YYYY]"
 
@@ -75,6 +74,13 @@ except ValueError:
     print("Formato de data inválido. Use DD/MM/YYYY")
     sys.exit(1)
 
+def safe_float(val, default=0.0):
+    try:
+        v = str(val).strip().replace(",", ".")
+        return float(v) if v else default
+    except:
+        return default
+
 registros = []
 with open(ARQUIVO, newline='', encoding='utf-8') as f:
     reader = csv.DictReader(f)
@@ -83,17 +89,25 @@ with open(ARQUIVO, newline='', encoding='utf-8') as f:
             data_str = row.get("Data da Reunião", "").strip()
             if not data_str:
                 continue
-            data = datetime.strptime(data_str, "%d/%m/%Y")
+            data = None
+            for fmt in ["%d/%m/%Y", "%Y-%m-%d", "%d-%m-%Y"]:
+                try:
+                    data = datetime.strptime(data_str, fmt)
+                    break
+                except:
+                    pass
+            if data is None:
+                continue
             registros.append({
                 "data": data,
-                "data_str": data_str,
+                "data_str": data.strftime("%d/%m/%Y"),
                 "cliente": row.get("Cliente", "").strip(),
                 "account": row.get("Gestor do Projeto", "").strip(),
-                "nota_resultado": float(row.get("Nota Resultado", 0) or 0),
-                "nota_entrega": float(row.get("Nota Entrega", 0) or 0),
-                "nota_relacionamento": float(row.get("Nota Relacionamento", 0) or 0),
-                "nota_checkin": float(row.get("Nota Checkin", 0) or 0),
-                "media": float(row.get("Média das notas", 0) or 0),
+                "nota_resultado": safe_float(row.get("Nota Resultado", 0)),
+                "nota_entrega": safe_float(row.get("Nota Entrega", 0)),
+                "nota_relacionamento": safe_float(row.get("Nota Relacionamento", 0)),
+                "nota_checkin": safe_float(row.get("Nota Checkin", 0)),
+                "media": safe_float(row.get("Média das notas", 0)),
                 "observacao": row.get("Observação sobre o Check-in:", "").strip(),
             })
         except Exception:
@@ -105,11 +119,13 @@ clientes_novos = {r["cliente"] for r in novos}
 
 historico = [r for r in registros if r["data"] < data_corte and r["cliente"] in clientes_novos]
 
-# Pegar últimos 3 históricos por cliente
+# Pegar últimos 3 históricos por cliente em ordem cronológica crescente (para exibir na tabela)
 historico_por_cliente = defaultdict(list)
 for r in sorted(historico, key=lambda x: x["data"], reverse=True):
     if len(historico_por_cliente[r["cliente"]]) < 3:
         historico_por_cliente[r["cliente"]].append(r)
+for k in historico_por_cliente:
+    historico_por_cliente[k] = list(reversed(historico_por_cliente[k]))
 
 # Médias dos novos
 if novos:
@@ -131,9 +147,9 @@ resultado = {
     "novos": novos,
     "historico_por_cliente": {k: v for k, v in historico_por_cliente.items()},
     "clientes_atencao": [r for r in novos if r["nota_checkin"] < 3.0],
+    "clientes_resultado_critico": [r for r in novos if r["nota_resultado"] < 3.0],
 }
 
-# Serializar datas para JSON
 def serialize(obj):
     if isinstance(obj, datetime):
         return obj.strftime("%d/%m/%Y")
@@ -148,91 +164,199 @@ Salve a saída JSON no buffer da sessão ou arquivo e use os dados extraídos pa
 
 ## Passo 4 — Montar o relatório HTML
 
-Com base na saída do Python e da sua interpretação inteligente dos comentários, gere o relatório seguindo um design em **HTML responsivo e limpo** para facilitar a leitura. Use a estrutura abaixo como base, mantendo um visual moderno:
+Com base na saída do Python e da sua interpretação inteligente dos comentários, gere o relatório seguindo um design em **HTML responsivo e limpo**. Use a estrutura abaixo como base:
 
 ```html
 <!DOCTYPE html>
 <html lang="pt-BR">
 <head>
 <meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Análise de Check-ins — [DATA DE HOJE]</title>
 <style>
-  body { font-family: 'Segoe UI', system-ui, sans-serif; line-height: 1.6; color: #333; max-width: 900px; margin: 0 auto; padding: 20px; background-color: #f8fafc; }
-  h1 { color: #0f172a; border-bottom: 2px solid #e2e8f0; padding-bottom: 0.5rem; }
-  h2 { color: #1e293b; margin-top: 2rem; }
-  table { width: 100%; border-collapse: collapse; margin: 1rem 0; background: #fff; border-radius: 8px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
-  th, td { padding: 12px 16px; text-align: left; border-bottom: 1px solid #e2e8f0; }
-  th { background-color: #f1f5f9; font-weight: 600; }
-  .alert { background: #fffbeb; border-left: 4px solid #f59e0b; padding: 1rem; margin: 1rem 0; border-radius: 4px; }
-  .danger { background: #fef2f2; border-left: 4px solid #ef4444; padding: 1rem; margin: 1rem 0; border-radius: 4px; }
-  .quote { background: #eff6ff; border-left: 4px solid #3b82f6; padding: 1rem; font-style: italic; margin: 1rem 0; }
-  .badge { display: inline-block; padding: 0.25rem 0.5rem; border-radius: 9999px; font-size: 0.875rem; font-weight: 600; }
+  body { font-family: 'Segoe UI', system-ui, sans-serif; line-height: 1.6; color: #333; max-width: 920px; margin: 0 auto; padding: 24px; background-color: #f8fafc; }
+  h1 { color: #0f172a; border-bottom: 2px solid #e2e8f0; padding-bottom: 0.5rem; margin-bottom: 0.4rem; }
+  h2 { color: #1e293b; margin-top: 2rem; margin-bottom: 0.5rem; }
+  h3 { color: #334155; margin-top: 1.5rem; margin-bottom: 0.3rem; }
+  p { margin: 0.4rem 0 0.8rem; }
+  table { width: 100%; border-collapse: collapse; margin: 0.8rem 0 1.4rem; background: #fff; border-radius: 8px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+  th, td { padding: 11px 15px; text-align: left; border-bottom: 1px solid #e2e8f0; font-size: 0.93rem; }
+  th { background-color: #f1f5f9; font-weight: 600; color: #475569; }
+  tr:last-child td { border-bottom: none; }
+  .alert { background: #fffbeb; border-left: 4px solid #f59e0b; padding: 0.85rem 1rem; margin: 1rem 0; border-radius: 4px; font-size: 0.9rem; color: #78350f; }
+  .danger { background: #fef2f2; border-left: 4px solid #ef4444; padding: 0.85rem 1rem; margin: 0.5rem 0 1rem; border-radius: 4px; }
+  .info { background: #f0fdf4; border-left: 4px solid #22c55e; padding: 0.85rem 1rem; margin: 0.5rem 0 1rem; border-radius: 4px; }
+  .quote { background: #eff6ff; border-left: 4px solid #3b82f6; padding: 0.9rem 1rem; font-style: italic; margin: 0.8rem 0; border-radius: 4px; color: #1e3a8a; }
+  .badge { display: inline-block; padding: 0.2rem 0.6rem; border-radius: 9999px; font-size: 0.82rem; font-weight: 600; }
   .badge-alta { background: #fee2e2; color: #991b1b; }
   .badge-media { background: #fef3c7; color: #92400e; }
   .badge-baixa { background: #d1fae5; color: #065f46; }
+  .nota-critica { color: #dc2626; font-weight: 700; }
+  .nota-ok { color: #16a34a; font-weight: 600; }
+  .nota-media { color: #d97706; font-weight: 600; }
+  .kpi-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; margin: 1rem 0 1.5rem; }
+  .kpi-card { background: #fff; border-radius: 8px; padding: 14px 16px; box-shadow: 0 1px 3px rgba(0,0,0,0.1); text-align: center; }
+  .kpi-label { font-size: 0.78rem; color: #64748b; text-transform: uppercase; letter-spacing: 0.04em; }
+  .kpi-value { font-size: 1.9rem; font-weight: 700; color: #0f172a; margin: 4px 0 0; }
+  .section-card { background: #fff; border-radius: 8px; padding: 18px 20px; box-shadow: 0 1px 3px rgba(0,0,0,0.1); margin: 1rem 0; }
+  /* Linhas de observação inline nas tabelas de evolução */
+  .obs-row td { background: #f8fafc; font-size: 0.83rem; color: #475569; font-style: italic; padding: 6px 15px 10px 15px; border-bottom: 1px solid #e2e8f0; }
+  .obs-row td span { font-style: normal; font-weight: 600; color: #94a3b8; margin-right: 4px; }
+  .obs-vazia td { background: #f8fafc; font-size: 0.83rem; color: #cbd5e1; font-style: italic; padding: 6px 15px 10px 15px; border-bottom: 1px solid #e2e8f0; }
+  .trend-stable { color: #64748b; }
+  .footer { text-align: center; color: #94a3b8; margin-top: 3rem; font-size: 0.82rem; border-top: 1px solid #e2e8f0; padding-top: 1.2rem; }
 </style>
 </head>
 <body>
 
-<h1>Análise de Check-ins — [DATA DE HOJE]</h1>
-<p><strong>Período:</strong> [DATA_CORTE] a [DATA DE HOJE]<br>
-<strong>Check-ins:</strong> N | <strong>Clientes:</strong> X | <strong>Accounts:</strong> Y</p>
+<h1>📋 Análise de Check-ins — [DATA DE HOJE]</h1>
+<p style="color:#64748b; font-size:0.9rem;">
+  <strong>Período:</strong> [DATA_CORTE] a [DATA DE HOJE] &nbsp;|&nbsp;
+  <strong>Check-ins:</strong> N &nbsp;|&nbsp;
+  <strong>Clientes:</strong> X &nbsp;|&nbsp;
+  <strong>Accounts:</strong> Y
+</p>
 
 <div class="alert">
-  ⚠️ Lembrete: check-ins são um indicador de tendência. A avaliação final inclui NPS, Quality Check e Retrospectivas.
+  ⚠️ <strong>Lembrete:</strong> Check-ins são um indicador de tendência. A avaliação final do cliente inclui NPS, Quality Check e Retrospectivas. Use estes dados para agir preventivamente.
 </div>
 
+<!-- PANORAMA GERAL — usar cards KPI, não tabela simples -->
 <h2>📊 Panorama Geral</h2>
-<table>
-  <tr><th>Métrica</th><th>Média do Período</th></tr>
-  <tr><td>Nota Geral</td><td>X.X</td></tr>
-  <tr><td>Resultado</td><td>X.X</td></tr>
-  <tr><td>Entregas</td><td>X.X</td></tr>
-  <tr><td>Relacionamento</td><td>X.X</td></tr>
-</table>
-<p>[Síntese executiva analítica sobre o que o período revela]</p>
+<div class="kpi-grid">
+  <div class="kpi-card">
+    <div class="kpi-label">Nota Check-in</div>
+    <div class="kpi-value" style="color:[COR_CHECKIN];">[MEDIA_CHECKIN]</div>
+  </div>
+  <div class="kpi-card">
+    <div class="kpi-label">Resultado</div>
+    <div class="kpi-value" style="color:[COR_RESULTADO];">[MEDIA_RESULTADO]</div>
+  </div>
+  <div class="kpi-card">
+    <div class="kpi-label">Entregas</div>
+    <div class="kpi-value" style="color:[COR_ENTREGA];">[MEDIA_ENTREGA]</div>
+  </div>
+  <div class="kpi-card">
+    <div class="kpi-label">Relacionamento</div>
+    <div class="kpi-value" style="color:[COR_RELAC];">[MEDIA_RELAC]</div>
+  </div>
+</div>
+<div class="section-card">
+  <p>[Síntese executiva analítica: o que o período revela, incluindo divergências entre notas de check-in e resultado]</p>
+</div>
 
-<h2>🔴 Clientes em Atenção (Notas < 3.0)</h2>
-<div class="danger">Atenção imediata para clientes com sinais críticos.</div>
+<!-- RADAR DE ATENÇÃO — inclui check-in < 3.0 E resultado < 3.0 mesmo com check-in OK -->
+<h2>🔴 Radar de Atenção</h2>
+<div class="danger">
+  [Descreva os casos críticos: check-in baixo OU resultado crítico. Nota de resultado < 3.0 deve ser destacada mesmo que a nota de check-in esteja OK.]
+</div>
 <table>
-  <tr><th>Cliente</th><th>Account</th><th>Data</th><th>Nota</th></tr>
-  <!-- iterar clientes em atenção -->
-  <tr><td>...</td><td>...</td><td>...</td><td>...</td></tr>
+  <tr>
+    <th>Cliente</th><th>Account</th><th>Data</th>
+    <th>Nota Check-in</th><th>Nota Resultado</th><th>Nota Entrega</th><th>Nota Relac.</th>
+  </tr>
+  <!-- iterar clientes_atencao + clientes_resultado_critico (deduplizados) -->
+  <tr>
+    <td>...</td><td>...</td><td>...</td>
+    <td class="nota-[ok|media|critica]">X,X</td>
+    <td class="nota-[ok|media|critica]">X,X [🔴|🟡]</td>
+    <td>X,X</td><td>X,X</td>
+  </tr>
 </table>
 
+<!-- EVOLUÇÃO POR CLIENTE — com comentários históricos inline -->
 <h2>📈 Evolução por Cliente</h2>
-<!-- Para CADA cliente novo -->
-<h3>[Nome do Cliente] — Account: [Nome do Account]</h3>
-<table>
-  <tr><th>Data</th><th>Nota</th><th>Δ</th></tr>
-  <tr><td>[hist -1]</td><td>...</td><td>—</td></tr>
-  <tr><td><strong>[NOVO]</strong></td><td>...</td><td>↑/→/↓</td></tr>
-</table>
-<p><strong>Tendência:</strong> [Frase direta resumindo a tendência de performance técnica vs percepção]</p>
+<!-- Para CADA cliente novo, criar um section-card -->
+<div class="section-card">
+  <h3>[Nome do Cliente] — Account: [Nome do Account]</h3>
+  <table>
+    <tr><th>Data</th><th>Check-in</th><th>Resultado</th><th>Entrega</th><th>Relac.</th><th>Δ Resultado</th></tr>
 
-<h2>💬 Destaques</h2>
-<!-- Para CADA check-in com observação significativa -->
-<h3>[Nome do Cliente]</h3>
-<p><strong>Account:</strong> [Account] | <strong>Data:</strong> [Data]</p>
-<div class="quote">"[Trecho mais crítico/insight real]"</div>
-<ul>
-  <li><strong>Pontos:</strong> [Ponto positivo/negativo]</li>
-  <li><strong>Leitura:</strong> [SEU diagnóstico de gestor]</li>
-</ul>
+    <!-- Para cada check-in histórico (ordem cronológica crescente): -->
+    <tr>
+      <td>[DATA_HIST]</td>
+      <td>[nota_checkin]</td>
+      <td class="nota-[ok|media|critica]">[nota_resultado]</td>
+      <td>[nota_entrega]</td>
+      <td>[nota_relacionamento]</td>
+      <td class="trend-stable">— / ↑ / → / ↓</td>
+    </tr>
+    <!-- SEMPRE adicionar linha de observação após cada linha de dados -->
+    <!-- Se a observação existir: -->
+    <tr class="obs-row">
+      <td colspan="6">
+        <span>Obs:</span> "[texto da observação]" — <em>[seu comentário editorial se relevante]</em>
+      </td>
+    </tr>
+    <!-- Se a observação estiver vazia: -->
+    <tr class="obs-vazia">
+      <td colspan="6"><span>Obs:</span> sem observação registrada. <em style="color:#dc2626;">[adicionar nota se a queda de nota coincidir com ausência de obs]</em></td>
+    </tr>
 
+    <!-- Linha do check-in NOVO (destacada) -->
+    <tr style="background:#fef2f2;"><!-- ou #f0fdf4 se positivo -->
+      <td><strong>[DATA_NOVO] ★</strong></td>
+      <td class="nota-ok"><strong>[nota_checkin]</strong></td>
+      <td class="nota-critica"><strong>[nota_resultado] 🔴</strong></td>
+      <td class="nota-ok"><strong>[nota_entrega]</strong></td>
+      <td class="nota-ok"><strong>[nota_relacionamento]</strong></td>
+      <td style="color:#dc2626; font-weight:700;">↓↓</td>
+    </tr>
+    <tr class="obs-row" style="background:#fef2f2;">
+      <td colspan="6"><span>Obs:</span> "[observação do check-in novo]" — <em>[seu diagnóstico]</em></td>
+    </tr>
+  </table>
+  <p><strong>Tendência:</strong> [Frase direta resumindo a trajetória das notas ao longo do histórico, conectando os comentários à evolução das métricas]</p>
+</div>
+
+<!-- DESTAQUES — apenas check-ins com observações significativas -->
+<h2>💬 Destaques dos Comentários</h2>
+<!-- Para CADA check-in novo com observação não-vazia e não-genérica -->
+<div class="section-card">
+  <h3>[Nome do Cliente]</h3>
+  <p><strong>Account:</strong> [Account] &nbsp;|&nbsp; <strong>Data:</strong> [Data]</p>
+  <div class="quote">"[Trecho mais crítico ou revelador da observação]"</div>
+  <ul>
+    <li><strong>Leitura fria:</strong> [Seu diagnóstico de gestor — traduza suavizações em linguagem direta]</li>
+    <li><strong>Risco:</strong> [O que pode acontecer se não houver ação]</li>
+  </ul>
+</div>
+
+<!-- PLANOS DE AÇÃO -->
 <h2>✅ Planos de Ação Recomendados</h2>
 <table>
-  <tr><th>Prioridade</th><th>Cliente</th><th>Ação</th></tr>
-  <!-- iterar acoes -->
-  <tr><td><span class="badge badge-alta">🔴 Alta</span></td><td>...</td><td>...</td></tr>
+  <tr><th style="width:110px;">Prioridade</th><th>Cliente</th><th>Account</th><th>Ação Específica</th></tr>
+  <!-- iterar ações ordenadas por prioridade -->
+  <tr>
+    <td><span class="badge badge-alta">🔴 Alta</span></td>
+    <td>...</td><td>...</td>
+    <td>[Ação concreta com dia, pessoa e objetivo — nunca "acompanhar de perto"]</td>
+  </tr>
+  <tr>
+    <td><span class="badge badge-media">🟡 Média</span></td>
+    <td>...</td><td>...</td><td>...</td>
+  </tr>
 </table>
 
-<p style="text-align: center; color: #64748b; margin-top: 3rem; font-size: 0.875rem;">
-  Análise gerada em [DATA_HOJE] • Fonte: Arquivo de Check-ins
-</p>
+<div class="footer">
+  Análise gerada em [DATA_HOJE] &nbsp;•&nbsp; Fonte: [nome do CSV] &nbsp;•&nbsp; [N] check-ins analisados
+</div>
 
 </body>
 </html>
 ```
+
+### Regras de cor para os KPI cards:
+- Nota ≥ 4,0 → `#16a34a` (verde)
+- Nota 3,0–3,9 → `#d97706` (amarelo)
+- Nota < 3,0 → `#dc2626` (vermelho)
+
+### Regras para a coluna Δ Resultado:
+- Primeira linha → `—`
+- Subiu → `↑` (verde)
+- Estável → `→` (cinza)
+- Caiu 1 ponto → `↓` (vermelho)
+- Caiu 2+ pontos → `↓↓` (vermelho negrito)
 
 ---
 
@@ -266,7 +390,7 @@ No chat da nossa conversa, não jogue o relatório inteiro. Apenas me entregue d
 
 1. **Resumo em 3 a 4 frases** explicando o sentimento geral da análise.
 2. **Planos de ação apenas de 🔴 Alta prioridade** em destaque, dizendo o que eu preciso fazer hoje.
-3. **Link rápido para leitura:** Mostre o path clicável para o arquivo HTML usando `file:///` e o caminho absoluto originado a partir de `./bases/gestao-checkins/dados/...`.
+3. **Link rápido para leitura:** Mostre o path clicável usando `computer://` e o caminho absoluto do arquivo HTML.
 4. Pergunte: "Deseja que eu te traga algum detalhamento de algum dos clientes médios/baixos agora?"
 
 ---
@@ -274,5 +398,7 @@ No chat da nossa conversa, não jogue o relatório inteiro. Apenas me entregue d
 ## 📌 Recomendações e Boas Práticas Comportamentais (Importantíssimo):
 - **Não minta informações ou invente clientes.** Extraia apenas dos dados.
 - **Ajude nas Entrelinhas:** Os accounts costumam suavizar problemas ("tivemos bons insights mas sem vendas" = inércia comercial / possível churn). Traduza de forma fria para o gestor.
-- **Se o campo "observação" de um check-in estiver em branco ou genérico**, não o coloque na aba destaques. Use apenas a tendência fria das notas.
-- **Evite planos genéricos** como "Acompanhar de perto". Recomende "Agendar call quinta com Account Fulano para revisar funnel da etapa 3". Tente ser pragmático.
+- **Se o campo "observação" de um check-in estiver em branco ou genérico**, não o coloque na seção de Destaques. Use apenas a tendência fria das notas.
+- **Exiba SEMPRE as observações inline nas tabelas de evolução**, linha por linha — tanto para check-ins históricos quanto para o novo. Se a observação estiver vazia, use a classe `obs-vazia` e indique explicitamente "sem observação registrada". Se a ausência coincide com queda de nota, adicione nota editorial em vermelho.
+- **Monitore o Resultado independentemente da nota de check-in.** Um cliente com check-in 4,0 mas resultado 2,0 é crítico e deve aparecer no Radar de Atenção.
+- **Evite planos genéricos** como "Acompanhar de perto". Recomende "Agendar call quinta com Account Fulano para revisar funnel da etapa 3". Tente ser pragmático e específico.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,3 +43,15 @@ Consulte [REGISTRY.md](./REGISTRY.md) pra ver tudo que o time ja compartilhou. P
 - Nunca commitar arquivos de `clientes/` ou `bases/` — sao pessoais, ficam no `.gitignore`.
 - Nunca editar `REGISTRY.md` a mao — e auto-gerado pelo script `scripts/build-registry.py` e pela GitHub Action.
 - Se o fluxo git/gh quebrar em qualquer skill (sync, compartilhar, push), oriente rodar `/onboarding` de novo — os checks de setup sao a primeira coisa que ele faz.
+
+## Contexto do Usuário (Gestão e Performance)
+
+O usuário atua como **Gestor de Qualidade e Performance** gerenciando 2 coordenadores (que por sua vez gerenciam squads e ~35 clientes). 
+A IA deve atuar como seu **Copiloto de Gestão**. 
+
+**Diretrizes de interação com este usuário:**
+- **Função:** O foco do usuário não é executar (ex: escrever copy), mas sim **Monitorar, Intervir e Desenvolver** os coordenadores.
+- **Mindset & Referências:** Use frameworks de gestão sempre que possível. As bases do usuário são: *Andy Grove* (Output do gestor, Alavancagem, 1-on-1s), *Vicente Falconi* (PDCA, Itens de Controle) e *Eliyahu Goldratt* (Teoria das Restrições, Gargalos).
+- **Abordagem:** Estruture raciocínios e problemas antes de propor soluções. Questione ideias fracas. Ajude a construir feedbacks difíceis de forma profissional.
+- **Tom de voz:** Direto, claro, objetivo e sem excesso de formalidade ou linguagem artificial. Respostas prontas ou genéricas não servem.
+- **Métricas Foco:** Churn (≤ 6%), CSP por squad (< 30%), NPS (≥ 8), Health Score e qualidade das entregas (Quality Checks/Retrospectivas).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,3 +43,15 @@ Consulte [REGISTRY.md](./REGISTRY.md) pra ver tudo que o time ja compartilhou. P
 - Nunca commitar arquivos de `clientes/` ou `bases/` — sao pessoais, ficam no `.gitignore`.
 - Nunca editar `REGISTRY.md` a mao — e auto-gerado pelo script `scripts/build-registry.py` e pela GitHub Action.
 - Se o fluxo git/gh quebrar em qualquer skill (sync, compartilhar, push), oriente rodar `/onboarding` de novo — os checks de setup sao a primeira coisa que ele faz.
+
+## Contexto do Usuário (Gestão e Performance)
+
+O usuário atua como **Gestor de Qualidade e Performance** gerenciando 2 coordenadores (que por sua vez gerenciam squads e ~35 clientes). 
+A IA deve atuar como seu **Copiloto de Gestão**. 
+
+**Diretrizes de interação com este usuário:**
+- **Função:** O foco do usuário não é executar (ex: escrever copy), mas sim **Monitorar, Intervir e Desenvolver** os coordenadores.
+- **Mindset & Referências:** Use frameworks de gestão sempre que possível. As bases do usuário são: *Andy Grove* (Output do gestor, Alavancagem, 1-on-1s), *Vicente Falconi* (PDCA, Itens de Controle) e *Eliyahu Goldratt* (Teoria das Restrições, Gargalos).
+- **Abordagem:** Estruture raciocínios e problemas antes de propor soluções. Questione ideias fracas. Ajude a construir feedbacks difíceis de forma profissional.
+- **Tom de voz:** Direto, claro, objetivo e sem excesso de formalidade ou linguagem artificial. Respostas prontas ou genéricas não servem.
+- **Métricas Foco:** Churn (≤ 6%), CSP por squad (< 30%), NPS (≥ 8), Health Score e qualidade das entregas (Quality Checks/Retrospectivas).

--- a/REGISTRY.md
+++ b/REGISTRY.md
@@ -1,6 +1,6 @@
 # Builders Hub — Registry
 
-**11 skills** · última atualização: 2026-04-17
+**11 skills** · última atualização: 2026-04-22
 
 > Catálogo auto-gerado por `scripts/build-registry.py`. Não edite à mão — rode `/sync-hub` ou envie PR pela `/compartilhar-skill`.
 

--- a/docs/Builders Hub.md
+++ b/docs/Builders Hub.md
@@ -1,0 +1,63 @@
+# Guia de Instalacao
+
+## Passo 1 — Baixar o repositorio
+
+1. Acesse o link do GitHub (compartilhado na aula)
+2. Clique no botao verde **Code**
+3. Clique em **Download ZIP**
+4. Descompacte o arquivo no seu computador (Desktop ou pasta de trabalho)
+
+## Passo 2 — Instalar o Anti-Gravity
+
+### Mac
+1. Acesse [antigravity.dev](https://antigravity.dev)
+2. Baixe o instalador para Mac
+3. Arraste para a pasta Aplicativos
+4. Abra o Anti-Gravity
+
+### Windows
+1. Acesse [antigravity.dev](https://antigravity.dev)
+2. Baixe o instalador para Windows
+3. Rode o instalador e siga as instrucoes
+4. Abra o Anti-Gravity
+
+## Passo 3 — Instalar a extensao do Claude
+
+1. No Anti-Gravity, clique no icone de **Extensions** (quadradinhos) na barra lateral esquerda
+2. Busque por **"Claude"**
+3. Clique em **Install**
+4. Quando pedido, conecte sua conta Anthropic
+
+## Passo 4 — Abrir o repositorio
+
+1. No Anti-Gravity: **File > Open Folder**
+2. Navegue ate a pasta `builders-hub` que voce descompactou
+3. Clique em **Open**
+
+## Passo 5 — Abrir o terminal
+
+1. Use o atalho: `Ctrl + ~` (Windows) ou `Cmd + ~` (Mac)
+2. Ou va em: **View > Terminal**
+3. O terminal vai abrir na parte de baixo da tela
+
+## Passo 6 — Rodar o onboarding
+
+No terminal, digite:
+```
+/onboarding
+```
+
+A skill valida git e GitHub CLI primeiro (garante que seu push/PR vao funcionar), depois instala o que faltar (Claude Code CLI, notebooklm, etc) e te mostra como compartilhar skills com o time via `/compartilhar-skill`.
+
+## Problemas comuns
+
+**"Comando nao encontrado"**
+- Verifique se a extensao do Claude esta instalada e ativa
+- Tente fechar e reabrir o Anti-Gravity
+
+**"Erro de autenticacao"**
+- Va em Extensions > Claude > Settings e reconecte sua conta
+
+**"MCP nao conecta"**
+- Verifique sua conexao com a internet
+- Tente rodar `/onboarding` novamente — ele vai tentar reconectar

--- a/scripts/checkin_script.py
+++ b/scripts/checkin_script.py
@@ -1,0 +1,81 @@
+import csv
+import json
+import os
+import sys
+from datetime import datetime
+from collections import defaultdict
+
+ARQUIVO = r"C:\Users\jo_da\OneDrive\Área de Trabalho\Gestão\Check-ins\Operação _ Batista&Co. - Check-ins.csv"
+DATA_CORTE_STR = "20/04/2026"
+
+try:
+    data_corte = datetime.strptime(DATA_CORTE_STR, "%d/%m/%Y")
+except ValueError:
+    print("Formato de data inválido. Use DD/MM/YYYY")
+    sys.exit(1)
+
+registros = []
+with open(ARQUIVO, newline='', encoding='utf-8') as f:
+    reader = csv.DictReader(f)
+    for row in reader:
+        try:
+            data_str = row.get("Data da Reunião", "").strip()
+            if not data_str:
+                continue
+            data = datetime.strptime(data_str, "%d/%m/%Y")
+            registros.append({
+                "data": data,
+                "data_str": data_str,
+                "cliente": row.get("Cliente", "").strip(),
+                "account": row.get("Gestor do Projeto", "").strip(),
+                "nota_resultado": float(row.get("Nota Resultado", 0) or 0),
+                "nota_entrega": float(row.get("Nota Entrega", 0) or 0),
+                "nota_relacionamento": float(row.get("Nota Relacionamento", 0) or 0),
+                "nota_checkin": float(row.get("Nota Checkin", 0) or 0),
+                "media": float(row.get("Média das notas", 0) or 0),
+                "observacao": row.get("Observação sobre o Check-in:", "").strip(),
+            })
+        except Exception:
+            continue
+
+# Separar novos e histórico
+novos = [r for r in registros if r["data"] >= data_corte]
+clientes_novos = {r["cliente"] for r in novos}
+
+historico = [r for r in registros if r["data"] < data_corte and r["cliente"] in clientes_novos]
+
+# Pegar últimos 3 históricos por cliente
+historico_por_cliente = defaultdict(list)
+for r in sorted(historico, key=lambda x: x["data"], reverse=True):
+    if len(historico_por_cliente[r["cliente"]]) < 3:
+        historico_por_cliente[r["cliente"]].append(r)
+
+# Médias dos novos
+if novos:
+    media_nota = sum(r["nota_checkin"] for r in novos) / len(novos)
+    media_resultado = sum(r["nota_resultado"] for r in novos) / len(novos)
+    media_entrega = sum(r["nota_entrega"] for r in novos) / len(novos)
+    media_relacionamento = sum(r["nota_relacionamento"] for r in novos) / len(novos)
+else:
+    media_nota = media_resultado = media_entrega = media_relacionamento = 0
+
+resultado = {
+    "total_novos": len(novos),
+    "clientes_analisados": len(clientes_novos),
+    "accounts_envolvidos": len({r["account"] for r in novos}),
+    "media_nota": round(media_nota, 2),
+    "media_resultado": round(media_resultado, 2),
+    "media_entrega": round(media_entrega, 2),
+    "media_relacionamento": round(media_relacionamento, 2),
+    "novos": novos,
+    "historico_por_cliente": {k: v for k, v in historico_por_cliente.items()},
+    "clientes_atencao": [r for r in novos if r["nota_checkin"] < 3.0],
+}
+
+# Serializar datas para JSON
+def serialize(obj):
+    if isinstance(obj, datetime):
+        return obj.strftime("%d/%m/%Y")
+    raise TypeError(f"Type {type(obj)} not serializable")
+
+print(json.dumps(resultado, default=serialize, ensure_ascii=False, indent=2))

--- a/scripts/setup_gestao_checkins.py
+++ b/scripts/setup_gestao_checkins.py
@@ -1,0 +1,37 @@
+import os
+import shutil
+
+workspace = r"c:\Users\jo_da\OneDrive\Área de Trabalho\V4\builders-hub-main"
+bases_dir = os.path.join(workspace, "bases")
+template_dir = os.path.join(bases_dir, "_template")
+project_dir = os.path.join(bases_dir, "gestao-checkins")
+
+if not os.path.exists(project_dir):
+    if os.path.exists(template_dir):
+        shutil.copytree(template_dir, project_dir)
+    else:
+        os.makedirs(os.path.join(project_dir, "dados"))
+        os.makedirs(os.path.join(project_dir, "docs"))
+        os.makedirs(os.path.join(project_dir, "referencias"))
+
+env_example = os.path.join(project_dir, ".env.example")
+env_file = os.path.join(project_dir, ".env")
+if os.path.exists(env_example):
+    shutil.copy(env_example, env_file)
+elif not os.path.exists(env_file):
+    open(env_file, 'w').close()
+
+old_dir = r"C:\Users\jo_da\OneDrive\Área de Trabalho\Gestão\Check-ins"
+new_data_dir = os.path.join(project_dir, "dados")
+
+if not os.path.exists(new_data_dir):
+    os.makedirs(new_data_dir)
+
+if os.path.exists(old_dir):
+    for f in os.listdir(old_dir):
+        # We migrate JSON state and CSV files mostly.
+        # It's better to bring all data files.
+        if f.endswith('.json') or f.endswith('.csv'):
+            shutil.copy(os.path.join(old_dir, f), os.path.join(new_data_dir, f))
+
+print("Dados copiados para", new_data_dir)


### PR DESCRIPTION
## O que mudou

Atualização da skill `gestao-checkin-analysis` de v2.0.0 para v2.1.0, sincronizada do Cowork para o repositório local.

### gestao-checkin-analysis v2.1.0
- **Script Python mais robusto:** `safe_float()` para conversão de notas com vírgula/ponto; parser tenta múltiplos formatos de data
- **Histórico cronológico:** registros históricos agora exibidos em ordem crescente na tabela de evolução
- **Novo campo:** `clientes_resultado_critico` — detecta resultado < 3.0 mesmo quando o check-in está OK
- **Detecção de falha:** Passo 1 recua a data de corte se a execução anterior registrou 0 check-ins
- **Template HTML renovado:** KPI cards no Panorama Geral, `section-card` por cliente, linhas `obs-row` com observações inline no histórico
- **Radar de Atenção expandido:** cobre `resultado < 3.0` independentemente da nota de check-in
- **Link do relatório:** usa `computer://` no lugar de `file:///`

### Também incluído
- Sync do `frontend-design` (SKILL.md atualizado + LICENSE.txt adicionado)
- Adição do `skills-lock.json` no `.agents/`

## Duplo-write
Ambas as cópias foram atualizadas: `.claude/skills/` e `.agents/skills/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)