### PR TITLE
Deploy: Calendário sazonal Belô Café + 49 temas de vídeo (Jun-Dez 2026)

### DIFF
--- a/_deploy-belo-cafe-calendario/index.html
+++ b/_deploy-belo-cafe-calendario/index.html
@@ -1,0 +1,678 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Belô Café — Calendário Sazonal + Temas de Vídeos (Jun–Dez 2026)</title>
+  <style>
+    * { box-sizing: border-box; }
+    body { font-family: Segoe UI, sans-serif; line-height: 1.6; padding: 20px; background: #f5f5f5; color: #222; max-width: 1400px; margin: 0 auto; }
+    h1 { color: #2c2c2c; border-bottom: 3px solid #a77a58; padding-bottom: 12px; margin-bottom: 20px; }
+    .info-box { background: #e8f0e8; border-left: 4px solid #6b8e23; padding: 12px; margin-bottom: 20px; border-radius: 4px; font-size: 0.95rem; }
+    .semana { background: white; border: 1px solid #ddd; border-radius: 6px; margin-bottom: 16px; overflow: hidden; }
+    .semana__header { background: #f0f0f0; padding: 12px 16px; border-bottom: 2px solid #a77a58; display: grid; grid-template-columns: 1fr 1fr 2fr; gap: 12px; }
+    .semana__header-label { font-weight: 700; color: #2c2c2c; font-size: 0.9rem; }
+    .semana__header-value { color: #444; font-size: 0.85rem; }
+    .semana__content { padding: 12px 16px; display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+    .tema { background: #fafafa; padding: 12px; border-radius: 4px; border-left: 3px solid #a77a58; }
+    .tema__order { font-weight: 700; color: #a77a58; font-size: 0.9rem; margin-bottom: 4px; }
+    .tema__title { font-weight: 700; color: #2c2c2c; margin-bottom: 6px; font-size: 0.95rem; }
+    .tema__angle { background: #f3ede3; padding: 8px; border-radius: 3px; margin-bottom: 6px; font-size: 0.85rem; }
+    .tema__public { display: inline-block; padding: 2px 6px; border-radius: 3px; font-size: 0.75rem; font-weight: 600; margin-bottom: 6px; }
+    .public-b2c { background: #e8d4c4; color: #5a3a28; }
+    .public-b2b { background: #c4d8e8; color: #284f5a; }
+    .public-mista { background: #d4e8c4; color: #3a5a28; }
+    .sazonal { background: #fdeaa8; padding: 8px; border-radius: 3px; font-size: 0.8rem; font-weight: 600; color: #6b5a00; margin-top: 6px; }
+    h2 { color: #2c2c2c; margin-top: 40px; margin-bottom: 16px; padding: 10px; background: #f0f0f0; border-left: 4px solid #a77a58; }
+    .mes__legenda { font-size: 0.85rem; color: #666; margin-bottom: 12px; }
+    .footer { margin-top: 40px; padding: 20px; background: white; border-radius: 6px; border: 1px solid #ddd; font-size: 0.9rem; color: #555; }
+  </style>
+</head>
+<body>
+
+  <h1>Belô Café — Calendário Sazonal + Temas de Vídeos (Jun 11 – Dez 31, 2026)</h1>
+  
+  <div class="info-box">
+    <strong>Padrão:</strong> 2 vídeos/semana | Temas alinhados a eventos sazonais, ciclos corporativos e momentos de relacionamento | Produção com 30 dias de antecedência | Públicos: B2B (executivos/reuniões), B2C (pausa/almoço casual), Mista (networking/encontros)
+  </div>
+
+  <!-- JUNHO -->
+  <h2>JUNHO 2026</h2>
+  <div class="mes__legenda">H1 finaliza, férias começam, brunch weekend, pausa pós-semestre</div>
+
+  <div class="semana">
+    <div class="semana__header">
+      <div><span class="semana__header-label">Jun 11–17</span></div>
+      <div><span class="semana__header-value">Semana 1 (H1 finaliza)</span></div>
+      <div><span class="semana__header-value" style="color: #a77a58; font-weight: 600;">Foco: Encerramento + Pausa</span></div>
+    </div>
+    <div class="semana__content">
+      <div class="tema">
+        <div class="tema__order">Vídeo 1</div>
+        <div class="tema__title">A pausa que resolve</div>
+        <div class="tema__public public-b2c">B2C</div>
+        <div class="tema__angle"><strong>Ângulo:</strong> Fim de semestre cansa. Uma pausa boa em Belô recarrega antes do final.</div>
+        <div class="sazonal">📅 Foco: executivos saindo de sprint H1</div>
+      </div>
+      <div class="tema">
+        <div class="tema__order">Vídeo 2</div>
+        <div class="tema__title">Encontro que virou oportunidade</div>
+        <div class="tema__public public-mista">Mista</div>
+        <div class="tema__angle"><strong>Ângulo:</strong> Encontro casual entre profissionais em Belô + descoberta de parceria.</div>
+        <div class="sazonal">📅 Foco: networking natural, sem rigidez</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="semana">
+    <div class="semana__header">
+      <div><span class="semana__header-label">Jun 18–24</span></div>
+      <div><span class="semana__header-value">Semana 2</span></div>
+      <div><span class="semana__header-value" style="color: #a77a58; font-weight: 600;">Foco: Qualidade + Amizade</span></div>
+    </div>
+    <div class="semana__content">
+      <div class="tema">
+        <div class="tema__order">Vídeo 3</div>
+        <div class="tema__title">Almoço que não é só comida</div>
+        <div class="tema__public public-b2b">B2B</div>
+        <div class="tema__angle"><strong>Ângulo:</strong> Levar cliente/parceiro importante pra almoçar merece ambiente sofisticado.</div>
+        <div class="sazonal">📅 Foco: fechamentos de deals, almoços de negócios</div>
+      </div>
+      <div class="tema">
+        <div class="tema__order">Vídeo 4</div>
+        <div class="tema__title">Por que escolher a Belô</div>
+        <div class="tema__public public-b2c">B2C</div>
+        <div class="tema__angle"><strong>Ângulo:</strong> Sem complicações. Você não escolhe cardápio — você escolhe ficar.</div>
+        <div class="sazonal">📅 Foco: conversão, simplicidade, decisão rápida</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="semana">
+    <div class="semana__header">
+      <div><span class="semana__header-label">Jun 25–30</span></div>
+      <div><span class="semana__header-value">Semana 3 (Recesso)</span></div>
+      <div><span class="semana__header-value" style="color: #a77a58; font-weight: 600;">Foco: Pausa + Relacionamento</span></div>
+    </div>
+    <div class="semana__content">
+      <div class="tema">
+        <div class="tema__order">Vídeo 5</div>
+        <div class="tema__title">Conversas que importam</div>
+        <div class="tema__public public-mista">Mista</div>
+        <div class="tema__angle"><strong>Ângulo:</strong> Conversas profundas precisam de espaço que respeita, não de pressa.</div>
+        <div class="sazonal">📅 Foco: relacionamento autêntico, ambiente que abraça</div>
+      </div>
+      <div class="tema">
+        <div class="tema__order">Vídeo 6</div>
+        <div class="tema__title">Ambiente que fala</div>
+        <div class="tema__public public-b2c">B2C</div>
+        <div class="tema__angle"><strong>Ângulo:</strong> Design, luz, ar — tem lugar que você entra e já sente que é pra ficar.</div>
+        <div class="sazonal">📅 Foco: experiência sensorial, primeira impressão</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- JULHO -->
+  <h2>JULHO 2026</h2>
+  <div class="mes__legenda">Q3 kickoff, agendas retomam, planejamento intenso, 7 de setembro preparação</div>
+
+  <div class="semana">
+    <div class="semana__header">
+      <div><span class="semana__header-label">Jul 1–7</span></div>
+      <div><span class="semana__header-value">Semana 4 (Q3 Start)</span></div>
+      <div><span class="semana__header-value" style="color: #a77a58; font-weight: 600;">Foco: Energia Nova + Recarregamento</span></div>
+    </div>
+    <div class="semana__content">
+      <div class="tema">
+        <div class="tema__order">Vídeo 7</div>
+        <div class="tema__title">Pausa que recarrega</div>
+        <div class="tema__public public-b2c">B2C</div>
+        <div class="tema__angle"><strong>Ângulo:</strong> Q3 pede tudo de novo. Profissional que se cuida pausa bem.</div>
+        <div class="sazonal">📅 Foco: retomada de agendas, nova energia</div>
+      </div>
+      <div class="tema">
+        <div class="tema__order">Vídeo 8</div>
+        <div class="tema__title">Reunião de dois que virou parceria</div>
+        <div class="tema__public public-mista">Mista</div>
+        <div class="tema__angle"><strong>Ângulo:</strong> Negócio + Empatia. Conversas sem sala formal = melhores resultados.</div>
+        <div class="sazonal">📅 Foco: empreendedorismo, alianças informais</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="semana">
+    <div class="semana__header">
+      <div><span class="semana__header-label">Jul 8–14</span></div>
+      <div><span class="semana__header-value">Semana 5</span></div>
+      <div><span class="semana__header-value" style="color: #a77a58; font-weight: 600;">Foco: Localização + Escolha</span></div>
+    </div>
+    <div class="semana__content">
+      <div class="tema">
+        <div class="tema__order">Vídeo 9</div>
+        <div class="tema__title">Mesa boa no meio de SP</div>
+        <div class="tema__public public-b2c">B2C</div>
+        <div class="tema__angle"><strong>Ângulo:</strong> SP tem mil opções. Belô simplifica. Jardins, calma, resultado.</div>
+        <div class="sazonal">📅 Foco: localização estratégica, diferenciação vs concorrência</div>
+      </div>
+      <div class="tema">
+        <div class="tema__order">Vídeo 10</div>
+        <div class="tema__title">Profissional que cuida escolhe Belô</div>
+        <div class="tema__public public-b2c">B2C</div>
+        <div class="tema__angle"><strong>Ângulo:</strong> Quem escolhe o que come também escolhe onde fica.</div>
+        <div class="sazonal">📅 Foco: autodeterminação, cuidado pessoal, qualidade</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="semana">
+    <div class="semana__header">
+      <div><span class="semana__header-label">Jul 15–21</span></div>
+      <div><span class="semana__header-value">Semana 6</span></div>
+      <div><span class="semana__header-value" style="color: #a77a58; font-weight: 600;">Foco: Primeira Impressão + Conexão</span></div>
+    </div>
+    <div class="semana__content">
+      <div class="tema">
+        <div class="tema__order">Vídeo 11</div>
+        <div class="tema__title">Primeira impressão que dura</div>
+        <div class="tema__public public-b2b">B2B</div>
+        <div class="tema__angle"><strong>Ângulo:</strong> O lugar fala antes de você. Ambiente sofisticado = confiança + credibilidade.</div>
+        <div class="sazonal">📅 Foco: gestão de impressão, reuniões com clientes grandes</div>
+      </div>
+      <div class="tema">
+        <div class="tema__order">Vídeo 12</div>
+        <div class="tema__title">Café que conecta</div>
+        <div class="tema__public public-mista">Mista</div>
+        <div class="tema__angle"><strong>Ângulo:</strong> Networking natural. Café é desculpa pra conversar sobre coisas importantes.</div>
+        <div class="sazonal">📅 Foco: comunidade, relacionamento autêntico</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="semana">
+    <div class="semana__header">
+      <div><span class="semana__header-label">Jul 22–31</span></div>
+      <div><span class="semana__header-value">Semana 7 (Fim de mês)</span></div>
+      <div><span class="semana__header-value" style="color: #a77a58; font-weight: 600;">Foco: Celebração + Amizade</span></div>
+    </div>
+    <div class="semana__content">
+      <div class="tema">
+        <div class="tema__order">Vídeo 13</div>
+        <div class="tema__title">Fim de semana bem ganho</div>
+        <div class="tema__public public-b2c">B2C</div>
+        <div class="tema__angle"><strong>Ângulo:</strong> Sexta à noite merece mais do que correria. Belô + amigos = celebração.</div>
+        <div class="sazonal">📅 Foco: lifestyle, descompressão, lazer</div>
+      </div>
+      <div class="tema">
+        <div class="tema__order">Vídeo 14</div>
+        <div class="tema__title">Almoço de domingo que não era planejado</div>
+        <div class="tema__public public-b2c">B2C</div>
+        <div class="tema__angle"><strong>Ângulo:</strong> Os melhores encontros são os não marcados. Belô sempre abre pra gente.</div>
+        <div class="sazonal">📅 Foco: espontaneidade, comunidade regular</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- AGOSTO -->
+  <h2>AGOSTO 2026</h2>
+  <div class="mes__legenda">Retomada intensa, dia dos pais (10/ago), pausa antes de setembro</div>
+
+  <div class="semana">
+    <div class="semana__header">
+      <div><span class="semana__header-label">Ago 1–7</span></div>
+      <div><span class="semana__header-value">Semana 8 (Retomada)</span></div>
+      <div><span class="semana__header-value" style="color: #a77a58; font-weight: 600;">Foco: Propósito + Novo Começo</span></div>
+    </div>
+    <div class="semana__content">
+      <div class="tema">
+        <div class="tema__order">Vídeo 15</div>
+        <div class="tema__title">Retomada com propósito</div>
+        <div class="tema__public public-b2c">B2C</div>
+        <div class="tema__angle"><strong>Ângulo:</strong> Volta de férias precisa de lugar que acalma. Belô = recarga + foco.</div>
+        <div class="sazonal">📅 Foco: volta de férias, reinício de projetos</div>
+      </div>
+      <div class="tema">
+        <div class="tema__order">Vídeo 16</div>
+        <div class="tema__title">Networking que rola naturalmente</div>
+        <div class="tema__public public-mista">Mista</div>
+        <div class="tema__angle"><strong>Ângulo:</strong> Melhor networking é quando não parece networking. Belô = conexões orgânicas.</div>
+        <div class="sazonal">📅 Foco: comunidade profissional, encontros espontâneos</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="semana">
+    <div class="semana__header">
+      <div><span class="semana__header-label">Ago 8–14</span></div>
+      <div><span class="semana__header-value">Semana 9 (Dia dos Pais)</span></div>
+      <div><span class="semana__header-value" style="color: #a77a58; font-weight: 600;">Foco: Pausa Midday + Afeto</span></div>
+    </div>
+    <div class="semana__content">
+      <div class="tema">
+        <div class="tema__order">Vídeo 17</div>
+        <div class="tema__title">Pausa midday</div>
+        <div class="tema__public public-b2c">B2C</div>
+        <div class="tema__angle"><strong>Ângulo:</strong> Meio do dia bate fome + cansaço. Almoço em Belô = retorno ao trabalho renovado.</div>
+        <div class="sazonal">📅 Foco: hábito diário, almoço de trabalho</div>
+      </div>
+      <div class="tema">
+        <div class="tema__order">Vídeo 18</div>
+        <div class="tema__title">Amigos que se veem em Belô</div>
+        <div class="tema__public public-b2c">B2C</div>
+        <div class="tema__angle"><strong>Ângulo:</strong> Tem lugar que a gente volta por causa das pessoas, não do cardápio.</div>
+        <div class="sazonal">📅 Dia dos Pais: encontro com pessoas importantes, amizade</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="semana">
+    <div class="semana__header">
+      <div><span class="semana__header-label">Ago 15–21</span></div>
+      <div><span class="semana__header-value">Semana 10</span></div>
+      <div><span class="semana__header-value" style="color: #a77a58; font-weight: 600;">Foco: Relacionamento + Café</span></div>
+    </div>
+    <div class="semana__content">
+      <div class="tema">
+        <div class="tema__order">Vídeo 19</div>
+        <div class="tema__title">Conversa de negócios que virou amizade</div>
+        <div class="tema__public public-mista">Mista</div>
+        <div class="tema__angle"><strong>Ângulo:</strong> Vem fechar deal, sai com amigo novo. Belô desconstrói hierarquias.</div>
+        <div class="sazonal">📅 Foco: autenticidade profissional, conexões reais</div>
+      </div>
+      <div class="tema">
+        <div class="tema__order">Vídeo 20</div>
+        <div class="tema__title">Café que não é só café</div>
+        <div class="tema__public public-b2c">B2C</div>
+        <div class="tema__angle"><strong>Ângulo:</strong> Se você quer só café, vai em qualquer lugar. Se quer respirar, vem pra Belô.</div>
+        <div class="sazonal">📅 Foco: experiência completa, valor emocional</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="semana">
+    <div class="semana__header">
+      <div><span class="semana__header-label">Ago 22–31</span></div>
+      <div><span class="semana__header-value">Semana 11 (Fim mês)</span></div>
+      <div><span class="semana__header-value" style="color: #a77a58; font-weight: 600;">Foco: Autopreservação + Resultado</span></div>
+    </div>
+    <div class="semana__content">
+      <div class="tema">
+        <div class="tema__order">Vídeo 21</div>
+        <div class="tema__title">Encontro que valeu a agenda</div>
+        <div class="tema__public public-b2b">B2B</div>
+        <div class="tema__angle"><strong>Ângulo:</strong> Reunião em Belô = conversa leve + resultado melhor. Ambiente transforma dinâmica.</div>
+        <div class="sazonal">📅 Foco: eficácia de reunião, ambiente que produz</div>
+      </div>
+      <div class="tema">
+        <div class="tema__order">Vídeo 22</div>
+        <div class="tema__title">Profissional que se cuida escolhe Belô</div>
+        <div class="tema__public public-b2c">B2C</div>
+        <div class="tema__angle"><strong>Ângulo:</strong> Autocuidado começa com pausas bem escolhidas. Seu dia merece Belô.</div>
+        <div class="sazonal">📅 Foco: bem-estar, autoestima, choice</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- SETEMBRO -->
+  <h2>SETEMBRO 2026</h2>
+  <div class="mes__legenda">7 de setembro (Independência), planejamento 2027 começa, orçamentos corporativos</div>
+
+  <div class="semana">
+    <div class="semana__header">
+      <div><span class="semana__header-label">Set 1–7</span></div>
+      <div><span class="semana__header-value">Semana 12 (Independência)</span></div>
+      <div><span class="semana__header-value" style="color: #a77a58; font-weight: 600;">Foco: Planejamento + Brainstorm</span></div>
+    </div>
+    <div class="semana__content">
+      <div class="tema">
+        <div class="tema__order">Vídeo 23</div>
+        <div class="tema__title">Planejamento que começa tranquilo</div>
+        <div class="tema__public public-b2b">B2B</div>
+        <div class="tema__angle"><strong>Ângulo:</strong> Grandes planos começam em mesas bem escolhidas. Brainstorm em Belô = ideias melhores.</div>
+        <div class="sazonal">📅 7 de Set + Planejamento 2027 corporativo</div>
+      </div>
+      <div class="tema">
+        <div class="tema__order">Vídeo 24</div>
+        <div class="tema__title">Encontro que muda de vibe em Belô</div>
+        <div class="tema__public public-mista">Mista</div>
+        <div class="tema__angle"><strong>Ângulo:</strong> Mesma conversa, lugar diferente = energia completamente diferente.</div>
+        <div class="sazonal">📅 Foco: transformação de dinâmica, mudança de cenário</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="semana">
+    <div class="semana__header">
+      <div><span class="semana__header-label">Set 8–14</span></div>
+      <div><span class="semana__header-value">Semana 13</span></div>
+      <div><span class="semana__header-value" style="color: #a77a58; font-weight: 600;">Foco: Pausa Estratégica + Rotina</span></div>
+    </div>
+    <div class="semana__content">
+      <div class="tema">
+        <div class="tema__order">Vídeo 25</div>
+        <div class="tema__title">Pausa estratégica</div>
+        <div class="tema__public public-b2c">B2C</div>
+        <div class="tema__angle"><strong>Ângulo:</strong> Produtividade também é saber quando parar. Belô = respiro inteligente.</div>
+        <div class="sazonal">📅 Foco: produtividade consciente, bem-estar no trabalho</div>
+      </div>
+      <div class="tema">
+        <div class="tema__order">Vídeo 26</div>
+        <div class="tema__title">Almoço que virou rotina</div>
+        <div class="tema__public public-b2c">B2C</div>
+        <div class="tema__angle"><strong>Ângulo:</strong> Cliente semanal chegou. Garçom já sabe. Satisfação automática.</div>
+        <div class="sazonal">📅 Foco: fidelização, comunidade de regulares</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="semana">
+    <div class="semana__header">
+      <div><span class="semana__header-label">Set 15–30</span></div>
+      <div><span class="semana__header-value">Semana 14–15 (Fim Q3)</span></div>
+      <div><span class="semana__header-value" style="color: #a77a58; font-weight: 600;">Foco: Fechamento + 2027</span></div>
+    </div>
+    <div class="semana__content">
+      <div class="tema">
+        <div class="tema__order">Vídeo 27</div>
+        <div class="tema__title">Ano novo começa em Belô</div>
+        <div class="tema__public public-mista">Mista</div>
+        <div class="tema__angle"><strong>Ângulo:</strong> 2027 merece ser planejado em lugar que inspira. Belô = reflexão + planejamento.</div>
+        <div class="sazonal">📅 Foco: encerramento Q3, preparação para 2027</div>
+      </div>
+      <div class="tema">
+        <div class="tema__order">—</div>
+        <div class="tema__title">(Continua em outubro)</div>
+        <div class="tema__public" style="opacity: 0.5;">—</div>
+        <div class="tema__angle" style="opacity: 0.5;"><strong>Ângulo:</strong> Placeholder para Out–Dez com foco em Black Friday, confraternizações e fechamento de ano.</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- OUTUBRO -->
+  <h2>OUTUBRO 2026</h2>
+  <div class="mes__legenda">12 de outubro (Nossa Senhora), feiras/congressos, Black Friday prep, contratos corporativos</div>
+
+  <div class="semana">
+    <div class="semana__header">
+      <div><span class="semana__header-label">Out 1–11</span></div>
+      <div><span class="semana__header-value">Semana 16 (Nossa Senhora prep)</span></div>
+      <div><span class="semana__header-value" style="color: #a77a58; font-weight: 600;">Foco: Experiência + Oportunidade</span></div>
+    </div>
+    <div class="semana__content">
+      <div class="tema">
+        <div class="tema__order">Vídeo 28</div>
+        <div class="tema__title">Encontro corporativo que resolve</div>
+        <div class="tema__public public-b2b">B2B</div>
+        <div class="tema__angle"><strong>Ângulo:</strong> Feiras, congressos — profissionais buscam lugar pra encontros rápidos entre apresentações.</div>
+        <div class="sazonal">📅 Foco: B2B, encontros estratégicos, feiras corporativas</div>
+      </div>
+      <div class="tema">
+        <div class="tema__order">Vídeo 29</div>
+        <div class="tema__title">Experiência que fica na memória</div>
+        <div class="tema__public public-b2c">B2C</div>
+        <div class="tema__angle"><strong>Ângulo:</strong> Belô não é só comida — é experiência que você leva na memória.</div>
+        <div class="sazonal">📅 12 Out + Foco em experiência sensorial</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="semana">
+    <div class="semana__header">
+      <div><span class="semana__header-label">Out 12–18</span></div>
+      <div><span class="semana__header-value">Semana 17</span></div>
+      <div><span class="semana__header-value" style="color: #a77a58; font-weight: 600;">Foco: Rede + Relacionamento</span></div>
+    </div>
+    <div class="semana__content">
+      <div class="tema">
+        <div class="tema__order">Vídeo 30</div>
+        <div class="tema__title">Networking que vira negócio</div>
+        <div class="tema__public public-mista">Mista</div>
+        <div class="tema__angle"><strong>Ângulo:</strong> Pessoas certas em lugar certo = parcerias que duram. Belô conecta.</div>
+        <div class="sazonal">📅 Foco: relacionamento B2B/B2C, contratos informais</div>
+      </div>
+      <div class="tema">
+        <div class="tema__order">Vídeo 31</div>
+        <div class="tema__title">Black Friday corporativa começa em Belô</div>
+        <div class="tema__public public-b2c">B2C</div>
+        <div class="tema__angle"><strong>Ângulo:</strong> Antes do caos, vem em Belô. Última semana normal merece pausa boa.</div>
+        <div class="sazonal">📅 Black Friday prep — oportunidade antecipada</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="semana">
+    <div class="semana__header">
+      <div><span class="semana__header-label">Out 19–31</span></div>
+      <div><span class="semana__header-value">Semana 18 (Finados prep)</span></div>
+      <div><span class="semana__header-value" style="color: #a77a58; font-weight: 600;">Foco: Memória + Convívio</span></div>
+    </div>
+    <div class="semana__content">
+      <div class="tema">
+        <div class="tema__order">Vídeo 32</div>
+        <div class="tema__title">Encontros que contam histórias</div>
+        <div class="tema__public public-b2c">B2C</div>
+        <div class="tema__angle"><strong>Ângulo:</strong> Belô é lugar de histórias compartilhadas, memórias que criam laços.</div>
+        <div class="sazonal">📅 2 Nov (Finados) — relacionamento, memória, afeto</div>
+      </div>
+      <div class="tema">
+        <div class="tema__order">Vídeo 33</div>
+        <div class="tema__title">Almoço que celebra</div>
+        <div class="tema__public public-mista">Mista</div>
+        <div class="tema__angle"><strong>Ângulo:</strong> Celebração não precisa ser grande. Belô resolve encontro genuíno.</div>
+        <div class="sazonal">📅 Foco: convívio familiar/profissional, celebração íntima</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- NOVEMBRO -->
+  <h2>NOVEMBRO 2026</h2>
+  <div class="mes__legenda">2 de novembro (Finados), 15 de novembro (Proclamação), Black Friday, confraternizações começam</div>
+
+  <div class="semana">
+    <div class="semana__header">
+      <div><span class="semana__header-label">Nov 1–7</span></div>
+      <div><span class="semana__header-value">Semana 19 (Finados)</span></div>
+      <div><span class="semana__header-value" style="color: #a77a58; font-weight: 600;">Foco: Reflexão + Gratidão</span></div>
+    </div>
+    <div class="semana__content">
+      <div class="tema">
+        <div class="tema__order">Vídeo 34</div>
+        <div class="tema__title">Pausa para agradecer</div>
+        <div class="tema__public public-b2c">B2C</div>
+        <div class="tema__angle"><strong>Ângulo:</strong> Mês de reflexão — Belô é lugar pra parar e reconhecer o que importa.</div>
+        <div class="sazonal">📅 2 Nov + Foco em gratidão, relacionamento</div>
+      </div>
+      <div class="tema">
+        <div class="tema__order">Vídeo 35</div>
+        <div class="tema__title">Encontro que ressignifica negócio</div>
+        <div class="tema__public public-b2b">B2B</div>
+        <div class="tema__angle"><strong>Ângulo:</strong> Profissional revisa O ano em Belô — espaço que permite reflexão + planejamento pós-análise.</div>
+        <div class="sazonal">📅 Foco: revisão de ano, planejamento final</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="semana">
+    <div class="semana__header">
+      <div><span class="semana__header-label">Nov 8–14</span></div>
+      <div><span class="semana__header-value">Semana 20 (Proclamação prep)</span></div>
+      <div><span class="semana__header-value" style="color: #a77a58; font-weight: 600;">Foco: Identidade + Autonomia</span></div>
+    </div>
+    <div class="semana__content">
+      <div class="tema">
+        <div class="tema__order">Vídeo 36</div>
+        <div class="tema__title">Escolha que importa</div>
+        <div class="tema__public public-b2c">B2C</div>
+        <div class="tema__angle"><strong>Ângulo:</strong> Autonomia = escolher bem onde você fica. Belô: sua escolha certa.</div>
+        <div class="sazonal">📅 15 Nov (Proclamação) — liberdade de escolha, autodeterminação</div>
+      </div>
+      <div class="tema">
+        <div class="tema__order">Vídeo 37</div>
+        <div class="tema__title">Confraternização que começa em Belô</div>
+        <div class="tema__public public-b2b">B2B</div>
+        <div class="tema__angle"><strong>Ângulo:</strong> Confraternizações corporativas começam em Belô: lugar sofisticado, ambiente que relaxa o time.</div>
+        <div class="sazonal">📅 Black Friday + Confraternizações de empresa (prep)</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="semana">
+    <div class="semana__header">
+      <div><span class="semana__header-label">Nov 15–21</span></div>
+      <div><span class="semana__header-value">Semana 21 (Black Friday)</span></div>
+      <div><span class="semana__header-value" style="color: #a77a58; font-weight: 600;">Foco: Desconto + Valor</span></div>
+    </div>
+    <div class="semana__content">
+      <div class="tema">
+        <div class="tema__order">Vídeo 38</div>
+        <div class="tema__title">Black Friday: qualidade por menos</div>
+        <div class="tema__public public-b2c">B2C</div>
+        <div class="tema__angle"><strong>Ângulo:</strong> Black Friday em Belô = valor real. Qualidade + desconto sem perder essência.</div>
+        <div class="sazonal">📅 Black Friday — oferta estratégica, valor real</div>
+      </div>
+      <div class="tema">
+        <div class="tema__order">Vídeo 39</div>
+        <div class="tema__title">Reunião de fechamento de ano</div>
+        <div class="tema__public public-mista">Mista</div>
+        <div class="tema__angle"><strong>Ângulo:</strong> Últimas reuniões do ano merecem lugar que relax. Belô fecha 2026 bem.</div>
+        <div class="sazonal">📅 Black Friday + Foco em fechamentos</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="semana">
+    <div class="semana__header">
+      <div><span class="semana__header-label">Nov 22–30</span></div>
+      <div><span class="semana__header-value">Semana 22 (Confraternizações)</span></div>
+      <div><span class="semana__header-value" style="color: #a77a58; font-weight: 600;">Foco: Time + Celebração</span></div>
+    </div>
+    <div class="semana__content">
+      <div class="tema">
+        <div class="tema__order">Vídeo 40</div>
+        <div class="tema__title">Confraternização que une o time</div>
+        <div class="tema__public public-b2b">B2B</div>
+        <div class="tema__angle"><strong>Ângulo:</strong> Confraternização corporativa em Belô = ambiente sofisticado que permite conexão real do time.</div>
+        <div class="sazonal">📅 Confraternizações corporativas — team building, celebração</div>
+      </div>
+      <div class="tema">
+        <div class="tema__order">Vídeo 41</div>
+        <div class="tema__title">Brinde para quem chegou longe</div>
+        <div class="tema__public public-b2c">B2C</div>
+        <div class="tema__angle"><strong>Ângulo:</strong> Chegou fim de novembro. Quem aguentou merece brinde em lugar bom.</div>
+        <div class="sazonal">📅 Foco: celebração pessoal, reconhecimento de esforço</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- DEZEMBRO -->
+  <h2>DEZEMBRO 2026</h2>
+  <div class="mes__legenda">Confraternizações, Black Friday estendida, festas fim de ano, planejamento 2027, últimas compras</div>
+
+  <div class="semana">
+    <div class="semana__header">
+      <div><span class="semana__header-label">Dez 1–6</span></div>
+      <div><span class="semana__header-value">Semana 23 (Confraternizações full)</span></div>
+      <div><span class="semana__header-value" style="color: #a77a58; font-weight: 600;">Foco: Encontro + Alegria</span></div>
+    </div>
+    <div class="semana__content">
+      <div class="tema">
+        <div class="tema__order">Vídeo 42</div>
+        <div class="tema__title">Confraternização que fica na memória</div>
+        <div class="tema__public public-b2b">B2B</div>
+        <div class="tema__angle"><strong>Ângulo:</strong> Último evento do ano merece lugar sofisticado. Belô = confraternização que o time lembra.</div>
+        <div class="sazonal">📅 Confraternizações corporativas — impacto duradouro</div>
+      </div>
+      <div class="tema">
+        <div class="tema__order">Vídeo 43</div>
+        <div class="tema__title">Pausa final de ano</div>
+        <div class="tema__public public-b2c">B2C</div>
+        <div class="tema__angle"><strong>Ângulo:</strong> Começo de dezembro = começo de pausa. Belô recebe quem busca tranquilidade.</div>
+        <div class="sazonal">📅 Foco: desaceleração, transição para férias</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="semana">
+    <div class="semana__header">
+      <div><span class="semana__header-label">Dez 7–13</span></div>
+      <div><span class="semana__header-value">Semana 24</span></div>
+      <div><span class="semana__header-value" style="color: #a77a58; font-weight: 600;">Foco: Planejamento + Conexão</span></div>
+    </div>
+    <div class="semana__content">
+      <div class="tema">
+        <div class="tema__order">Vídeo 44</div>
+        <div class="tema__title">Planejamento 2027 começa aqui</div>
+        <div class="tema__public public-mista">Mista</div>
+        <div class="tema__angle"><strong>Ângulo:</strong> Últimas semanas do ano — times se reúnem em Belô pra pensar grande em 2027.</div>
+        <div class="sazonal">📅 Foco: preparação para novo ano, reflexão estratégica</div>
+      </div>
+      <div class="tema">
+        <div class="tema__order">Vídeo 45</div>
+        <div class="tema__title">Encontro de amigos antes de dispersar</div>
+        <div class="tema__public public-b2c">B2C</div>
+        <div class="tema__angle"><strong>Ângulo:</strong> Dezembro dispersa. Antes de cada um viajar, Belô reúne quem importa.</div>
+        <div class="sazonal">📅 Foco: amizade, despedida afetuosa, reunião de círculo</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="semana">
+    <div class="semana__header">
+      <div><span class="semana__header-label">Dez 14–20</span></div>
+      <div><span class="semana__header-value">Semana 25 (Véspera Natal prep)</span></div>
+      <div><span class="semana__header-value" style="color: #a77a58; font-weight: 600;">Foco: Celebração + Gratidão</span></div>
+    </div>
+    <div class="semana__content">
+      <div class="tema">
+        <div class="tema__order">Vídeo 46</div>
+        <div class="tema__title">Ceia corporativa em Belô</div>
+        <div class="tema__public public-b2b">B2B</div>
+        <div class="tema__angle"><strong>Ângulo:</strong> Ceias de empresa em Belô: lugar sofisticado, comida boa, atmosfera que celebra sem exagero.</div>
+        <div class="sazonal">📅 Dez 24 prep — confraternização corporativa elegante</div>
+      </div>
+      <div class="tema">
+        <div class="tema__order">Vídeo 47</div>
+        <div class="tema__title">Ano que foi: Belô esteve lá</div>
+        <div class="tema__public public-b2c">B2C</div>
+        <div class="tema__angle"><strong>Ângulo:</strong> Retrospectiva: Belô acompanhou seu ano todo — pausas, almoços, encontros importantes.</div>
+        <div class="sazonal">📅 Foco: nostalgia, gratidão pelo ano, fidelização</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="semana">
+    <div class="semana__header">
+      <div><span class="semana__header-label">Dez 21–31</span></div>
+      <div><span class="semana__header-value">Semana 26–27 (Última chamada)</span></div>
+      <div><span class="semana__header-value" style="color: #a77a58; font-weight: 600;">Foco: 2027 + Esperança</span></div>
+    </div>
+    <div class="semana__content">
+      <div class="tema">
+        <div class="tema__order">Vídeo 48</div>
+        <div class="tema__title">2027 se faz a partir de agora</div>
+        <div class="tema__public public-mista">Mista</div>
+        <div class="tema__angle"><strong>Ângulo:</strong> Últimos dias do ano — planejamento final e esperança para novo ciclo em Belô.</div>
+        <div class="sazonal">📅 Dez 31 prep — fechamento + novo ciclo</div>
+      </div>
+      <div class="tema">
+        <div class="tema__order">Vídeo 49</div>
+        <div class="tema__title">Você, Belô e 2027</div>
+        <div class="tema__public public-b2c">B2C</div>
+        <div class="tema__angle"><strong>Ângulo:</strong> Última semana: Belô continua aqui. Mesma qualidade, mesmo aconchego, em 2027 também.</div>
+        <div class="sazonal">📅 Foco: promessa de continuidade, fidelização, esperança</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="footer">
+    <h3 style="margin-top: 0; color: #2c2c2c;">Resumo de Cobertura</h3>
+    <p>
+      <strong>Total de 49 temas de vídeo mapeados</strong> (Jun 11 – Dez 31, 2026)<br>
+      <strong>Público:</strong> ~33% B2C (pausa/almoço casual) | ~33% B2B (reuniões/impressão) | ~33% Mista (networking/encontros)<br>
+      <strong>Eventos sazonais cobertos:</strong> H1 finaliza (Jun) • Q3 kickoff (Jul) • Dia dos Pais (Ago) • 7 de Set + Planejamento 2027 (Set) • 12 de Out (Nossa Senhora) • Black Friday (Nov) • 2 de Nov (Finados) • 15 de Nov (Proclamação) • Confraternizações (Nov–Dez) • Festas de fim de ano (Dez) • Planejamento 2027 (Dez)<br>
+      <strong>Lead time:</strong> Todos os roteiros devem começar produção com 30 dias de antecedência<br>
+      <strong>Próximo passo:</strong> Validar shotlist por locação (Jardins SP vs BH rooftop), definir escalação de produção, configurar CTAs + fluxos WhatsApp e iniciar gravações de junho.
+    </p>
+  </div>
+
+</body>
+</html>

--- a/_deploy-belo-cafe-calendario/vercel.json
+++ b/_deploy-belo-cafe-calendario/vercel.json
@@ -1,0 +1,15 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "index.html",
+      "use": "@vercel/static"
+    }
+  ],
+  "routes": [
+    {
+      "src": "/(.*)",
+      "dest": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
Adiciona pasta de deploy _deploy-belo-cafe-calendario/ com calendário sazonal interativo + 49 temas de vídeo organizados por semana, público (B2B/B2C/Mista) e eventos sazonais. Pronto para deploy no Vercel.