### PR TITLE
feat(skills): add ekyte task-suite skills (briefing, refresh, task)

### DIFF
--- a/.agents/skills/ekyte-briefing-refresh/SKILL.md
+++ b/.agents/skills/ekyte-briefing-refresh/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: ekyte-briefing-refresh
+description: Atualiza os arquivos de cache da `/ekyte-briefing` — `clientes/_skill-ekyte/drives.md` (links de Drive por cliente) e `clientes/_skill-ekyte/backups-crm.md` (planilhas de backup CRM por cliente). Use quando o Fabio entrar com cliente novo, trocar link de Drive de algum cliente, criar planilha de backup CRM nova, ou quando rodar `/ekyte-briefing-refresh`. Não toca em templates da skill (esses são gerenciados pela `/ekyte-templates-refresh`).
+area: ekyte
+author: fabio
+version: 1.0.0
+user-invocable: true
+---
+
+# /ekyte-briefing-refresh — Atualizar drives e backups CRM
+
+Mantém os dois arquivos de lookup que a `/ekyte-briefing` usa: `drives.md` (sempre presente) e `backups-crm.md` (preenchido sob demanda).
+
+## Quando usar
+
+- `/ekyte-briefing-refresh` (invocação direta)
+- "atualiza o Drive do cliente X"
+- "entrou cliente novo, atualiza"
+- "criei a planilha de backup do CRM, salva aqui"
+- "Cliente H agora tem Drive: <link>"
+
+## Pré-requisitos
+
+- `clientes/_skill-ekyte/drives.md` existente (criado pela `/ekyte-briefing` na primeira instalação).
+- `clientes/_skill-ekyte/backups-crm.md` existente.
+
+## Fluxo
+
+### 1) Perguntar o que atualizar
+
+```
+O que você quer atualizar?
+
+1) Drive de cliente — adicionar/trocar link de Drive
+2) Planilha de Backup CRM — adicionar/trocar planilha de backup
+3) Ambos
+```
+
+### 2) Modo "Drive de cliente"
+
+```
+Qual cliente?
+1) Cliente E                  → atual: <link>
+2) Cliente F  → atual: <link>
+3) Cliente A           → atual: <link>
+4) Cliente B                   → atual: <link>
+5) Cliente C                → atual: <link>
+6) Cliente D                  → atual: <link>
+7) Cliente G        → atual: <link>
+8) Cliente H         → atual: _sem Drive ainda_
+9) Cliente novo (não está nos 8 acima)
+```
+
+- Opções 1-8: pedir novo link, validar formato (URL Google Drive), atualizar `drives.md`.
+- Opção 9: pedir nome do cliente + alias + link. **Avisar**: cliente novo também precisa estar no `cache.md` (workspaces) — sugerir rodar `/ekyte-refresh` na sequência se ainda não rodou.
+
+Mostrar diff antes de salvar:
+```
+Drive de Cliente G:
+  ANTES: https://drive.google.com/drive/folders/1R1TGag8...
+  DEPOIS: https://drive.google.com/drive/folders/NOVO_ID...
+
+Confirma? (sim/não)
+```
+
+### 3) Modo "Planilha de Backup CRM"
+
+```
+Qual cliente vai ter planilha de backup atualizada?
+[lista os 8 com status atual: vazio / link]
+```
+
+Pedir link da planilha. Salvar em `backups-crm.md`. Mesmo padrão de diff antes de confirmar.
+
+### 4) Modo "Ambos"
+
+Roda 2) e depois 3) em sequência.
+
+### 5) Salvar e reportar
+
+Após cada update:
+- Atualizar tabela do arquivo correspondente.
+- Atualizar campo "Última atualização" no topo do arquivo.
+- Reportar resumo:
+
+```
+✅ Atualizações salvas:
+  • Drive de Cliente G atualizado
+  • Backup CRM de Cliente C adicionado
+
+Arquivos modificados:
+  - clientes/_skill-ekyte/drives.md
+  - clientes/_skill-ekyte/backups-crm.md
+```
+
+## Guardrails
+
+1. **Diff obrigatório.** Sempre mostrar antes/depois antes de salvar. Erros de digitação em link de Drive quebram o briefing inteiro depois — vale pedir confirmação.
+
+2. **Validação mínima de URL.** Drive precisa ser `drive.google.com`. Backup pode ser sheets.google.com OU outro formato. Se URL não bate o domínio esperado, perguntar se está certo antes de salvar.
+
+3. **Cliente fora dos 8 fixos** → exigir confirmação extra ("Esse cliente não está nos 8 do `cache.md`. Tem certeza? Vai precisar adicionar no cache.md depois também."). Não bloquear, mas avisar.
+
+4. **Não mexer em templates.** Esta skill toca **só** em `drives.md` e `backups-crm.md`. Templates são responsabilidade de `/ekyte-templates-refresh`.
+
+## Como invocar
+
+- `/ekyte-briefing-refresh` (direto).
+- "atualiza Drive do Y" / "salva planilha de backup do X".
+
+## O que NÃO fazer
+
+- Não escrever em `briefing-templates/` (use `/ekyte-templates-refresh`).
+- Não mexer em `cache.md` (use `/ekyte-refresh`).
+- Não criar cliente novo silenciosamente — sempre avisar que `cache.md` também precisa ser atualizado.

--- a/.agents/skills/ekyte-briefing/SKILL.md
+++ b/.agents/skills/ekyte-briefing/SKILL.md
@@ -1,0 +1,396 @@
+---
+name: ekyte-briefing
+description: Monta briefings ricos e estruturados pra tarefas do Ekyte com base em templates locais por sigla, contexto puxado do NotebookLM do cliente, e perguntas ativas estruturadas. Usado como subskill da `/ekyte-task` — recebe pacote {cliente, sigla, tipo, qtd, input, modo} e devolve HTML rico formatado pronto pra entrar no campo `description`/`description_create_task` do Ekyte, com heads e labels em negrito. Pode ser invocada avulsa quando o usuário só quer pensar/estruturar uma demanda sem subir task. Suporta modo 5W1H quando vem planilha de plano de ação.
+area: ekyte
+author: fabio
+version: 1.0.0
+user-invocable: true
+---
+
+# /ekyte-briefing — Geração de briefing rico pra tasks do Ekyte
+
+Substitui o briefing "uma linha + `<<PREENCHER>>`" da v1 da `/ekyte-task` por um briefing estruturado, profundo e pré-preenchido com contexto do NotebookLM do cliente.
+
+## Regra soberana de formatação Ekyte (atualizada em 2026-06-15)
+
+Briefings enviados ao Ekyte devem ser **HTML rico**, não texto plano. Esta regra substitui qualquer orientação legada neste arquivo que diga para remover HTML ou converter tudo para texto simples.
+
+Padrão obrigatório:
+- Seções principais viram heads visuais maiores e em negrito: `<div><strong><span style="font-size: 18px;">ATIVOS DA CAMPANHA</span></strong></div>`.
+- Labels de campo ficam em negrito: `<div><strong>Drive do Cliente:</strong> <a href="...">...</a></div>`.
+- Listas de entregáveis, guardrails e métricas usam `<ul><li>...</li></ul>`.
+- Espaçamento entre blocos usa `<div><br></div>`.
+- Não usar `<h1>` ou `<h2>`. CSS inline só é permitido em heads de seção para aumentar fonte (`font-size: 18px`). O Ekyte renderiza melhor com `<div>`, `<strong>`, `<span style="font-size: 18px;">`, `<a>`, `<ul>` e `<li>`.
+- Preferir texto ASCII dentro do HTML quando a API retornar acentos quebrados como `?`; visual correto > acento quebrado.
+- O campo `briefing_ekyte_text` pode manter esse nome por compatibilidade, mas seu conteúdo deve ser HTML rico.
+
+## Quando usar
+
+**Modo subskill (principal)** — invocada pela `/ekyte-task` no passo 6 da criação de task. Recebe pacote estruturado, devolve briefing em HTML rico formatado pronto.
+
+**Modo avulso** — Fabio chama direto:
+- `/ekyte-briefing` + descrição livre
+- "me brieffa um CA pro Cliente A com foco em remarketing produto X"
+- "preciso pensar essa demanda CRM antes de subir — me ajuda a montar o briefing"
+
+Em modo avulso, a skill devolve o HTML rico formatado para Ekyte **e** o Markdown limpo, e pergunta se Fabio quer subir como task (aí invoca `/ekyte-task`).
+
+## Pré-requisitos
+
+- MCP `ekyte` configurada (pra eventual lookup de tipo de tarefa).
+- Cache `clientes/_skill-ekyte/cache.md` populado (workspaces/projetos/tipos).
+- `clientes/_skill-ekyte/drives.md` populado (drives dos clientes).
+- `clientes/_skill-ekyte/briefing-templates/*.md` presentes (templates por sigla + base + universal + 5W1H).
+- Cliente alvo deve ter `clientes/<cliente>/CLAUDE.md` com bloco `## NotebookLM`. Em modo subskill da `/ekyte-task`, a skill deve tentar consultar NotebookLM; se faltar cadastro, pedir cadastro ou autorização explícita do gerente de projetos para seguir sem NotebookLM.
+- `notebooklm-py` autenticado (pra `/cs-notebooklm-consulta-cliente` rodar). Se não estiver, pedir login ou autorização explícita do gerente de projetos para seguir sem síntese.
+
+Os dois pré-requisitos de NotebookLM acima só são bloqueantes quando o pacote recebe `notebook_obrigatorio: true`. Tarefas da whitelist operacional chegam com `notebook_obrigatorio: false` e não devem abrir bloqueio de cadastro/login.
+
+## Pacote de entrada (modo subskill)
+
+A `/ekyte-task` passa:
+
+```json
+{
+  "cliente": "Cliente A",
+  "cliente_alias": "cliente-a",
+  "sigla": "CA",
+  "task_type_name": "Criativo Ads",
+  "task_type_id": "29740",
+  "qtd": 9,
+  "titulo": "[09][CA][IA] Cliente A | Remarketing produto X",
+  "input_livre": "cria 9 CAs pro Cliente A com foco em remarketing produto X",
+  "modo": "texto_livre",   // ou "planilha_demandas" ou "5w1h"
+  "projeto_novo": false,
+  "notebook_obrigatorio": true,
+  "motivo_isencao_notebook": null,
+  "planilha_5w1h_url": null,  // preenchido se modo=5w1h
+  "planilha_demanda_row": null  // preenchido se modo=planilha_demandas
+}
+```
+
+## Fluxo
+
+### 1) Carregar contexto inicial
+
+Em paralelo (independentes):
+- Ler `clientes/_skill-ekyte/drives.md` → mapa cliente → drive_link
+- Ler `clientes/_skill-ekyte/backups-crm.md` (se sigla é CRM-relacionada)
+- Ler `clientes/<cliente>/CLAUDE.md` → extrair Notebook ID do bloco `## NotebookLM`
+- Carregar `clientes/_skill-ekyte/briefing-templates/_header-universal.md`
+- Carregar template específico da sigla (ex: `CA.md`). Se sigla é criativa (CA/LP/RV), carregar também `_base-criativo.md`.
+
+### 2) Decidir modo de operação
+
+Antes de decidir o modo de entrada, respeitar a classificação recebida da `/ekyte-task`:
+
+- `notebook_obrigatorio: true` → seguir os passos 3 a 5 e consultar `/cs-notebooklm-consulta-cliente`.
+- `notebook_obrigatorio: false` → pular os passos 3, 3.5, 4 e 4.5; registrar `motivo_isencao_notebook`; montar briefing operacional a partir da descrição, links de Drive/backup e template. Não exigir NotebookLM cadastrado nem login.
+- Campo ausente → assumir `true`. A falha segura é consultar.
+- `projeto_novo: true` → forçar `notebook_obrigatorio: true`, exceto projetos internos de timesheet/rotina administrativa sem contexto de cliente.
+
+Whitelist aceita para `notebook_obrigatorio: false`: otimização de campanhas recorrente; atualização de Growth Pack recorrente; apontamento de horas/timesheet; atendimento/comunicação recorrente; envio recorrente de NPS/CSAT; atualização administrativa interna recorrente sem decisão estratégica. Qualquer análise, criação, implementação, tracking, CRM, automação, projeção, campanha, público, pesquisa ou planejamento exige NotebookLM.
+
+**Modo `texto_livre`** (default): segue fluxo padrão.
+
+**Modo `5w1h`**: input contém link de planilha 5W1H + skill validou cabeçalho. Pula `_base-criativo.md`, carrega `_5w1h.md` e usa como layout principal. Skill abre a planilha (WebFetch) e extrai os 6W.
+
+**Modo `planilha_demandas`**: input veio da planilha de demandas (já manipulada pela `/ekyte-task`). Skill recebe o `planilha_demanda_row` com colunas `descricao`, `Tags`, etc — usa `descricao` como base e enriquece via NotebookLM.
+
+### 3) Cache de sessão NotebookLM
+
+Verificar se já tem síntese cacheada pro cliente nesta conversa:
+
+```
+sessao_notebook_cache = {
+  "Cliente A": { "sintese": "...", "ts": "2026-04-30 10:15", "perguntas": [...] }
+}
+```
+
+- **Cache HIT** (cliente já consultado): reusar síntese.
+- **Cache MISS** OU primeira task do cliente na sessão: seguir pro passo 3.5 antes de invocar NotebookLM.
+
+### 3.5) Cache persistente de público (TTL 90d)
+
+Antes de invocar `/cs-notebooklm-consulta-cliente`, checar `clientes/<cliente>/publicos-cache.md`. Formato e regras: ver [_publicos-cache-template.md](../../../clientes/_skill-ekyte/_publicos-cache-template.md).
+
+1. **Identificar a linha/categoria** a partir do título/input:
+   - Produto explícito no título (`Saint Tropez`, `Cliente A Baby`) → mapear pra linha conhecida.
+   - Sinal contextual sem produto (`remarketing produto X`) → perguntar ao Fabio qual linha.
+   - Cliente sem segmentação (Cliente C, Cliente D) → linha `Geral`.
+
+2. **Abrir `publicos-cache.md`** do cliente. Buscar bloco `## <linha>` (match case-insensitive, ignora acentos).
+
+3. **Decidir HIT/STALE/MISS:**
+   - **HIT** (idade < 75d): pré-preencher campos 3-9 do `_base-criativo.md` (consciência, faixa, sexo, ganchos) + avatar/ofertas/restrições/tom-de-voz com os valores do cache. Marcar no preview: `[do cache: <linha> · <N>d]`. Cache cobre público; não substitui a consulta NotebookLM quando `projeto_novo: true` ou quando ainda não existe síntese de sessão para o cliente.
+   - **STALE** (75d ≤ idade < 90d): usa o cache **mas** mostra aviso no preview da pergunta ativa: `⚠️ cache de público da linha "<X>" tem <N>d (expira em <M>d). Quer atualizar antes de seguir? (sim/não, default não)`. Resposta sim = força MISS path. Não/silêncio = HIT silencioso.
+   - **MISS** (idade ≥ 90d OU bloco inexistente OU arquivo inexistente): segue pro passo 4 (NotebookLM completo). Após sucesso da consulta, **escrever o bloco no cache** (passo 4.5).
+
+4. **Modo planilha com OBS robusta:** se o pacote de entrada veio da `/ekyte-task` com descrição substancial, usar a OBS como base do briefing, não como substituta do NotebookLM. HIT de cache pode dispensar apenas a pergunta específica de público; MISS/STALE-com-update invoca `/cs-notebooklm-consulta-cliente` para atualizar público. Se `projeto_novo: true`, rodar consulta NotebookLM atual mesmo com cache HIT.
+
+### 4) Invocar `/cs-notebooklm-consulta-cliente`
+
+Compor as 5 perguntas dirigidas pelo tipo da task (cada template tem suas próprias na seção "Pré-preenchimento via NotebookLM").
+
+Tarefa enviada:
+```
+"vou montar briefing de [tipo] (sigla [sigla]) pro [cliente]. preciso saber: [resumo das 5 perguntas]"
+```
+
+A skill `/cs-notebooklm-consulta-cliente` faz o trabalho pesado: decompõe, dispara, agrega, salva artefato. Retorna síntese estruturada.
+
+**Se a `/cs-notebooklm-consulta-cliente` retornar erro** (sessão expirada, cliente sem NotebookLM, etc):
+- Em modo subskill da `/ekyte-task`: pausar e pedir decisão. Cliente sem NotebookLM cadastrado → pedir `/notebooklm-cadastrar` ou comando explícito do gerente de projetos para seguir sem NotebookLM; sessão expirada → pedir `notebooklm login` ou comando explícito para seguir sem síntese.
+- Em modo subskill com `projeto_novo: true`: a tentativa de consulta NotebookLM é obrigatória. Se falhar, só continuar com autorização explícita do gerente de projetos, registrando no briefing que foi criado sem síntese NotebookLM.
+- Em modo avulso: avisar Fabio e perguntar se ele quer seguir sem síntese apenas como rascunho.
+
+Cachear síntese em memória (sessão).
+
+### 4.5) Popular cache persistente de público (após sucesso do passo 4)
+
+Se o passo 3.5 deu MISS/STALE-com-update e o passo 4 (NotebookLM) retornou síntese válida, **escrever bloco no cache** antes de seguir pro 5:
+
+1. Abrir/criar `clientes/<cliente>/publicos-cache.md` (formato em [_publicos-cache-template.md](../../../clientes/_skill-ekyte/_publicos-cache-template.md)).
+2. Se já existe bloco `## <linha>`: **substituir inteiro** (preserva os demais blocos do arquivo).
+3. Se não existe: **acrescentar ao final** do arquivo.
+4. Atualizar header "Última escrita: YYYY-MM-DD".
+5. Campos a gravar (NotebookLM silencioso em algum = `_não documentado_`, **nunca fabricar**):
+   - `ult_consulta`, `expira` (ult_consulta + 90d), `fonte` (URL do notebook)
+   - `Avatar` (texto narrativo 2-4 linhas)
+   - `Faixa etária dominante` (bins)
+   - `Sexo` (Masculino|Feminino|Ambos)
+   - `Nível de consciência` (1-5 com labels)
+   - `Ganchos com tração documentada` (lista)
+   - `Ofertas que já rodaram`, `Restrições documentadas`, `Tom de voz`
+
+Esse cache fica disponível pras próximas sessões (modo inline rápido da `/ekyte-task` consome direto sem precisar invocar essa skill).
+
+### 5) Pré-preenchimento dos campos do template
+
+Com a síntese em mãos, varrer o template da sigla e pré-preencher campos onde a síntese tem informação.
+
+Marcar campos pré-preenchidos com `[sugerido pelo NotebookLM, confirma?]` no preview de pergunta. Se Fabio aceitar tudo, vira valor final; se editar, vai a edição.
+
+### 6) Pergunta ativa em lote
+
+Listar **todas** as perguntas do template em uma só rodada, numeradas. Pré-preenchidos aparecem com a sugestão visível.
+
+Formato:
+
+```
+📋 BRIEFING: [09][CA][IA] Cliente A | Remarketing produto X
+
+Pra montar o briefing, responde as perguntas abaixo. Pode responder tudo de uma vez,
+em qualquer formato — se ficar dúvida, eu pergunto de novo só do que ficou solto.
+
+NotebookLM consultado em 2026-04-30 10:15. Síntese disponível e usei pra
+pré-preencher [N] campos. Você confirma ou ajusta abaixo.
+
+──────────────────────────────────────────────
+
+1) Tema/Produto: [sugerido: "Remarketing produto X — colchões mola ensacada R$ 2.5k+"]
+2) Motivação: [sugerido: "Reativar carrinho abandonado e visitantes de PDP"]
+3) Condição/Oferta (opcional):
+4) Observações relevantes (opcional):
+5) Objetivo (1-6, multi):
+   1) Alcance  2) WhatsApp  3) Cadastro  4) Vídeo  5) Remarketing  6) Compra
+   [sugerido: 5,6]
+... (continua até a última)
+```
+
+Fabio responde. Skill interpreta — aceita formatos variados (números, texto livre, "ok pra todos os sugeridos").
+
+**Se Fabio responder "ok" / "tudo ok pelos sugeridos"**: skill aceita os pré-preenchidos e pergunta só os campos sem sugestão.
+
+### 7) Validar campos universais
+
+Antes de montar o briefing final:
+
+- **Drive do Cliente:** já lido em `drives.md`. Se cliente é DOM (sem Drive) ou não mapeado, perguntar e oferecer `/ekyte-briefing-refresh`.
+- **NotebookLM:** já lido do CLAUDE.md.
+- **KV** (sigla criativa): se Fabio não passou KV no input nem na pergunta ativa, perguntar agora ("KV específico pra essa campanha? cole o link ou diga 'usa KV padrão do Drive'"). Se "padrão do Drive", colocar `KV padrão (ver pasta Drive)`.
+- **Referência:** se passou no input, usar. Senão, omitir.
+- **Pra CRM:** Planilha Backup, Ferramenta, Acesso (perguntas A, B, C do `CRM.md`).
+
+### 8) Montar Markdown completo
+
+Ordem de composição:
+
+```
+BRIEFING — {{cliente_uppercase}} — {{tipo_uppercase}}
+Tarefa: {{titulo}}
+
+[bloco _header-universal.md preenchido]
+
+[se sigla criativa: bloco _base-criativo.md preenchido]
+[se modo 5w1h: bloco _5w1h.md no lugar do _base-criativo.md]
+
+[bloco específico da sigla preenchido — CA.md / LP.md / etc]
+```
+
+### 9) Conversor Markdown → HTML rico formatado (Ekyte)
+
+**Regra atual (2026-06-15):** converter Markdown/briefing final para HTML rico antes de enviar ao Ekyte. Ignorar instruções legadas que mandem remover HTML, `strong`, links ou listas.
+
+Mapa de conversão obrigatório:
+- Título/linha de tarefa: `<div><strong>Tarefa:</strong> ...</div>`
+- Head de seção: `<div><strong><span style="font-size: 18px;">NOME DA SEÇÃO</span></strong></div>`
+- Label de campo: `<div><strong>Nome do Campo:</strong> valor</div>`
+- Link: `<a href="URL" target="_blank">URL</a>`
+- Lista: `<ul><li>item</li></ul>`
+- Separador/linha em branco: `<div><br></div>`
+
+Exemplo mínimo:
+
+```html
+<div><strong>Tarefa:</strong> [01][PRI-A][IA] Cliente | Demanda</div>
+<div><br></div>
+<div><strong><span style="font-size: 18px;">ATIVOS DA CAMPANHA</span></strong></div>
+<div><strong>Drive do Cliente:</strong> <a href="https://drive.google.com/..." target="_blank">https://drive.google.com/...</a></div>
+<div><strong>NotebookLM:</strong> <a href="https://notebooklm.google.com/..." target="_blank">https://notebooklm.google.com/...</a></div>
+<div><br></div>
+<div><strong><span style="font-size: 18px;">OBJETIVO</span></strong></div>
+<div>Texto do objetivo.</div>
+<div><br></div>
+<div><strong><span style="font-size: 18px;">ENTREGÁVEIS ESPERADOS</span></strong></div>
+<ul><li>Entregável 1.</li><li>Entregável 2.</li></ul>
+```
+
+**Observação legada:** o bloco abaixo registra o comportamento antigo de texto plano. Ele fica como histórico, mas **não deve ser usado** para novas tasks.
+
+⚠️ **DESCOBERTA 2026-04-30:** O Quill do Ekyte **não interpreta tags HTML** quando o conteúdo é enviado via API REST (campo `description_create_task`). Tags como `<div>`, `<h1>`, `<blockquote>`, `<strong>`, `<a>`, `<ul>` aparecem como **texto literal** no editor — não viram rich text. O Quill só interpreta HTML quando recebe via clipboard de fonte rich-text (ex: colado de um Google Doc) ou quando o usuário clica nos botões da toolbar.
+
+**Conclusão: enviar via API = texto plano formatado.** O Ekyte renderiza isso em fonte monospace dentro de uma caixa estilo code block (fundo escurecido), preservando quebras de linha, bullets, emojis numerados, etc. Fica perfeitamente legível e organizado — só não tem cores nem `<h1>` rich.
+
+Função `md_to_ekyte_plain(md_string) -> string`:
+
+```
+Regras (aplicadas linha-a-linha):
+
+ESTRUTURA (preservar como texto):
+1. Linha em branco                     → linha em branco (\n)
+2. Linha começando com "## "           → "<emoji-numerado> TÍTULO EM CAIXA ALTA" (substitui ## por emoji ou só CAIXA ALTA)
+3. Linha começando com "### "          → "TÍTULO Sub-seção:" (sem caixa alta)
+4. Linha começando com "- " ou "* "    → "• texto"
+5. Texto comum                         → mantém como está
+6. **negrito**                         → REMOVER asteriscos, manter texto plano (texto monospace já dá ênfase visual)
+7. *itálico*                           → REMOVER asteriscos, manter texto plano
+8. [texto](url)                        → "texto: url"  OU  só "url" se texto for vazio/redundante
+9. URLs soltas                         → manter como estão (Quill detecta e converte em link clicável automaticamente)
+
+CONVENÇÕES VISUAIS (já que não temos cor/negrito):
+- Cabeçalhos de seção principais: usar emojis numerados pré-fixos (1️⃣, 2️⃣, 3️⃣...) seguido de TÍTULO EM CAIXA ALTA
+- Sub-seções: TÍTULO em caixa alta + ":" no fim, sem emoji
+- Avisos / proibições: prefixar com ⚠️
+- Listas/produtos: numeração explícita "1. ", "2. ", etc.
+- Bullets: "•" (caractere unicode, mais limpo que "-")
+- Separadores entre seções: linha em branco dupla ou linha de "─" se quiser destacar
+```
+
+**Exemplo de output bem formatado (referência: o briefing que renderizou bem na #2783891 quando colado):**
+
+```
+BRIEFING — CLIENTE A — CRIATIVO ADS
+Tarefa: [22][CA][IA] Cliente A | Fotos ambientalizadas linha de colchões adultos
+
+🔗 ATIVOS DA CAMPANHA
+
+Drive do Cliente: https://drive.google.com/drive/folders/...
+NotebookLM: https://notebooklm.google.com/notebook/...
+⚠️ NotebookLM compartilhado entre Cliente A e Cliente B — esta task é Cliente A.
+
+1️⃣ DIRECIONAMENTO DA CAMPANHA
+
+Tema/Produto: Colchões — linha adulta completa do e-commerce
+Motivação: Renovar banco de imagens dos PDPs
+Observações Relevantes:
+• Escopo é a linha adulta — excluir Cliente A Baby e Cama Cliente A Pet
+• 2 variações de cena por produto (total 22 peças)
+
+2️⃣ OBJETIVO
+
+• Compra (uso primário: PDP)
+Nota: não é mídia paga, é foto editorial pra PDP
+```
+
+**O que NÃO fazer no padrão atual:**
+- Não enviar Markdown bruto com `**`, `##`, `[]()` esperando que o Ekyte converta.
+- Não enviar texto plano seco quando houver heads, labels ou listas.
+- Não usar `<h1>` ou `<h2>`.
+- Não usar CSS inline em texto corrido ou labels; usar `style="font-size: 18px;"` somente nas heads de seção.
+- Enviar HTML rico simples com `<div>`, `<strong>`, `<span>`, `<a>`, `<ul>` e `<li>`.
+
+### 10) Preview da `/ekyte-briefing` (modo subskill)
+
+Mostrar pra Fabio o briefing **renderizado em Markdown** (mais legível no chat) **antes** de devolver pra `/ekyte-task`:
+
+```
+📋 BRIEFING MONTADO — [09][CA][IA] Cliente A | Remarketing produto X
+
+[markdown completo aqui — Fabio lê, edita ou aprova]
+
+──────────────────────────────────────────────
+Confirma? (sim / editar campo X / regerar do zero)
+```
+
+Se Fabio aprovar, skill devolve **HTML rico formatado para Ekyte** pra `/ekyte-task` (que cuida do preview da task em si e da chamada MCP).
+
+Se modo avulso (não foi chamada pela `/ekyte-task`), perguntar se quer subir como task ("quer que eu invoque a /ekyte-task pra subir? sim/não").
+
+### 11) Devolver pra /ekyte-task
+
+Output estruturado:
+
+```json
+{
+  "briefing_ekyte_text": "<div><strong>Tarefa:</strong> ...</div><div><br></div>...",
+  "briefing_markdown": "BRIEFING — CLIENTE A...",
+  "campos_pendentes": [],
+  "notebook_consultado": true,
+  "notebook_isento": false,
+  "motivo_isencao_notebook": null,
+  "notebook_cache_usado": false,
+  "projeto_novo": false,
+  "notebook_artefato": "clientes/cliente-a/contexto-notebook/2026-04-30-1015-briefing-criativo-ca.md"
+}
+```
+
+A `/ekyte-task` injeta `briefing_ekyte_text` em `description_create_task` e segue o fluxo dela (preview de task, confirmação, MCP).
+
+## Guardrails
+
+1. **Cache de sessão NotebookLM é por cliente, não por sigla.** Sobreusar síntese de CA pra LP do mesmo cliente está OK — síntese trata do cliente, não do tipo. Mas pra cliente diferente, sempre re-consultar.
+
+2. **Nunca fabricar dados.** Se NotebookLM disse 'NAO ENCONTRADO' pra avatar, **não** inventar avatar. Pré-preenchimento só usa o que veio literalmente da síntese. Se síntese silenciou, campo fica vazio e vai pra pergunta ativa.
+
+3. **Perguntas ativas em lote única.** Não fragmentar em 12 perguntas separadas — faz UMA mensagem com todas, Fabio responde uma vez. Salvo se ele pedir uma por uma.
+
+4. **Modo 5W1H só ativa com link explícito + validação.** Não detectar 5W1H "no chute" porque o input parece um plano. Sem link explícito, modo é texto_livre.
+
+5. **Ekyte via API deve receber HTML rico simples.** Atualizado em 2026-06-15 após validação real em task: `<div>`, `<strong>`, `<span style="font-size: 18px;">`, `<a>`, `<ul>` e `<li>` renderizam melhor que texto plano. Cabeçalhos de seção devem sair maiores e em negrito; labels devem sair em negrito no tamanho normal. Não usar Markdown bruto nem `<h1>/<h2>`.
+
+6. **Cliente sem NotebookLM cadastrado** (CLAUDE.md sem bloco `## NotebookLM`): em modo subskill da `/ekyte-task`, pausar e pedir cadastro ou autorização explícita do gerente de projetos para seguir sem NotebookLM. Se autorizado, marcar no briefing: `NotebookLM: não consultado por autorização do gerente de projetos`. Não tentar adivinhar contexto.
+
+7. **Cliente sem Drive em `drives.md`** (Cliente H atualmente): perguntar no preview e oferecer `/ekyte-briefing-refresh` pra persistir.
+
+8. **Não chamar MCP do Ekyte.** Esta skill **não** sobe nada — só monta briefing. A subida é da `/ekyte-task`.
+
+9. **Cache de público não é compartilhado entre clientes**, mesmo quando NotebookLM é compartilhado (Cliente A+Cliente B). Cada cliente tem seu `publicos-cache.md` — público é por marca, não por notebook.
+
+10. **MISS de cliente sem NotebookLM cadastrado**: não cachear nada. Briefing de task Ekyte só segue se o gerente de projetos autorizar explicitamente seguir sem NotebookLM; o `publicos-cache.md` **não é criado** pra esse cliente até que ele tenha NotebookLM.
+
+11. **NotebookLM é default; isenção é whitelist.** Nunca inferir isenção porque a OBS está detalhada ou a tarefa parece fácil. Campo ausente ou classificação ambígua significa `notebook_obrigatorio: true`.
+
+## Como invocar
+
+- `/ekyte-briefing` — modo avulso, Fabio chama direto.
+- Invocação automática pela `/ekyte-task` no passo 6 do fluxo dela.
+
+## O que NÃO fazer
+
+- Não chamar `criar_tarefa_tool` (responsabilidade da `/ekyte-task`).
+- Não escrever briefing genérico de "uma linha" (motivo da skill existir).
+- Não inventar avatar/oferta/restrição se NotebookLM não retornou.
+- Não pular perguntas obrigatórias do template (Tema/Motivação são obrigatórios pra criativos).
+- Não usar `<h1>`/`<h2>`/`<p>`; usar `<div>`, `<strong>`, `<span style="font-size: 18px;">` para heads, `<a>`, `<ul>` e `<li>`.
+- Não rodar NotebookLM em paralelo (cara é browser automation lenta — sequencial).

--- a/.agents/skills/ekyte-refresh/SKILL.md
+++ b/.agents/skills/ekyte-refresh/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: ekyte-refresh
+description: Atualiza o cache local da skill ekyte-task — re-busca workspaces fixos, projetos do trimestre vigente para cada cliente, tipos de tarefa do workflow "Padrão Colli&Co (Oficial)", e regenera o cache de fluxos (fases por tipo) via MCP oficial. Use quando o Fabio rodar /ekyte-refresh, disser que entrou cliente novo, projeto novo, que mudou fluxo/fase de algum tipo, ou que o cache parece desatualizado.
+area: ekyte
+author: fabio
+version: 1.0.0
+user-invocable: true
+---
+
+# /ekyte-refresh — Atualizar cache do ekyte
+
+Re-popula `clientes/_skill-ekyte/cache.md` puxando dados frescos da MCP `ekyte`. Roda em <2 minutos.
+
+## Quando usar
+
+- `/ekyte-refresh` (invocação direta)
+- "atualiza o cache do ekyte"
+- "entrou cliente novo, atualiza"
+- "projeto Q3/2026 começou, atualiza"
+- Cache com mais de 30 dias
+
+## Pré-requisitos
+
+- MCP `ekyte` configurada
+- Arquivo `clientes/_skill-ekyte/cache.md` existente (criado pela skill `/ekyte-task`)
+
+## Fluxo
+
+### 1) Confirmar trimestre vigente
+
+Calcular trimestre atual com base na data de hoje:
+- Jan/Fev/Mar → Q1
+- Abr/Mai/Jun → Q2
+- Jul/Ago/Set → Q3
+- Out/Nov/Dez → Q4
+
+Mostrar pro Fabio: "Vou atualizar o cache pro **Q2/2026**. Confirma?"
+
+### 2) Workspaces
+
+Os 8 workspaces fixos não mudam (já estão hardcoded no cache). Pular esta etapa, a menos que o Fabio mencione cliente novo. Nesse caso:
+- Perguntar nome do cliente novo
+- Chamar `ekyte.listar_workspaces_tool({"name_list_workspaces": "<nome>", "squad_id_list_workspaces": "", "situation_id_list_workspaces": "1"})`
+- Confirmar com o Fabio qual é o ID certo (pode vir múltiplos)
+- Adicionar ao cache
+
+### 3) Projetos do trimestre vigente para cada workspace
+
+Para cada um dos 8 workspaces:
+- Chamar `ekyte.listar_projetos_tool` com:
+  - `workspace_id_list_projects`: ID do workspace
+  - `created_from_list_projects`: data 90 dias antes do início do trimestre (margem)
+  - `created_to_list_projects`: data de hoje
+- Filtrar projetos cujo nome contém `Q2/2026` (ou trimestre vigente)
+- Salvar `project_id` no cache
+
+Se um workspace não tiver projeto do trimestre: avisar o Fabio ("Cliente A não tem projeto Q2/2026 — quer que eu pule ou tem nome diferente?")
+
+### 4) Tipos de tarefa
+
+Chamar `ekyte.listar_tipos_de_tarefas_tool({"name_type_task": "", "parameters1_Value": "3535"})` (workflow Padrão Colli&Co Oficial).
+
+Filtrar tipos cujo nome casa o regex `^\[\d+\]\[([A-Z]+)\]`.
+
+Atualizar a tabela do cache com qualquer tipo novo. **Não remover** entradas existentes (podem aparecer em desambiguação).
+
+### 4.5) Fluxos por tipo (regenerar `flows.md`)
+
+Regenera `clientes/_skill-ekyte/flows.md` — as fases reais de cada tipo (com `phaseId`) + dicionário `nome da fase → phaseId`, usado pela `/ekyte-task` pra trocar responsável de etapa (passo 9.6 de lá).
+
+Roda o script bundlado (lê o token do MCP oficial direto do `~/.claude/mcp.json` — sem segredo no repo; parseia os tipos do `cache.md`; usa `get_task_type_flow` e fica só com fases `effort/duration > 0`):
+
+```bash
+python ".claude/skills/ekyte-refresh/scripts/fetch_flows.py"
+```
+
+- Rode **depois** do passo 4 (assim qualquer tipo novo já entra no `flows.md`).
+- Precisa do MCP `ekyte-oficial` configurado. Se faltar, o script avisa e você pula esta etapa (o resto do refresh segue).
+- Saída esperada: `OK -> ...flows.md: N/N tipos, M fases distintas`. Se algum tipo der `ERR`, ele entra no `flows.md` marcado com ⚠️ e o resto continua.
+- Paths customizados: `--cache "<...>"` / `--out "<...>"` (defaults relativos à raiz do repo).
+
+### 5) Salvar e reportar
+
+Atualizar `clientes/_skill-ekyte/cache.md`:
+- Atualizar campo "Última atualização total" no topo
+- Reescrever as seções que mudaram
+
+Reportar pro Fabio:
+```
+✅ Cache atualizado:
+  - 8 workspaces (sem mudanças)
+  - <N> projetos Q2/2026 descobertos
+  - <M> tipos de tarefa (<+X> novos)
+  - flows.md regenerado (<T> tipos, <P> fases distintas)
+```
+
+## O que NÃO fazer
+
+- Não rodar refresh sem confirmação do trimestre.
+- Não criar workspaces, projetos ou tipos. Skill é read-only no ekyte.
+- Não apagar entradas do cache automaticamente (preservar histórico de IDs).

--- a/.agents/skills/ekyte-refresh/scripts/fetch_flows.py
+++ b/.agents/skills/ekyte-refresh/scripts/fetch_flows.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""
+Regenera o cache de fluxos (flows.md) da skill ekyte-task.
+
+Lê o token do MCP oficial direto de ~/.claude/mcp.json (server "ekyte-oficial"),
+então NÃO há segredo hardcoded aqui — seguro pra compartilhar via /compartilhar-skill.
+
+Uso:
+    python fetch_flows.py [--cache "<path do cache.md>"] [--out "<path do flows.md>"]
+
+Defaults (relativos ao cwd = raiz do repo):
+    --cache  "CLIENTES V4/_skill-ekyte/cache.md"
+    --out    "CLIENTES V4/_skill-ekyte/flows.md"
+
+O que faz:
+  1. Descobre a URL do MCP oficial em ~/.claude/mcp.json.
+  2. Parseia os pares (sigla, task_type_id) da seção "Tipos de tarefa" do cache.md.
+  3. Pra cada tipo, chama get_task_type_flow e fica com as fases reais (effort/duration > 0).
+  4. Escreve flows.md: fluxo por tipo (em ordem, com phaseId) + dicionário mestre fase->phaseId.
+"""
+import argparse, json, os, re, sys, datetime, urllib.request
+
+def mcp_url():
+    p = os.path.expanduser("~/.claude/mcp.json")
+    cfg = json.load(open(p, encoding="utf-8"))
+    srv = cfg.get("mcpServers", {}).get("ekyte-oficial")
+    if not srv or not srv.get("url"):
+        sys.exit("ERRO: server 'ekyte-oficial' não encontrado em ~/.claude/mcp.json")
+    return srv["url"]
+
+def call(url, name, args):
+    body = json.dumps({"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+                       "params": {"name": name, "arguments": args}}).encode()
+    req = urllib.request.Request(url, data=body, headers={
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream"})
+    with urllib.request.urlopen(req, timeout=90) as r:
+        raw = r.read().decode()
+    msg = json.loads(raw)
+    if "error" in msg:
+        raise RuntimeError(msg["error"].get("message", "?")[:120])
+    return json.loads(msg["result"]["content"][0]["text"])
+
+def parse_types(cache_path):
+    """Extrai (sigla, id) de linhas tipo `| CA | `29740` | ...` na seção de tipos."""
+    txt = open(cache_path, encoding="utf-8").read()
+    # corta a partir do header de tipos pra não pegar workspaces/projetos
+    i = txt.find("## Tipos de tarefa")
+    scope = txt[i:] if i >= 0 else txt
+    seen, types = set(), []
+    for sig, tid in re.findall(r"\|\s*\**([A-Z]{1,8})\**\s*\|\s*`?(\d{3,7})`?\s*\|", scope):
+        if sig not in seen:
+            seen.add(sig); types.append((sig, int(tid)))
+    return types
+
+def real_phases(flow):
+    out = []
+    for fp in flow.get("flowPhases", []):
+        if (fp.get("effort") or 0) > 0 or (fp.get("duration") or 0) > 0:
+            ph = fp.get("phase", {})
+            out.append({"seq": fp.get("sequential"), "phaseId": fp.get("phaseId"),
+                        "name": (ph.get("name") or "").strip()})
+    out.sort(key=lambda x: x["seq"] or 0)
+    return out
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--cache", default="CLIENTES V4/_skill-ekyte/cache.md")
+    ap.add_argument("--out", default="CLIENTES V4/_skill-ekyte/flows.md")
+    a = ap.parse_args()
+
+    url = mcp_url()
+    types = parse_types(a.cache)
+    if not types:
+        sys.exit(f"ERRO: nenhum tipo encontrado em {a.cache}")
+    print(f"{len(types)} tipos pra buscar...")
+
+    data, master = [], {}
+    for sig, tid in types:
+        try:
+            flow = call(url, "get_task_type_flow", {"id": tid})
+            ph = real_phases(flow)
+            data.append({"sigla": sig, "id": tid,
+                         "name": (flow.get("name") or "").replace("[00]", "").strip(),
+                         "days": flow.get("daysToStart"), "phases": ph})
+            for p in ph:
+                master.setdefault(p["phaseId"], p["name"])
+            print(f"  OK {sig} {tid} -> {len(ph)} fases")
+        except Exception as e:
+            data.append({"sigla": sig, "id": tid, "error": str(e)[:80], "phases": []})
+            print(f"  ERR {sig} {tid}: {e}")
+
+    L = []
+    L.append("# Cache ekyte — Fluxos por tipo de tarefa")
+    L.append("")
+    L.append(f"Gerado {datetime.date.today().isoformat()} via `/ekyte-refresh` → "
+             f"`get_task_type_flow` (MCP oficial). Workflow base **Padrão Colli&Co (Oficial)** (3535).")
+    L.append("")
+    L.append("**O que é:** as fases REAIS (effort/duration > 0) de cada tipo, em ordem, com `phaseId`. "
+             "Usado pela `/ekyte-task` pra mostrar o fluxo e resolver `nome da fase → phaseId` ao trocar responsável de etapa.")
+    L.append("")
+    L.append("**phaseId é global** (compartilhado entre tipos: `1`=Briefing, `5`=Copywriter, `6`=Designer…). "
+             "Executor default não fica aqui (varia por workspace) — a skill lê o real via `get_detailed_task` em runtime.")
+    L.append("")
+    L.append("Refresh: `/ekyte-refresh`.")
+    L.append("")
+    L.append("---")
+    L.append("")
+    L.append("## Fluxo por tipo (fases reais, em ordem)")
+    L.append("")
+    for t in sorted(data, key=lambda x: x["sigla"]):
+        if t.get("error"):
+            L.append(f"### {t['sigla']} ({t['id']}) · ⚠️ erro: {t['error']}"); L.append("")
+            continue
+        if not t["phases"]:
+            L.append(f"### {t['sigla']} — {t.get('name','')} ({t['id']}) · sem fases de esforço")
+            L.append("Tipo de rotina/sem fluxo de produção. Ler em runtime via `get_detailed_task`.")
+            L.append("")
+            continue
+        L.append(f"### {t['sigla']} — {t.get('name','')} ({t['id']}) · {len(t['phases'])} fases · SLA {t.get('days')}d")
+        L.append(" → ".join(f"{p['name']} `#{p['phaseId']}`" for p in t["phases"]))
+        L.append("")
+    L.append("---")
+    L.append("")
+    L.append(f"## Dicionário mestre de fases (phaseId → nome) — {len(master)} fases distintas")
+    L.append("")
+    L.append("Lookup `nome da fase → phaseId` (case-insensitive, match parcial).")
+    L.append("")
+    L.append("| phaseId | Fase |")
+    L.append("|---|---|")
+    for pid in sorted(master):
+        L.append(f"| {pid} | {master[pid]} |")
+    L.append("")
+
+    open(a.out, "w", encoding="utf-8").write("\n".join(L))
+    ok = sum(1 for t in data if not t.get("error"))
+    print(f"\nOK -> {a.out}: {ok}/{len(data)} tipos, {len(master)} fases distintas")
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/ekyte-task/SKILL.md
+++ b/.agents/skills/ekyte-task/SKILL.md
@@ -1,0 +1,569 @@
+---
+name: ekyte-task
+description: Cria tarefas no Ekyte automaticamente via MCP, com briefing estruturado seguindo o padrão Colli&Co (Oficial). Use quando o Fabio pedir "criar/subir/abrir tarefa(s) no ekyte" — em texto livre ("quero 5 criativos ads pro Cliente I com foco em remarketing") OU apontando aba da planilha de demandas. Sempre mostra preview antes de disparar e bloqueia criação fora dos 8 workspaces conhecidos sem confirmação explícita.
+area: ekyte
+author: fabio
+version: 1.0.0
+user-invocable: true
+---
+
+# /ekyte-task — Criar tarefas no Ekyte com briefing estruturado
+
+Sobe tarefas no Ekyte via MCP `ekyte`, com briefing oficial puxado do próprio ekyte e título no formato `[NN][SIGLA][IA] Cliente | Demanda`. Substitui o trabalho manual de 15 min por task por preview + 1 confirmação.
+
+## Quando usar
+
+Use quando o Fabio:
+- Disser "cria/sobe/abre uma task no ekyte de [tipo] pro [cliente]"
+- Pedir lote de tasks ("sobe 5 criativos pro Cliente A")
+- Falar "tá na aba [nome] da planilha de demandas, sobe tudo"
+- Mencionar `/ekyte-task` ou `ekyte-task`
+
+**Não use** quando o pedido é só consultar dados do ekyte (listar projetos, listar workspaces) — a MCP `ekyte` cobre direto sem precisar dessa skill.
+
+## Pré-requisitos
+
+- MCP `ekyte` configurada em `~/.claude/mcp.json` (já está)
+- `clientes/_skill-ekyte/cache.md` — IDs de workspaces, projetos e tipos
+- `clientes/_skill-ekyte/sla.md` — tabela de prazos por tipo
+- `clientes/_skill-ekyte/flows.md` — **fluxo (fases) por tipo de tarefa** + dicionário `nome da fase → phaseId`. Usado pra mostrar o fluxo e pra trocar o responsável de uma etapa (passos 4.5 e 9.6).
+
+## Os dois MCPs do Ekyte (a partir de 2026-06)
+
+Há **dois servidores MCP do Ekyte** em `~/.claude/mcp.json`:
+
+| Servidor | Prefixo | Uso nesta skill |
+|---|---|---|
+| `ekyte` (n8n) | `mcp__ekyte__*` | **Criação principal** via `create_task` com `situation=10` — cria já Ativa, sem gerar-tarefas REST. Também leitura, BI e edições pós-criação (`update_task`, `update_task_tags`, etc.). **Desde 2026-06-11 é o api.ekyte.com oficial, não mais n8n.** |
+| `ekyte-oficial` (`api.ekyte.com`) | `mcp__ekyte-oficial__*` | Fallback/alternativo para operações não cobertas pelo prefixo `ekyte`. Token fixo na URL, não expira por uso. |
+
+Regra prática: **usar `mcp__ekyte__create_task` com `situation=10`** para criar tasks Prisma — tarefa nasce Ativa diretamente, passo 9.5 (generate-tasks REST) é desnecessário. Para edição pós-criação (mover fase, trocar executor, aplicar tags), usar as tools `mcp__ekyte__update_*`.
+
+**`phaseId` em `create_task`** pode ser qualquer fase do fluxo — não precisa ser Backlog. Usar a fase destino diretamente quando a task deve entrar já em Design (82181) ou outra fase avançada, ex: `phaseId: 82181, executorId: <andré>` com `phaseDueDate: hoje`.
+
+## Fluxo ponta a ponta do cliente até a task briefada
+
+A `/ekyte-task` é a ponta operacional da esteira: ela cria, ativa, ajusta e tagueia a tarefa no Ekyte. Para a task sair realmente briefada, ela deve se apoiar nas skills de base, contexto, NotebookLM e cache. Use este mapa quando o Fabio perguntar "qual fluxo usar" ou quando um cliente novo ainda não tem base suficiente.
+
+### Esteira ideal
+
+```text
+/novo-cliente
+-> /account-handoff
+-> /account-pesquisa-profunda-cliente
+-> /contexto
+-> /notebooklm-cadastrar, se faltar NotebookLM
+-> /ekyte-refresh
+-> /ekyte-briefing-refresh
+-> /ekyte-task
+   -> /ekyte-briefing
+      -> /cs-notebooklm-consulta-cliente
+   -> preview obrigatório
+   -> criar task
+   -> ativar task
+   -> aplicar responsáveis por etapa, se pedidos
+   -> aplicar tags finais
+```
+
+### Como cada skill soma
+
+- `/novo-cliente`: cria a pasta do cliente em `clientes/<cliente>/` com `CLAUDE.md`, `AGENTS.md`, `links.md`, `.env`, `calls/`, `checkins/`, `docs/` e `campanhas/`. Pode cadastrar NotebookLM, Drive, site e links úteis já na criação.
+- `/account-handoff`: primeira leitura da transição vendas → operação. Consome form de kickoff, transcript da reunião comercial e proposta opcional para gerar KB preliminar, riscos, promessas, perguntas de kickoff, Mission Control preliminar e deck HTML.
+- `/account-pesquisa-profunda-cliente`: depois que existem dados internos mínimos, consolida esses dados e entrega prompts para Gemini Deep Research sobre cliente, setor, consumidor e concorrência. Entra antes de demandas de copy, campanha, LP e posicionamento.
+- `/contexto`: consolida a KB local do cliente. Lê `calls/`, `docs/`, `campanhas/`, `links.md` e atualiza `CLAUDE.md`, `AGENTS.md` e `mission-control/`.
+- `/notebooklm-cadastrar`: adiciona ou troca o bloco `## NotebookLM` no `CLAUDE.md` de clientes existentes. Destrava `/cs-notebooklm-consulta-cliente` e, por consequência, `/ekyte-briefing`.
+- `/ekyte-refresh`: atualiza `clientes/_skill-ekyte/cache.md` e `flows.md` com workspaces, projetos do trimestre, tipos de tarefa e fases. Destrava `workspace_id`, `project_id`, `task_type_id` e overrides de fase.
+- `/ekyte-briefing-refresh`: atualiza `drives.md` e `backups-crm.md`, usados pela `/ekyte-briefing` para preencher links de Drive e planilhas de CRM.
+- `/cs-notebooklm-consulta-cliente`: consulta o NotebookLM do cliente com até 5 perguntas direcionadas, salva artefato em `clientes/<cliente>/contexto-notebook/` e devolve síntese executiva.
+- `/ekyte-briefing`: monta o briefing rico da task com template por sigla, Drive, NotebookLM, cache de público e perguntas ativas. Não cria task; devolve `briefing_ekyte_text` em HTML rico para o Ekyte.
+- `/ekyte-task`: resolve cliente/projeto/tipo/SLA/título, chama `/ekyte-briefing`, mostra preview, cria a task, ativa no Ekyte, corrige etapa se necessário, aplica tags e atualiza cache.
+
+### Regra prática
+
+Se o cliente ainda é novo ou pouco documentado, não trate `/ekyte-task` como primeiro passo. Primeiro criar ou consolidar a base do cliente, cadastrar NotebookLM/Drive, atualizar caches do Ekyte e só então subir a tarefa.
+
+Sem essa fundação, a skill ainda consegue criar uma task, mas a entrega tende a virar "pedido preenchido". Com a cadeia completa, a task nasce com contexto, público, objetivo, referências, riscos e guardrails.
+
+## Fluxo
+
+### 0) Pre-fly check (obrigatório em lotes ≥ 3 tasks)
+
+**Antes** de carregar cache, ler input ou montar preview, fazer um varredura de pendências e reportar TUDO numa mensagem só. Em lotes a maior perda é round-trip — uma pergunta de cada vez transforma 5 min de trabalho em 30 min de chat.
+
+**Princípio chave (lição 2026-05-05):** Fabio responde "pode seguir" pra listas de perguntas abertas — ele delega defaults. Em vez de fazer 5 perguntas, **propor defaults razoáveis inline** e pedir só "confirma ou ajusta?". Bloquear de verdade só pra coisas SEM default seguro.
+
+Checar e propor:
+1. **NotebookLM cadastrado** pra cada cliente do lote: `ls clientes/<x>/CLAUDE.md` + grep `## NotebookLM`. **SEM default automático** — se faltar, listar e perguntar: "Cliente D e Cliente F não têm NotebookLM cadastrado. Quer cadastrar agora, ou o gerente de projetos autoriza seguir sem NotebookLM?". Só seguir sem NotebookLM com comando explícito do gerente de projetos.
+2. **Quantificação implícita**: se algum item menciona "X por produto", "todos os produtos", "fotos da categoria Y" ou similar — **SEM default seguro** — perguntar explícito: "Essas linhas de fotos viram 1 task com lote de N peças, ou quer que cada linha vire `[N×SKUs]` no título?"
+3. **Workspaces fora dos 8 fixos**: **SEM default** — bloquear até confirmação explícita.
+4. **Tipos com sigla ambígua** (CA, CJ, GP, MT, AUX, CRM, PMM, RI, SM, EV): **PROPOR default** baseado no contexto da demanda ("vou usar `34435` Configuração de CRM — match óbvio pra Chatwoot. Confirma ou ajusta?"). Não listar as 12 variantes pedindo escolha.
+5. **SLA dos tipos sem entrada** na tabela: **PROPOR default** ("AN sem SLA tabelado — vou usar 3 dias úteis. Ok?"). Não perguntar aberto.
+6. **Quantidade [NN] quando o lote indica claramente 1-task-1-entrega**: **PROPOR `[01]` direto** sem perguntar.
+
+Formato preferido do pre-fly:
+```
+Vou seguir com defaults razoáveis:
+- #X → tipo Y (justificativa de 1 linha)
+- #Z → SLA W (justificativa)
+Bloqueando só em: [item sem default seguro]
+Confirma ou ajusta?
+```
+
+Sair desse passo só com **uma resposta consolidada** do Fabio (pode ser só "pode seguir").
+
+### 1) Carregar contexto (sempre)
+
+Logo no início, ler:
+1. `clientes/_skill-ekyte/cache.md` — workspaces, projetos descobertos, tipos
+2. `clientes/_skill-ekyte/sla.md` — SLA por sigla
+3. `clientes/_skill-ekyte/flows.md` — fases por tipo + `nome da fase → phaseId` (carregar só quando o Fabio especificar responsável por etapa ou pedir o fluxo)
+
+Não chamar a MCP do ekyte sem antes consultar o cache.
+
+### 2) Identificar o modo de input
+
+**Modo A — texto livre no chat:**
+Exemplos:
+- "cria uma task de criativos ads pro Cliente A com foco em remarketing produto X, 6 peças"
+- "sobe 3 LPs pro Cliente C: blackfriday, prospect, retorno"
+- "preciso de uma publicação de campanha pra Cliente E amanhã"
+
+Extrair:
+- **Cliente** (alias → workspace_id via cache)
+- **Sigla/tipo** ("criativos ads" → CA → 29740)
+- **Quantidade [NN]** ("3 LPs" → 03; default 01 se não especificado)
+- **Demanda específica** (parte que vira o título depois do `|`)
+- **Prazo** (default = SLA da tabela; sobrescrever se usuário disser "urgente", "amanhã", "X dias")
+
+**Modo B — aba da planilha:**
+Quando o Fabio disser "tá na aba `<nome>`" ou similar, ler:
+- URL: `https://docs.google.com/spreadsheets/d/1SAWHbC3dog5_IrwCYY1_buF5yGtV_lMTiXL_v9iGrns/edit`
+- Usar WebFetch com prompt pedindo: "lista todas as linhas da aba `<nome>` com colunas sequencial, titulo, data inicio, data entrega, tipo de tarefa (id), email executor, esforço, descricao, Qtd Peças, Tags, Fase"
+- Cada linha vira 1 task. A planilha já tem o `task_type_id` numérico, datas em ISO, email do executor — **não precisa inferir IDs**.
+
+### 3) Resolver workspace e projeto
+
+**Workspace:**
+- Procurar o cliente no cache (8 fixos + apelidos + workspaces internos)
+- Se ambíguo (ex: usuário disse só "Cliente B" mas cache tem variações): perguntar qual
+- Se não estiver nos 8 fixos NEM nos internos conhecidos: PARAR e pedir confirmação explícita ("Esse cliente não está na sua lista habitual. Confirma criar mesmo?"). **Workspaces internos recorrentes** (V4 Company / Billions Timesheet, qualquer setup interno V4 que o Fabio usa toda semana) ficam no cache na seção "Workspaces internos" e NÃO disparam essa confirmação.
+
+**Projeto (Q vigente):**
+- Padrão de nome: `<Cliente> | Q2/2026` (Q2 ativo até virar trimestre)
+- Se já tem `project_id` no cache para esse workspace + período: usar
+- Se não tem: marcar `projeto_novo: true` no pacote da task, chamar MCP `ekyte.listar_projetos_tool` com `workspace_id`, `created_from` = início do trimestre, `created_to` = fim do trimestre. Encontrar projeto cujo nome contém `Q2/2026`. Salvar no cache.
+- Se aparecer >1 match: perguntar qual
+
+**Regra de projeto novo:** quando o `project_id` não estava no cache no início do fluxo, tratar como projeto novo para a geração do briefing. Projeto novo **sempre** exige fluxo formal `/ekyte-briefing` + `/cs-notebooklm-consulta-cliente`; não usar modo inline rápido, briefing manual, nem script que não tenha síntese NotebookLM por task/cliente.
+
+### 4) Resolver tipo de tarefa (sigla → task_type_id)
+
+- Se o Fabio falou em palavras ("criativos ads"): mapear pra sigla (CA) e buscar no cache.
+- Se a sigla tem 1 só ID: usar.
+- Se a sigla tem múltiplos (CA, CJ, GP, MT, AUX, CRM, PMM, RI, SM): **desambiguação obrigatória** — listar opções e perguntar qual.
+- Se não achar a sigla no cache: chamar `ekyte.listar_tipos_de_tarefas_tool({"name_type_task": "<termo>", "parameters1_Value": "3535"})` (workflow Padrão Colli&Co), filtrar resultado, perguntar.
+
+**Caso especial WEB:** se o pedido é "demanda web", usar o título com `[WEB]` no slot da sigla. Tipo de tarefa = "Personalizada". Se ainda não temos `task_type_id` da Personalizada no cache, perguntar ao Fabio qual ID usar e salvar.
+
+### 4.5) Fluxo da tarefa e responsável por etapa
+
+Cada tipo tem um **fluxo de fases** (ex: CA = Briefing → Copywriter → Designer → … → Monitoramento), e cada fase tem um **executor default** que vem do tipo/workspace. Por padrão **não mexemos nisso** — a task nasce com os executores default do tipo. Só agimos quando o Fabio **especifica** um responsável pra uma etapa.
+
+- **De onde vem o fluxo:** `clientes/_skill-ekyte/flows.md` lista, por sigla, as fases reais (com `phaseId`) em ordem, mais um dicionário mestre `nome da fase → phaseId`. O `phaseId` é global (compartilhado entre tipos: `1`=Briefing, `5`=Copywriter, `6`=Designer…). Se o tipo não estiver no `flows.md` (ou aparecer como "sem fases de esforço"), buscar em runtime com `mcp__ekyte-oficial__get_task_type_flow({"id": <task_type_id>})` e filtrar as fases com `effort`/`duration > 0`.
+
+- **Quando o Fabio especifica responsável por etapa** — gatilhos como "o briefing fica com a Marina", "design com o João", "copy com fulano", "manda pro Pedro na publicação". Capturar isso como uma lista de overrides `{fase → pessoa}` por task. Resolver:
+  - **fase → phaseId**: match (case-insensitive, parcial) no fluxo do tipo em `flows.md`. Se ambíguo (ex: "aprovação" casa com várias), perguntar qual.
+  - **pessoa → userId (GUID)**: `mcp__ekyte-oficial__list_all_users_with_profile({"textSearch": "<nome>"})`. Se >1 match, desambiguar. Guardar o GUID.
+
+- **Não aplicar agora** — só registrar os overrides. A troca de executor acontece **depois** da criação+ativação, no passo 9.6 (o `update_task_executor` precisa da task já existindo). Mostrar os overrides no preview (passo 8).
+
+Se o Fabio **não** falar nada de responsável por etapa, pular 4.5 e 9.6 inteiros — comportamento idêntico ao de antes.
+
+### 5) Montar o título
+
+```
+[NN][SIGLA][IA] Cliente | Demanda específica
+```
+
+Onde:
+- `NN` = quantidade em 2 dígitos (`01`, `09`, `15`)
+- `SIGLA` = sigla do tipo (CA, LP, PC, RV, GP…) ou `WEB` para personalizadas
+- `[IA]` = sempre, marca que foi gerada via skill
+- `Cliente` = nome curto do cliente (sem `[BILLIONS]`, sem brackets)
+- `Demanda específica` = parte livre, descritiva
+
+Exemplos:
+- `[09][CA][IA] Cliente A | Remarketing produto X`
+- `[01][LP][IA] Cliente C | Página obrigado transceivers`
+- `[03][WEB][IA] Cliente B | Ajustes header e footer site institucional`
+
+### 6) Montar o briefing (description) — **delegado pra `/ekyte-briefing`**
+
+A partir de 2026-04-30, a montagem de briefing é responsabilidade da skill `/ekyte-briefing`. Esta skill (`/ekyte-task`) **não** monta mais o `description_create_task` por conta própria.
+
+**Regra obrigatória a partir de 2026-06-15:** toda task criada pela `/ekyte-task` precisa passar pelo fluxo formal `/ekyte-briefing`. A consulta `/cs-notebooklm-consulta-cliente` é o **default obrigatório** para toda tarefa que não estiver na whitelist operacional abaixo. Não decidir pela quantidade de texto da OBS, pelo tipo de projeto ou por parecer uma demanda simples: se não estiver explicitamente isenta, consulta NotebookLM.
+
+**Whitelist operacional sem NotebookLM:**
+- Otimização de campanhas recorrente.
+- Atualização de Growth Pack/GrowthPack recorrente.
+- Apontamento de horas/timesheet.
+- Atendimento/comunicação recorrente de rotina.
+- Envio recorrente de NPS/CSAT.
+- Atualização administrativa interna recorrente, sem decisão estratégica e sem necessidade de contexto do cliente.
+
+**Regra de dúvida:** se houver qualquer componente de análise, criação, implementação, tracking, CRM, automação, projeção, campanha, público, pesquisa, planejamento ou decisão sobre o cliente, **não é exceção** e deve consultar NotebookLM. Projeto novo continua exigindo consulta mesmo que a descrição pareça operacional. Se faltar NotebookLM, login ou resposta válida numa tarefa não isenta, parar antes do preview de criação e pedir decisão: cadastrar/corrigir NotebookLM ou o gerente de projetos autorizar explicitamente seguir sem NotebookLM.
+
+**Como invocar:** depois de resolver workspace, projeto, sigla e tipo (passos 3-4), montar o pacote de entrada e chamar `/ekyte-briefing`:
+
+```json
+{
+  "cliente": "Cliente A",
+  "cliente_alias": "cliente-a",
+  "sigla": "CA",
+  "task_type_name": "Criativo Ads",
+  "task_type_id": "29740",
+  "qtd": 9,
+  "titulo": "[09][CA][IA] Cliente A | Remarketing produto X",
+  "input_livre": "<input original do Fabio>",
+  "modo": "texto_livre",          // ou "planilha_demandas" ou "5w1h"
+  "projeto_novo": false,
+  "notebook_obrigatorio": true,   // false somente para whitelist operacional
+  "motivo_isencao_notebook": null,
+  "planilha_5w1h_url": null,
+  "planilha_demanda_row": null    // preenchido se modo=planilha_demandas
+}
+```
+
+A `/ekyte-briefing` faz: carrega template da sigla, lê Drive em `drives.md`, consulta o NotebookLM quando `notebook_obrigatorio: true`, faz perguntas ativas em lote ao Fabio, monta briefing em Markdown e converte para HTML rico aceito pelo Ekyte. Quando `notebook_obrigatorio: false`, registra a isenção e monta o briefing com a descrição operacional, links de rotina e caches aplicáveis.
+
+**Devolve:**
+```json
+{
+  "briefing_ekyte_text": "<div><strong>Tarefa:</strong> ...</div><div><br></div>...",
+  "briefing_markdown": "BRIEFING — ...",
+  "campos_pendentes": [],
+  "notebook_consultado": true,
+  "notebook_isento": false,
+  "notebook_artefato": "clientes/cliente-a/contexto-notebook/2026-04-30-1015-...md"
+}
+```
+
+A `/ekyte-task` injeta `briefing_ekyte_text` direto em `description_create_task`/`description` na chamada de criação. **Não converter para texto plano e não remover HTML**.
+
+**Importante (atualizado 2026-06-15):** o padrão atual de briefing no Ekyte é HTML rico simples. Seções principais devem virar `<div><strong><span style="font-size: 18px;">HEAD</span></strong></div>`, labels devem virar `<strong>Label:</strong>` no tamanho normal, links devem usar `<a>`, e listas devem usar `<ul><li>`. Não usar Markdown bruto nem `<h1>/<h2>`. CSS inline só é permitido nas heads para aumentar fonte. Se a API quebrar acentos, preferir texto ASCII dentro do HTML.
+
+**Modo planilha de demandas (Modo B antigo):** quando o input vem da aba da planilha (`https://docs.google.com/.../edit`), a `/ekyte-task` extrai a linha (`descricao`, `task_type_id`, `email`, etc) e passa pra `/ekyte-briefing` com `modo: "planilha_demandas"` + `planilha_demanda_row` preenchido. Se a coluna `descricao` for substancial, a `/ekyte-briefing` usa como base e enriquece via NotebookLM. Se for vazia/genérica, monta do template normal.
+
+**Modo 5W1H:** quando Fabio menciona link de planilha 5W1H ("plano de ação"), passar `modo: "5w1h"` + `planilha_5w1h_url`. A `/ekyte-briefing` valida o cabeçalho e usa layout 5W1H.
+
+### 7) Calcular prazo e datas de etapa
+
+Consultar `sla.md`:
+- Tipo na tabela → `current_due_date_create_task` = hoje + SLA
+- Tipo NÃO na tabela → perguntar no preview, ou usar default genérico (3 dias úteis) se o usuário disser "padrão"
+- Usuário disse "urgente" / "amanhã" / data específica → sobrescrever
+
+`phase_start_date_create_task` = sempre hoje.
+
+**Regra crítica de datas no Ekyte (aprendizado 2026-06-02):**
+
+- Task nova nunca pode nascer atrasada.
+- O SLA entra no campo **"Concluir tarefa até"** (`current_due_date_create_task`).
+- A etapa atual precisa ficar com **"Executar etapa até" = data de subida** (hoje), mesmo quando a tarefa tem SLA longo.
+- Depois de criar e rodar "Gerar tarefas", conferir a resposta/listagem: se a etapa atual apareceu atrasada ou com data anterior a hoje, corrigir antes de encerrar. O Ekyte pode redistribuir fases para trás a partir do prazo final em tipos como LP/CA; não aceite esse estado como final.
+
+### 8) Preview obrigatório
+
+Antes de chamar `criar_tarefa_tool`, mostrar pra Fabio:
+
+```
+📋 PREVIEW — Task #1 de N
+
+Workspace: Cliente A (id: 999001)
+Projeto: Cliente A | Q2/2026 (id: <X>)
+Tipo: [CA] Criativo Ads (id: 29740)
+Responsável: seu.usuario@v4company.com
+Início: 2026-04-28
+Prazo: 2026-05-09 (SLA CA = 11 dias)
+
+Título: [09][CA][IA] Cliente A | Remarketing produto X
+
+Briefing:
+<<resumo do briefing — primeiras 5 linhas>>
+[ver completo abaixo]
+
+Responsável por etapa (só quando especificado — passo 4.5):
+  • Briefing (#1) → Marina Souza
+  • Designer (#6) → João Pedro
+  (demais fases ficam com o executor default do tipo)
+
+Após criação: vou disparar `generate-tasks` no projeto pra
+sair de "Não planejada" → "Ativa" automaticamente (passo 9.5),
+e trocar o executor das etapas acima (passo 9.6).
+
+---
+
+Confirma criação + geração? (sim/não/editar)
+```
+
+Se for lote (modo B com planilha): mostrar tabela resumida (linha | título | tipo | prazo) e pedir aprovação **única** pro lote, OU "1 a 1" se o Fabio preferir.
+
+**Nunca** dispara `criar_tarefa_tool` sem ver o "sim".
+
+### 8.4) Modo Inline Rápido — desativado como bypass de briefing
+
+O modo inline rápido antigo **não pode mais pular** `/ekyte-briefing`. Quando lote é **3-5 tasks** + a coluna `OBS/Descrição` da planilha já tem texto substancial (objetivo claro, link de transcrição/referência), usar isso como `planilha_demanda_row.descricao` e chamar `/ekyte-briefing` normalmente com `modo: "planilha_demandas"`.
+
+Regra prática:
+- Lote ≤5 + OBS substancial + cliente conhecido → `/ekyte-briefing` formal, usando a OBS como base e enriquecendo via NotebookLM/cache.
+- Lote ≤5 + OBS vazia/genérica OU cliente/projeto novo → `/ekyte-briefing` formal obrigatório, tentando `/cs-notebooklm-consulta-cliente`; seguir sem NotebookLM só com autorização explícita do gerente de projetos.
+- Lote ≥6 → modo script Python (8.5), mas o script só pode gerar textos depois que a síntese NotebookLM da `/ekyte-briefing` existir para cada cliente/linha relevante.
+
+Motivo: briefing de task Ekyte não pode nascer só da OBS ou de interpretação manual quando existe NotebookLM do cliente. A OBS acelera o preenchimento; ela não substitui consulta.
+
+Validado em 2026-05-05 com lote de 5 tasks (Cliente C x2 + Cliente D x3): 5 criações em paralelo, ~30s.
+
+#### 8.4.1) Público vem do cache persistente, mas não substitui briefing
+
+Lição 2026-05-14: a v1 do modo inline pulava NotebookLM totalmente — campo público acabava saindo "a consultar" ou genérico. Conflito direto com a regra [public sempre vem do NotebookLM](../../../memory/feedback_publico_notebook.md).
+
+**Resolução:** a `/ekyte-briefing` consulta `clientes/<cliente>/publicos-cache.md` antes de montar briefing. Layout e TTL: ver [_publicos-cache-template.md](../../../clientes/_skill-ekyte/_publicos-cache-template.md). Cache de público pode evitar repetir pergunta de público, mas não elimina a obrigação de chamar `/ekyte-briefing`; em projeto novo, também não elimina a consulta `/cs-notebooklm-consulta-cliente`.
+
+Fluxo:
+
+1. **Identificar a linha** de cada task do lote (Colchões adultos / Cliente A Baby / Geral / etc).
+2. **Para cada linha distinta no lote**, abrir o cache uma vez:
+   - **HIT** (< 75d) → usa direto para público. O briefing formal ganha bloco "Público" preenchido (avatar + faixa + sexo + consciência + ganchos) com marcador `[do cache: <linha> · <N>d]`. Se `projeto_novo: true`, ainda consultar NotebookLM para contexto geral da task.
+   - **STALE** (75-90d) → pergunta no pre-fly: `⚠️ cache de público da linha "Cliente A Baby" tem 78d. Atualizar antes do lote? (sim/não)`. Sem resposta = HIT silencioso.
+   - **MISS** (≥ 90d OU inexistente) → invocar `/cs-notebooklm-consulta-cliente` **uma única vez por linha do lote**, com 1 pergunta dirigida só de público (não as 5 padrão). ~1min/linha. Após resposta, escrever bloco no cache.
+3. **Não consultar NotebookLM mais de uma vez por linha por lote.** Se 4 tasks são todas "Colchões adultos", consulta roda 1x (no MISS) e as 4 reusam.
+
+Quando MISS rola, o cache populado fica disponível pras próximas sessões — paga o investimento em 2-3 lotes. Mesmo com cache, a saída final precisa vir da `/ekyte-briefing`.
+
+### 8.5) Modo Lote — script Python (≥6 tasks)
+
+Quando o lote for ≥6 tasks, montar briefing na chat custa contexto e fica frágil. **Default a partir de 6:** gerar os textos via script Python parametrizado, mas somente depois de rodar `/ekyte-briefing` e obter síntese NotebookLM por cliente/linha relevante. O script reaproveita a síntese e os templates; ele não substitui a consulta.
+
+Estrutura recomendada:
+1. Criar pasta de trabalho `<workspace_user>/briefings-ekyte-<YYYY-MM-DD>/`.
+2. Escrever `gerar_briefings.py` que define funções reaproveitáveis por padrão de demanda (ex: `web_pdp(cliente, ws_id, proj_id)`, `fotos(filename, qtd_por_sku, total_skus, ...)`) e chama essas funções pra cada task. Saída: 1 `.docx` por task (use `python-docx`).
+3. Escrever `extrair_textos.py` que converte os .docx em HTML rico simples para Ekyte (`<div>`, `<strong>`, `<span style="font-size: 18px;">` somente em heads, `<a>`, `<ul>`, `<li>`; sem `<h1>/<h2>`). **Pular o bloco "Metadados (Ekyte)"** — esses dados já vão nos campos próprios da MCP. Salva tudo num `_briefings_textos.json` chave→HTML.
+4. Disparar as MCP `criar_tarefa_tool` em paralelo (várias por mensagem) com `description_create_task` lendo do JSON gerado a partir da síntese aprovada.
+
+Vantagens medidas (lote de 25 em 2026-05-04):
+- Estrutura uniforme (toda task cobre Objetivo / Contexto / Escopo / Entregáveis / Perguntas / Referências).
+- Reaproveitamento de padrão (8 fotos Cliente A = 1 função × 6 chamadas, não 6 briefings escritos à mão).
+- Os .docx ficam de subproduto pro Fabio revisar antes do disparo se quiser.
+
+### 9) Chamar a MCP
+
+Após confirmação, chamar `ekyte.criar_tarefa_tool` com os 8 campos:
+
+```json
+{
+  "workspace_id_create_task": "999001",
+  "ctc_task_type_id_create_task": "29740",
+  "user_email_create_task": "seu.usuario@v4company.com",
+  "title_create_task": "[09][CA][IA] Cliente A | Remarketing produto X",
+  "description_create_task": "<HTML rico formatado do briefing>",
+  "current_due_date_create_task": "2026-05-09",
+  "ctc_task_project_id_create_task": "<id do projeto>",
+  "phase_start_date_create_task": "2026-04-28"
+}
+```
+
+Reportar sucesso/erro de cada criação. Se erro: parar, mostrar a mensagem, não tentar a próxima sem aprovação.
+
+### 9.5) Gerar tarefas (sair de "Não planejada" → "Ativa") — revisado 2026-06-17
+
+> **Quando pular este passo:** se a task foi criada via `mcp__ekyte__create_task` com `situation=10`, ela já nasce Ativa — este passo inteiro pode ser ignorado. Confirmar com `list_tasks` filtrando `situation=10` se houver dúvida.
+
+O passo abaixo é necessário apenas quando a criação foi feita pelo fluxo legado n8n (`criar_tarefa_tool`), que cria a task como **"Não planejada"** e exige ativação project-level via REST.
+
+**Após ativar, validar datas de etapa:** na resposta do `generate-tasks` ou em listagem posterior, toda task criada nesta execução precisa ter a etapa atual sem atraso. A coluna **"Executar etapa até"** deve ser hoje (data da subida). A coluna **"Concluir tarefa até"** deve seguir o SLA/prazo final. Se o Ekyte gerar fase inicial no passado, corrigir imediatamente via ferramenta/API de edição de task/fase antes de finalizar o relatório.
+
+> **Nota (MCP oficial):** o servidor `ekyte-oficial` expõe `create_task` com `situation=10` (cria já Ativa) e `update_task_phase` (move uma task específica de fase). Não substituem o "Gerar tarefas" project-level — são alternativas por-task que exigem montar o `flow`/`phaseId` na criação. Por ora mantemos a criação via `ekyte` (n8n) + ativação REST; o oficial fica como caminho de **edição/correção** pós-criação. Reavaliar migrar a criação inteira pro oficial quando o `flow` estiver mapeado no cache.
+
+**Endpoint:**
+```
+POST https://api.ekyte.com/api/v2/companies/{company_id}/projects/{project_id}/generate-tasks
+Headers:
+  Authorization: Bearer <EKYTE_TOKEN>
+  Content-Type: application/json
+Body: []
+```
+
+**Atenção ao body:** é **array vazio `[]`**, não objeto `{}`. Mandar `{}` retorna 422 com `"requires a JSON array"`. O backend é .NET e desserializa em `System.Int64[]`. `[]` ativa **todas** as "Não planejadas" do projeto de uma vez — não é por-task, é por-projeto.
+
+**Pegadinha crítica do 500 (descoberta 2026-05-16):** se o projeto **não tem mais tasks "Não planejada"** (já foram ativadas manualmente OU outra chamada generate-tasks rodou antes), o endpoint retorna **HTTP 500 com body vazio** — não 200, não 204, não erro descritivo. Isso **não é erro de verdade**, é "nada pra ativar". Sempre validar via listagem antes/depois.
+
+**Implementação no fluxo (sempre seguir nesta ordem):**
+
+1. **Pré-check via MCP — task já está ativa?**
+   Pra cada task criada no passo 9, chamar `listar_tarefas_tool` com:
+   - `project_id` = projeto da task
+   - `created_from` / `created_to` = data de hoje
+   - `status_list_task` = `10` (ativas)
+
+   Se a task aparece na resposta com `situation: 10`, ela **já está ativa** — outro fluxo (Fabio manual, ou generate-tasks anterior do lote) já cuidou. **Pular essa task silenciosamente.** Não chamar o REST.
+
+2. **Ler `clientes/_skill-ekyte/.env`** (formato em `.env.example`). Se arquivo não existe, avisar Fabio:
+   ```
+   ⚠️ clientes/_skill-ekyte/.env não cadastrado. Tasks criadas vão ficar como
+   'Não planejada' até você gerar manualmente no Ekyte.
+
+   Pra cadastrar o token (~3 min):
+   1. F12 em app.ekyte.com → aba Network → no filtro digita 'api.ekyte'
+   2. Clica em "Gerar tarefas" em qualquer projeto (força uma request real)
+   3. Na request POST que aparece, aba Headers → copia o valor de
+      'authorization: Bearer eyJhbGc...'
+   4. Cola só o JWT (sem 'Bearer ') em EKYTE_TOKEN= no .env
+
+   Quer cadastrar agora? (sim/não)
+   ```
+   Se "não", pular passo 9.5 inteiro e seguir pro 10. **Não insistir** depois — Fabio sabe que pode gerar manual no Ekyte web.
+
+3. **Agrupar tasks criadas (que ainda não estão ativas) por `ctc_task_project_id_create_task`**. Lote de 5 tasks em projetos diferentes = até 5 chamadas; 10 tasks todas no mesmo Q2 do Cliente A = 1 chamada.
+
+4. **Pra cada `project_id` único**, disparar:
+   ```bash
+   curl -X POST "$EKYTE_API_BASE/companies/$EKYTE_COMPANY_ID/projects/<project_id>/generate-tasks" \
+     -H "Authorization: Bearer $EKYTE_TOKEN" \
+     -H "Content-Type: application/json" \
+     -H "Origin: https://app.ekyte.com" \
+     -H "Referer: https://app.ekyte.com/" \
+     -d '[]'
+   ```
+
+5. **Tratamento de resposta:**
+   - **200 OK** → reportar `✅ Projeto <nome> ativado`. Re-listar via MCP só pra confirmar contagem.
+   - **500 com body vazio** → **não é erro de verdade.** Provavelmente projeto não tinha mais "Não planejada" no momento da chamada (Fabio gerou em paralelo via UI, ou já foi ativado). Re-listar via MCP `listar_tarefas_tool` filtrando o `project_id` + criadas hoje + `status_list_task: 10`. Se a task aparece ativa, reportar `✅ Projeto <nome>: tasks já ativas (500 é falso erro do Ekyte quando não há "Não planejada")`. Se não aparece, aí sim é erro real — escalar.
+   - **401 Unauthorized** → token expirou. Avisar:
+     ```
+     ❌ Token EKYTE_TOKEN expirou. As tasks foram criadas mas ficaram como 'Não planejada'.
+
+     Renovar (~2 min):
+     1. F12 em app.ekyte.com → Network → filtro 'api.ekyte'
+     2. Clica em "Gerar tarefas" em qualquer projeto
+     3. Copia o header 'authorization: Bearer eyJhbGc...' da request POST
+     4. Cola só o JWT (sem 'Bearer ') em EKYTE_TOKEN= no .env
+
+     Token NÃO está em localStorage — só vem via Network durante interação real.
+     ```
+     Não tentar refresh automático.
+   - **Outros erros** → reportar status + body, não interromper outras chamadas, avisar no relatório final.
+
+6. **Relatório consolidado** após todas as chamadas:
+   ```
+   ✅ 4 tasks criadas
+   ✅ Ativas: Cliente A | Q2/2026 (2 tasks), Cliente C | Q2/2026 (2 tasks)
+   ```
+
+   Se alguma falhou de verdade:
+   ```
+   ✅ 4 tasks criadas
+   ✅ Ativas: Cliente A | Q2/2026 (2 tasks)
+   ⚠️ NÃO ativadas: Cliente C | Q2/2026 (2 tasks) — token expirado, renova e retenta
+   ```
+
+**Token TTL:** JWT do Ekyte vale ~180 dias. Quando 401, renovar via Network (NÃO localStorage — Ekyte usa httpOnly cookie + JWT no header só durante requests). Capturar via Console JS / localStorage **não funciona** — única forma é interceptar Network durante ação real na UI.
+
+### 9.6) Trocar responsável de etapa (só se especificado no passo 4.5)
+
+Roda **depois** da criação+ativação (9/9.5), e **só** se o Fabio especificou responsável por etapa. Sem overrides, pular.
+
+Via MCP **oficial** (`ekyte-oficial`) — sem JWT manual, token fixo na URL. Pra cada override `{fase → pessoa}` da task:
+
+1. **Pegar o `taskId` real** da task recém-criada/ativada. Se não tiver em mãos, achar via `mcp__ekyte-oficial__list_tasks` filtrando projeto + criadas hoje + título, ou `get_detailed_task` pra confirmar as fases reais.
+
+2. **Confirmar o `phaseId`** da fase: do `flows.md` (passo 4.5) ou das fases reais da task via `get_detailed_task`. A fase precisa existir no fluxo da task.
+
+3. **Aplicar:**
+   ```
+   mcp__ekyte-oficial__update_task_executor(
+     taskId: <id>,
+     phaseId: <phaseId da fase>,
+     patchDoc: [{"op":"replace","path":"/executorId","value":"<userId GUID>"}]
+   )
+   ```
+   > O schema do `patchDoc` não detalha o campo; o path `/executorId` segue a estrutura do fluxo (`executorId` por fase) e a convenção do `update_task`. **Confirmar no 1º uso** — se a API rejeitar, inspecionar `get_detailed_task` pra ver o nome exato do campo e ajustar este passo + esta nota.
+   > Se a fase for a **etapa atual** da task, o Ekyte troca também o executor corrente da task (comportamento documentado da tool).
+
+4. **Relatório** — somar ao consolidado do 9.5:
+   ```
+   👤 Responsáveis ajustados:
+      • #9342321 Briefing → Marina Souza ✅
+      • #9342321 Designer → João Pedro ✅
+   ```
+   Se uma troca falhar, reportar a fase + erro e seguir as outras (não abortar o lote).
+
+**Guardrail:** nunca trocar executor de fase que o Fabio não pediu. Default do tipo é sagrado — só sobrescrever o que foi explicitamente especificado.
+
+### 9.7) Aplicar somente a tag IA
+
+Ao final de toda criação via `/ekyte-task`, depois de criar, ativar, corrigir datas de etapa e aplicar overrides de responsável, adicionar somente:
+
+- `IA` **em vermelho** (resolver `tagId` pela lista/cache de tags; se houver mais de uma tag `IA`, usar a vermelha)
+
+Regra de aplicação:
+
+1. Resolver o `tagId` da tag `IA` vermelha. Buscar por nome exato `IA` e conferir a cor/metadado visual. Se a tag `IA` existir mas não for vermelha, avisar no relatório e não usar a tag errada. Se não existir tag `IA` vermelha e a API disponível permitir criação/edição de tags, criar/ajustar para vermelho antes de aplicar; se não permitir, pedir ao Fabio para criar a tag vermelha e deixar claro que a task ficou sem essa tag.
+2. Ler as tags atuais da task.
+3. Fazer merge: tags atuais + `IA` vermelha. **Não adicionar `SPRINT GROWTH`, `SEMANA NN` nem qualquer outra tag automática.**
+4. Aplicar a lista completa via MCP oficial `update_task_tags` quando disponível. Se usar REST, endpoint:
+   `PUT /api/v2/companies/{company_id}/ctc-tasks/{task_id}/tags`
+   com body:
+   ```json
+   [{"ctcTaskId": 9500983, "tagId": "<IA_VERMELHA>"}]
+   ```
+
+**Nunca substituir tags preexistentes sem merge.** O endpoint de tags substitui a lista inteira. Em task nova sem tags anteriores, a lista final deve conter somente `IA` vermelha.
+
+### 10) Atualizar cache
+
+Sempre que descobrir um `project_id` novo (ou um `task_type_id` confirmado de tipo Personalizada), atualizar `clientes/_skill-ekyte/cache.md` antes de encerrar. Se descobrir o fluxo de um tipo que não estava em `flows.md` (buscado em runtime no 4.5), salvar lá também. Refresh total dos fluxos: re-rodar o fetch de `get_task_type_flow` por tipo (ainda não embutido no `/ekyte-refresh` — wire pendente).
+
+---
+
+## Guardrails (não-negociáveis)
+
+1. **Lock de cliente por sessão.** Se o Fabio começou trabalhando "Cliente A", não criar tasks em outro workspace sem confirmação explícita ("acabamos com Cliente A, agora estou indo pra Cliente C").
+
+2. **Desambiguação obrigatória** em:
+   - Cliente com >1 match (rara, mas possível com nomes parecidos)
+   - Sigla com >1 task_type_id (CA, CJ, GP, MT, AUX, CRM, PMM, RI, SM)
+   - Projeto com >1 match para o período pedido
+
+3. **Preview obrigatório** antes de cada criação. Sem exceção. Mesmo no modo B em lote, exibir resumo + esperar "ok".
+
+4. **Workspace fora dos 8** → PARAR e pedir confirmação explícita. A conta é master Collie, blast radius alto.
+
+5. **Erro = parar.** Se uma criação falhar (HTTP error, timeout, schema rejeitado), pausar o fluxo e reportar. Não seguir pra próxima task do lote sem aprovação.
+
+6. **Sem auto-execução.** Mesmo que o Fabio diga "confia, manda tudo", insistir no preview da primeira task pelo menos.
+
+7. **Gerar tarefas é parte obrigatória do fluxo.** Toda task criada deve sair de "Não planejada" no final da execução. Se token expirou ou `.env` não existe, **avisar explicitamente** que as tasks ficaram em rascunho — Fabio não pode descobrir isso depois.
+
+8. **Nunca entregar task atrasada.** Antes de encerrar, validar individualmente que nenhuma task criada caiu em "Atrasado". O campo "Executar etapa até" precisa ser a data de criação/subida; o SLA só controla "Concluir tarefa até". Se houver backdating automático do Ekyte, corrigir antes de considerar a execução concluída. Uma task ainda atrasada é falha pendente, não sucesso.
+
+9. **Somente tag IA.** Toda task criada pela skill deve receber somente a tag automática `IA` em vermelho. Não adicionar `SPRINT GROWTH`, `SEMANA NN` ou qualquer outra tag automática. Preservar tags que já existiam na task por merge; em task nova sem tags anteriores, o resultado final é apenas `IA`.
+
+10. **Token Ekyte é sensível.** Nunca logar/imprimir o valor de `EKYTE_TOKEN` nas mensagens pro Fabio (mesmo truncado). Só dizer "token presente/ausente/expirado".
+
+---
+
+## Como invocar
+
+- `/ekyte-task` — usuário chama explicitamente
+- Detectar automaticamente quando o Fabio:
+  - Disser "cria/sobe/abre uma task/tarefa no ekyte"
+  - Mencionar uma sigla `[CA]`, `[LP]`, etc. seguida de cliente
+  - Apontar aba da planilha de demandas pra subida em lote
+
+## O que NÃO fazer
+
+- Não inventar `task_type_id`, `workspace_id` ou `project_id`. Se não está no cache, buscar ou perguntar.
+- Não criar workspace, projeto ou tipo novos por conta própria. Skill v1 só **cria task**, nunca infraestrutura.
+- Não pular o preview, mesmo que o Fabio peça pressa.
+- Não escrever briefing do zero quando o tipo tem template oficial — sempre usar o template e preencher.
+- Não tentar aplicar tag nativa na chamada de criação da MCP — o schema não expõe. Marcar IA pelo título `[IA]` e aplicar a tag `IA` vermelha no pós-criação, via passo 9.7.

--- a/.agents/skills/ekyte-templates-refresh/SKILL.md
+++ b/.agents/skills/ekyte-templates-refresh/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: ekyte-templates-refresh
+description: Atualiza, adiciona ou ajusta os templates de briefing por sigla usados pela `/ekyte-briefing` em `clientes/_skill-ekyte/briefing-templates/`. Use quando o Fabio rodar `/ekyte-templates-refresh`, mencionar que quer "criar template novo" pra uma sigla que ainda não tem (ex: KV, MT, EM, EV), "ajustar o template de CA" pra adicionar/remover seção, ou quando rodar 5 tasks reais e quiser refinar perguntas/campos.
+area: ekyte
+author: fabio
+version: 1.0.0
+user-invocable: true
+---
+
+# /ekyte-templates-refresh — Manutenção dos templates de briefing
+
+Cuida do diretório `clientes/_skill-ekyte/briefing-templates/`. Adicionar sigla nova, ajustar template existente, ou propagar uma melhoria pra múltiplos templates.
+
+## Quando usar
+
+- `/ekyte-templates-refresh` (direto)
+- "cria template pro KV" / "preciso de template pra MT (Motion)"
+- "no template de CA, adiciona pergunta sobre [X]"
+- "remove a seção [Y] do PC"
+- "depois de 5 tasks, quero refinar o template de CA"
+
+## Pré-requisitos
+
+- Diretório `clientes/_skill-ekyte/briefing-templates/` existente, com pelo menos:
+  - `_header-universal.md`
+  - `_base-criativo.md`
+  - `_5w1h.md`
+  - `CA.md`, `LP.md`, `RV.md`, `PC.md`, `AN.md`, `CRM.md`
+
+## Fluxo
+
+### 1) Identificar a operação
+
+```
+O que você quer fazer?
+
+1) Adicionar template novo (sigla que ainda não tem .md)
+2) Ajustar template existente (adicionar/remover/modificar seção ou pergunta)
+3) Atualizar arquivo compartilhado (_header-universal, _base-criativo, _5w1h)
+4) Listar templates atuais (saber o que já existe)
+```
+
+### 2) Modo "Adicionar template novo"
+
+Perguntar:
+- **Sigla** (ex: `MT`, `EM`, `KV`)
+- **Tipo de tarefa** (nome legível, ex: "Motion", "E-mail Marketing")
+- **task_type_id** (puxar do `cache.md` se já existe; se não, perguntar)
+- **Família** (qual base usar):
+  - Criativo (importa `_base-criativo.md`) → CA, LP, RV, KV, MT, EV, DC, DLP, DE, AC, OCA, SM, EM, PAPP, PI, PMS, PPSH, PSMS, PWPP
+  - Operacional (só `_header-universal.md`) → PC, RI, EKT, REL, OVERVIEW
+  - Analítica (só `_header-universal.md`, sem KV) → AN, AUX
+  - CRM/Relacionamento (`_header-universal.md` + bloco extra de infra CRM) → CRM, ACRM, ATM, CB
+  - Outra → criar do zero, perguntar estrutura
+
+Skill propõe um esqueleto baseado na família + perguntas comuns + perguntas específicas que **Fabio** define. Mostra preview do template antes de salvar.
+
+### 3) Modo "Ajustar template existente"
+
+Perguntar:
+- Qual sigla ajustar?
+- Qual tipo de ajuste:
+  - Adicionar seção/pergunta nova
+  - Remover seção/pergunta
+  - Modificar pergunta (texto, opções, default)
+  - Reordenar seções
+
+Mostrar diff (linhas antes/depois) antes de aplicar.
+
+### 4) Modo "Atualizar arquivo compartilhado"
+
+`_header-universal.md`, `_base-criativo.md`, `_5w1h.md`. **Cuidado redobrado** — mudança aqui afeta TODOS os templates que importam.
+
+Avisar: "Esta mudança vai afetar os templates X, Y, Z. Confirma?"
+
+### 5) Modo "Listar templates atuais"
+
+Output:
+```
+📂 Templates em clientes/_skill-ekyte/briefing-templates/
+
+Compartilhados:
+  • _header-universal.md (vai em todo briefing)
+  • _base-criativo.md (CA, LP, RV)
+  • _5w1h.md (modo plano de ação)
+
+Por sigla:
+  • CA.md — Criativo Ads
+  • LP.md — Landing Page
+  • RV.md — Roteiro de Vídeo
+  • PC.md — Publicação de Campanha
+  • AN.md — Análise de Dados
+  • CRM.md — CRM / Relacionamento
+
+Siglas SEM template ainda (cairão no fallback genérico):
+  • KV, MT, EV, EM, OCA, SM, ... (lista do cache.md filtrando os que já existem)
+```
+
+### 6) Salvar e reportar
+
+Diff antes de cada Write/Edit. Após salvar:
+```
+✅ Template atualizado:
+  - clientes/_skill-ekyte/briefing-templates/CA.md (3 linhas adicionadas)
+```
+
+## Guardrails
+
+1. **Diff obrigatório.** Antes de qualquer Write/Edit, mostrar mudanças linha-a-linha.
+2. **Mudança em compartilhado afeta múltiplos.** Listar templates afetados antes.
+3. **Não criar template duplicado** sem confirmação. Se sigla já tem `.md`, perguntar se é pra sobrescrever ou se é variante (ex: `CA-v4s.md` pra task_type_id 37979).
+4. **Manter o padrão de conversão Markdown→HTML.** Toda nova seção precisa seguir as regras: `<div>` por linha, `<strong>` em CAIXA ALTA pra título de seção, sem `<h>`/`<p>`/`<ul>`.
+5. **Validar referências cruzadas.** Se template importa `_base-criativo.md`, ele precisa existir. Se referência sigla mas pula uma seção dela, alertar.
+
+## Como invocar
+
+- `/ekyte-templates-refresh` (direto).
+- "cria template pro [SIGLA]".
+- "ajusta o template de [SIGLA]".
+
+## O que NÃO fazer
+
+- Não tocar em `drives.md` ou `backups-crm.md` (use `/ekyte-briefing-refresh`).
+- Não tocar em `cache.md` (use `/ekyte-refresh`).
+- Não escrever templates sem validar a família primeiro (cliente vai querer brieffar uma analítica como criativo se template estiver errado).
+- Não esquecer da regra de KV: aplicável **só** pra siglas criativas (CA/LP/RV/etc). Templates analíticos/operacionais omitem KV.

--- a/.claude/skills/ekyte-briefing-refresh/SKILL.md
+++ b/.claude/skills/ekyte-briefing-refresh/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: ekyte-briefing-refresh
+description: Atualiza os arquivos de cache da `/ekyte-briefing` — `clientes/_skill-ekyte/drives.md` (links de Drive por cliente) e `clientes/_skill-ekyte/backups-crm.md` (planilhas de backup CRM por cliente). Use quando o Fabio entrar com cliente novo, trocar link de Drive de algum cliente, criar planilha de backup CRM nova, ou quando rodar `/ekyte-briefing-refresh`. Não toca em templates da skill (esses são gerenciados pela `/ekyte-templates-refresh`).
+area: ekyte
+author: fabio
+version: 1.0.0
+user-invocable: true
+---
+
+# /ekyte-briefing-refresh — Atualizar drives e backups CRM
+
+Mantém os dois arquivos de lookup que a `/ekyte-briefing` usa: `drives.md` (sempre presente) e `backups-crm.md` (preenchido sob demanda).
+
+## Quando usar
+
+- `/ekyte-briefing-refresh` (invocação direta)
+- "atualiza o Drive do cliente X"
+- "entrou cliente novo, atualiza"
+- "criei a planilha de backup do CRM, salva aqui"
+- "Cliente H agora tem Drive: <link>"
+
+## Pré-requisitos
+
+- `clientes/_skill-ekyte/drives.md` existente (criado pela `/ekyte-briefing` na primeira instalação).
+- `clientes/_skill-ekyte/backups-crm.md` existente.
+
+## Fluxo
+
+### 1) Perguntar o que atualizar
+
+```
+O que você quer atualizar?
+
+1) Drive de cliente — adicionar/trocar link de Drive
+2) Planilha de Backup CRM — adicionar/trocar planilha de backup
+3) Ambos
+```
+
+### 2) Modo "Drive de cliente"
+
+```
+Qual cliente?
+1) Cliente E                  → atual: <link>
+2) Cliente F  → atual: <link>
+3) Cliente A           → atual: <link>
+4) Cliente B                   → atual: <link>
+5) Cliente C                → atual: <link>
+6) Cliente D                  → atual: <link>
+7) Cliente G        → atual: <link>
+8) Cliente H         → atual: _sem Drive ainda_
+9) Cliente novo (não está nos 8 acima)
+```
+
+- Opções 1-8: pedir novo link, validar formato (URL Google Drive), atualizar `drives.md`.
+- Opção 9: pedir nome do cliente + alias + link. **Avisar**: cliente novo também precisa estar no `cache.md` (workspaces) — sugerir rodar `/ekyte-refresh` na sequência se ainda não rodou.
+
+Mostrar diff antes de salvar:
+```
+Drive de Cliente G:
+  ANTES: https://drive.google.com/drive/folders/1R1TGag8...
+  DEPOIS: https://drive.google.com/drive/folders/NOVO_ID...
+
+Confirma? (sim/não)
+```
+
+### 3) Modo "Planilha de Backup CRM"
+
+```
+Qual cliente vai ter planilha de backup atualizada?
+[lista os 8 com status atual: vazio / link]
+```
+
+Pedir link da planilha. Salvar em `backups-crm.md`. Mesmo padrão de diff antes de confirmar.
+
+### 4) Modo "Ambos"
+
+Roda 2) e depois 3) em sequência.
+
+### 5) Salvar e reportar
+
+Após cada update:
+- Atualizar tabela do arquivo correspondente.
+- Atualizar campo "Última atualização" no topo do arquivo.
+- Reportar resumo:
+
+```
+✅ Atualizações salvas:
+  • Drive de Cliente G atualizado
+  • Backup CRM de Cliente C adicionado
+
+Arquivos modificados:
+  - clientes/_skill-ekyte/drives.md
+  - clientes/_skill-ekyte/backups-crm.md
+```
+
+## Guardrails
+
+1. **Diff obrigatório.** Sempre mostrar antes/depois antes de salvar. Erros de digitação em link de Drive quebram o briefing inteiro depois — vale pedir confirmação.
+
+2. **Validação mínima de URL.** Drive precisa ser `drive.google.com`. Backup pode ser sheets.google.com OU outro formato. Se URL não bate o domínio esperado, perguntar se está certo antes de salvar.
+
+3. **Cliente fora dos 8 fixos** → exigir confirmação extra ("Esse cliente não está nos 8 do `cache.md`. Tem certeza? Vai precisar adicionar no cache.md depois também."). Não bloquear, mas avisar.
+
+4. **Não mexer em templates.** Esta skill toca **só** em `drives.md` e `backups-crm.md`. Templates são responsabilidade de `/ekyte-templates-refresh`.
+
+## Como invocar
+
+- `/ekyte-briefing-refresh` (direto).
+- "atualiza Drive do Y" / "salva planilha de backup do X".
+
+## O que NÃO fazer
+
+- Não escrever em `briefing-templates/` (use `/ekyte-templates-refresh`).
+- Não mexer em `cache.md` (use `/ekyte-refresh`).
+- Não criar cliente novo silenciosamente — sempre avisar que `cache.md` também precisa ser atualizado.

--- a/.claude/skills/ekyte-briefing/SKILL.md
+++ b/.claude/skills/ekyte-briefing/SKILL.md
@@ -1,0 +1,396 @@
+---
+name: ekyte-briefing
+description: Monta briefings ricos e estruturados pra tarefas do Ekyte com base em templates locais por sigla, contexto puxado do NotebookLM do cliente, e perguntas ativas estruturadas. Usado como subskill da `/ekyte-task` — recebe pacote {cliente, sigla, tipo, qtd, input, modo} e devolve HTML rico formatado pronto pra entrar no campo `description`/`description_create_task` do Ekyte, com heads e labels em negrito. Pode ser invocada avulsa quando o usuário só quer pensar/estruturar uma demanda sem subir task. Suporta modo 5W1H quando vem planilha de plano de ação.
+area: ekyte
+author: fabio
+version: 1.0.0
+user-invocable: true
+---
+
+# /ekyte-briefing — Geração de briefing rico pra tasks do Ekyte
+
+Substitui o briefing "uma linha + `<<PREENCHER>>`" da v1 da `/ekyte-task` por um briefing estruturado, profundo e pré-preenchido com contexto do NotebookLM do cliente.
+
+## Regra soberana de formatação Ekyte (atualizada em 2026-06-15)
+
+Briefings enviados ao Ekyte devem ser **HTML rico**, não texto plano. Esta regra substitui qualquer orientação legada neste arquivo que diga para remover HTML ou converter tudo para texto simples.
+
+Padrão obrigatório:
+- Seções principais viram heads visuais maiores e em negrito: `<div><strong><span style="font-size: 18px;">ATIVOS DA CAMPANHA</span></strong></div>`.
+- Labels de campo ficam em negrito: `<div><strong>Drive do Cliente:</strong> <a href="...">...</a></div>`.
+- Listas de entregáveis, guardrails e métricas usam `<ul><li>...</li></ul>`.
+- Espaçamento entre blocos usa `<div><br></div>`.
+- Não usar `<h1>` ou `<h2>`. CSS inline só é permitido em heads de seção para aumentar fonte (`font-size: 18px`). O Ekyte renderiza melhor com `<div>`, `<strong>`, `<span style="font-size: 18px;">`, `<a>`, `<ul>` e `<li>`.
+- Preferir texto ASCII dentro do HTML quando a API retornar acentos quebrados como `?`; visual correto > acento quebrado.
+- O campo `briefing_ekyte_text` pode manter esse nome por compatibilidade, mas seu conteúdo deve ser HTML rico.
+
+## Quando usar
+
+**Modo subskill (principal)** — invocada pela `/ekyte-task` no passo 6 da criação de task. Recebe pacote estruturado, devolve briefing em HTML rico formatado pronto.
+
+**Modo avulso** — Fabio chama direto:
+- `/ekyte-briefing` + descrição livre
+- "me brieffa um CA pro Cliente A com foco em remarketing produto X"
+- "preciso pensar essa demanda CRM antes de subir — me ajuda a montar o briefing"
+
+Em modo avulso, a skill devolve o HTML rico formatado para Ekyte **e** o Markdown limpo, e pergunta se Fabio quer subir como task (aí invoca `/ekyte-task`).
+
+## Pré-requisitos
+
+- MCP `ekyte` configurada (pra eventual lookup de tipo de tarefa).
+- Cache `clientes/_skill-ekyte/cache.md` populado (workspaces/projetos/tipos).
+- `clientes/_skill-ekyte/drives.md` populado (drives dos clientes).
+- `clientes/_skill-ekyte/briefing-templates/*.md` presentes (templates por sigla + base + universal + 5W1H).
+- Cliente alvo deve ter `clientes/<cliente>/CLAUDE.md` com bloco `## NotebookLM`. Em modo subskill da `/ekyte-task`, a skill deve tentar consultar NotebookLM; se faltar cadastro, pedir cadastro ou autorização explícita do gerente de projetos para seguir sem NotebookLM.
+- `notebooklm-py` autenticado (pra `/cs-notebooklm-consulta-cliente` rodar). Se não estiver, pedir login ou autorização explícita do gerente de projetos para seguir sem síntese.
+
+Os dois pré-requisitos de NotebookLM acima só são bloqueantes quando o pacote recebe `notebook_obrigatorio: true`. Tarefas da whitelist operacional chegam com `notebook_obrigatorio: false` e não devem abrir bloqueio de cadastro/login.
+
+## Pacote de entrada (modo subskill)
+
+A `/ekyte-task` passa:
+
+```json
+{
+  "cliente": "Cliente A",
+  "cliente_alias": "cliente-a",
+  "sigla": "CA",
+  "task_type_name": "Criativo Ads",
+  "task_type_id": "29740",
+  "qtd": 9,
+  "titulo": "[09][CA][IA] Cliente A | Remarketing produto X",
+  "input_livre": "cria 9 CAs pro Cliente A com foco em remarketing produto X",
+  "modo": "texto_livre",   // ou "planilha_demandas" ou "5w1h"
+  "projeto_novo": false,
+  "notebook_obrigatorio": true,
+  "motivo_isencao_notebook": null,
+  "planilha_5w1h_url": null,  // preenchido se modo=5w1h
+  "planilha_demanda_row": null  // preenchido se modo=planilha_demandas
+}
+```
+
+## Fluxo
+
+### 1) Carregar contexto inicial
+
+Em paralelo (independentes):
+- Ler `clientes/_skill-ekyte/drives.md` → mapa cliente → drive_link
+- Ler `clientes/_skill-ekyte/backups-crm.md` (se sigla é CRM-relacionada)
+- Ler `clientes/<cliente>/CLAUDE.md` → extrair Notebook ID do bloco `## NotebookLM`
+- Carregar `clientes/_skill-ekyte/briefing-templates/_header-universal.md`
+- Carregar template específico da sigla (ex: `CA.md`). Se sigla é criativa (CA/LP/RV), carregar também `_base-criativo.md`.
+
+### 2) Decidir modo de operação
+
+Antes de decidir o modo de entrada, respeitar a classificação recebida da `/ekyte-task`:
+
+- `notebook_obrigatorio: true` → seguir os passos 3 a 5 e consultar `/cs-notebooklm-consulta-cliente`.
+- `notebook_obrigatorio: false` → pular os passos 3, 3.5, 4 e 4.5; registrar `motivo_isencao_notebook`; montar briefing operacional a partir da descrição, links de Drive/backup e template. Não exigir NotebookLM cadastrado nem login.
+- Campo ausente → assumir `true`. A falha segura é consultar.
+- `projeto_novo: true` → forçar `notebook_obrigatorio: true`, exceto projetos internos de timesheet/rotina administrativa sem contexto de cliente.
+
+Whitelist aceita para `notebook_obrigatorio: false`: otimização de campanhas recorrente; atualização de Growth Pack recorrente; apontamento de horas/timesheet; atendimento/comunicação recorrente; envio recorrente de NPS/CSAT; atualização administrativa interna recorrente sem decisão estratégica. Qualquer análise, criação, implementação, tracking, CRM, automação, projeção, campanha, público, pesquisa ou planejamento exige NotebookLM.
+
+**Modo `texto_livre`** (default): segue fluxo padrão.
+
+**Modo `5w1h`**: input contém link de planilha 5W1H + skill validou cabeçalho. Pula `_base-criativo.md`, carrega `_5w1h.md` e usa como layout principal. Skill abre a planilha (WebFetch) e extrai os 6W.
+
+**Modo `planilha_demandas`**: input veio da planilha de demandas (já manipulada pela `/ekyte-task`). Skill recebe o `planilha_demanda_row` com colunas `descricao`, `Tags`, etc — usa `descricao` como base e enriquece via NotebookLM.
+
+### 3) Cache de sessão NotebookLM
+
+Verificar se já tem síntese cacheada pro cliente nesta conversa:
+
+```
+sessao_notebook_cache = {
+  "Cliente A": { "sintese": "...", "ts": "2026-04-30 10:15", "perguntas": [...] }
+}
+```
+
+- **Cache HIT** (cliente já consultado): reusar síntese.
+- **Cache MISS** OU primeira task do cliente na sessão: seguir pro passo 3.5 antes de invocar NotebookLM.
+
+### 3.5) Cache persistente de público (TTL 90d)
+
+Antes de invocar `/cs-notebooklm-consulta-cliente`, checar `clientes/<cliente>/publicos-cache.md`. Formato e regras: ver [_publicos-cache-template.md](../../../clientes/_skill-ekyte/_publicos-cache-template.md).
+
+1. **Identificar a linha/categoria** a partir do título/input:
+   - Produto explícito no título (`Saint Tropez`, `Cliente A Baby`) → mapear pra linha conhecida.
+   - Sinal contextual sem produto (`remarketing produto X`) → perguntar ao Fabio qual linha.
+   - Cliente sem segmentação (Cliente C, Cliente D) → linha `Geral`.
+
+2. **Abrir `publicos-cache.md`** do cliente. Buscar bloco `## <linha>` (match case-insensitive, ignora acentos).
+
+3. **Decidir HIT/STALE/MISS:**
+   - **HIT** (idade < 75d): pré-preencher campos 3-9 do `_base-criativo.md` (consciência, faixa, sexo, ganchos) + avatar/ofertas/restrições/tom-de-voz com os valores do cache. Marcar no preview: `[do cache: <linha> · <N>d]`. Cache cobre público; não substitui a consulta NotebookLM quando `projeto_novo: true` ou quando ainda não existe síntese de sessão para o cliente.
+   - **STALE** (75d ≤ idade < 90d): usa o cache **mas** mostra aviso no preview da pergunta ativa: `⚠️ cache de público da linha "<X>" tem <N>d (expira em <M>d). Quer atualizar antes de seguir? (sim/não, default não)`. Resposta sim = força MISS path. Não/silêncio = HIT silencioso.
+   - **MISS** (idade ≥ 90d OU bloco inexistente OU arquivo inexistente): segue pro passo 4 (NotebookLM completo). Após sucesso da consulta, **escrever o bloco no cache** (passo 4.5).
+
+4. **Modo planilha com OBS robusta:** se o pacote de entrada veio da `/ekyte-task` com descrição substancial, usar a OBS como base do briefing, não como substituta do NotebookLM. HIT de cache pode dispensar apenas a pergunta específica de público; MISS/STALE-com-update invoca `/cs-notebooklm-consulta-cliente` para atualizar público. Se `projeto_novo: true`, rodar consulta NotebookLM atual mesmo com cache HIT.
+
+### 4) Invocar `/cs-notebooklm-consulta-cliente`
+
+Compor as 5 perguntas dirigidas pelo tipo da task (cada template tem suas próprias na seção "Pré-preenchimento via NotebookLM").
+
+Tarefa enviada:
+```
+"vou montar briefing de [tipo] (sigla [sigla]) pro [cliente]. preciso saber: [resumo das 5 perguntas]"
+```
+
+A skill `/cs-notebooklm-consulta-cliente` faz o trabalho pesado: decompõe, dispara, agrega, salva artefato. Retorna síntese estruturada.
+
+**Se a `/cs-notebooklm-consulta-cliente` retornar erro** (sessão expirada, cliente sem NotebookLM, etc):
+- Em modo subskill da `/ekyte-task`: pausar e pedir decisão. Cliente sem NotebookLM cadastrado → pedir `/notebooklm-cadastrar` ou comando explícito do gerente de projetos para seguir sem NotebookLM; sessão expirada → pedir `notebooklm login` ou comando explícito para seguir sem síntese.
+- Em modo subskill com `projeto_novo: true`: a tentativa de consulta NotebookLM é obrigatória. Se falhar, só continuar com autorização explícita do gerente de projetos, registrando no briefing que foi criado sem síntese NotebookLM.
+- Em modo avulso: avisar Fabio e perguntar se ele quer seguir sem síntese apenas como rascunho.
+
+Cachear síntese em memória (sessão).
+
+### 4.5) Popular cache persistente de público (após sucesso do passo 4)
+
+Se o passo 3.5 deu MISS/STALE-com-update e o passo 4 (NotebookLM) retornou síntese válida, **escrever bloco no cache** antes de seguir pro 5:
+
+1. Abrir/criar `clientes/<cliente>/publicos-cache.md` (formato em [_publicos-cache-template.md](../../../clientes/_skill-ekyte/_publicos-cache-template.md)).
+2. Se já existe bloco `## <linha>`: **substituir inteiro** (preserva os demais blocos do arquivo).
+3. Se não existe: **acrescentar ao final** do arquivo.
+4. Atualizar header "Última escrita: YYYY-MM-DD".
+5. Campos a gravar (NotebookLM silencioso em algum = `_não documentado_`, **nunca fabricar**):
+   - `ult_consulta`, `expira` (ult_consulta + 90d), `fonte` (URL do notebook)
+   - `Avatar` (texto narrativo 2-4 linhas)
+   - `Faixa etária dominante` (bins)
+   - `Sexo` (Masculino|Feminino|Ambos)
+   - `Nível de consciência` (1-5 com labels)
+   - `Ganchos com tração documentada` (lista)
+   - `Ofertas que já rodaram`, `Restrições documentadas`, `Tom de voz`
+
+Esse cache fica disponível pras próximas sessões (modo inline rápido da `/ekyte-task` consome direto sem precisar invocar essa skill).
+
+### 5) Pré-preenchimento dos campos do template
+
+Com a síntese em mãos, varrer o template da sigla e pré-preencher campos onde a síntese tem informação.
+
+Marcar campos pré-preenchidos com `[sugerido pelo NotebookLM, confirma?]` no preview de pergunta. Se Fabio aceitar tudo, vira valor final; se editar, vai a edição.
+
+### 6) Pergunta ativa em lote
+
+Listar **todas** as perguntas do template em uma só rodada, numeradas. Pré-preenchidos aparecem com a sugestão visível.
+
+Formato:
+
+```
+📋 BRIEFING: [09][CA][IA] Cliente A | Remarketing produto X
+
+Pra montar o briefing, responde as perguntas abaixo. Pode responder tudo de uma vez,
+em qualquer formato — se ficar dúvida, eu pergunto de novo só do que ficou solto.
+
+NotebookLM consultado em 2026-04-30 10:15. Síntese disponível e usei pra
+pré-preencher [N] campos. Você confirma ou ajusta abaixo.
+
+──────────────────────────────────────────────
+
+1) Tema/Produto: [sugerido: "Remarketing produto X — colchões mola ensacada R$ 2.5k+"]
+2) Motivação: [sugerido: "Reativar carrinho abandonado e visitantes de PDP"]
+3) Condição/Oferta (opcional):
+4) Observações relevantes (opcional):
+5) Objetivo (1-6, multi):
+   1) Alcance  2) WhatsApp  3) Cadastro  4) Vídeo  5) Remarketing  6) Compra
+   [sugerido: 5,6]
+... (continua até a última)
+```
+
+Fabio responde. Skill interpreta — aceita formatos variados (números, texto livre, "ok pra todos os sugeridos").
+
+**Se Fabio responder "ok" / "tudo ok pelos sugeridos"**: skill aceita os pré-preenchidos e pergunta só os campos sem sugestão.
+
+### 7) Validar campos universais
+
+Antes de montar o briefing final:
+
+- **Drive do Cliente:** já lido em `drives.md`. Se cliente é DOM (sem Drive) ou não mapeado, perguntar e oferecer `/ekyte-briefing-refresh`.
+- **NotebookLM:** já lido do CLAUDE.md.
+- **KV** (sigla criativa): se Fabio não passou KV no input nem na pergunta ativa, perguntar agora ("KV específico pra essa campanha? cole o link ou diga 'usa KV padrão do Drive'"). Se "padrão do Drive", colocar `KV padrão (ver pasta Drive)`.
+- **Referência:** se passou no input, usar. Senão, omitir.
+- **Pra CRM:** Planilha Backup, Ferramenta, Acesso (perguntas A, B, C do `CRM.md`).
+
+### 8) Montar Markdown completo
+
+Ordem de composição:
+
+```
+BRIEFING — {{cliente_uppercase}} — {{tipo_uppercase}}
+Tarefa: {{titulo}}
+
+[bloco _header-universal.md preenchido]
+
+[se sigla criativa: bloco _base-criativo.md preenchido]
+[se modo 5w1h: bloco _5w1h.md no lugar do _base-criativo.md]
+
+[bloco específico da sigla preenchido — CA.md / LP.md / etc]
+```
+
+### 9) Conversor Markdown → HTML rico formatado (Ekyte)
+
+**Regra atual (2026-06-15):** converter Markdown/briefing final para HTML rico antes de enviar ao Ekyte. Ignorar instruções legadas que mandem remover HTML, `strong`, links ou listas.
+
+Mapa de conversão obrigatório:
+- Título/linha de tarefa: `<div><strong>Tarefa:</strong> ...</div>`
+- Head de seção: `<div><strong><span style="font-size: 18px;">NOME DA SEÇÃO</span></strong></div>`
+- Label de campo: `<div><strong>Nome do Campo:</strong> valor</div>`
+- Link: `<a href="URL" target="_blank">URL</a>`
+- Lista: `<ul><li>item</li></ul>`
+- Separador/linha em branco: `<div><br></div>`
+
+Exemplo mínimo:
+
+```html
+<div><strong>Tarefa:</strong> [01][PRI-A][IA] Cliente | Demanda</div>
+<div><br></div>
+<div><strong><span style="font-size: 18px;">ATIVOS DA CAMPANHA</span></strong></div>
+<div><strong>Drive do Cliente:</strong> <a href="https://drive.google.com/..." target="_blank">https://drive.google.com/...</a></div>
+<div><strong>NotebookLM:</strong> <a href="https://notebooklm.google.com/..." target="_blank">https://notebooklm.google.com/...</a></div>
+<div><br></div>
+<div><strong><span style="font-size: 18px;">OBJETIVO</span></strong></div>
+<div>Texto do objetivo.</div>
+<div><br></div>
+<div><strong><span style="font-size: 18px;">ENTREGÁVEIS ESPERADOS</span></strong></div>
+<ul><li>Entregável 1.</li><li>Entregável 2.</li></ul>
+```
+
+**Observação legada:** o bloco abaixo registra o comportamento antigo de texto plano. Ele fica como histórico, mas **não deve ser usado** para novas tasks.
+
+⚠️ **DESCOBERTA 2026-04-30:** O Quill do Ekyte **não interpreta tags HTML** quando o conteúdo é enviado via API REST (campo `description_create_task`). Tags como `<div>`, `<h1>`, `<blockquote>`, `<strong>`, `<a>`, `<ul>` aparecem como **texto literal** no editor — não viram rich text. O Quill só interpreta HTML quando recebe via clipboard de fonte rich-text (ex: colado de um Google Doc) ou quando o usuário clica nos botões da toolbar.
+
+**Conclusão: enviar via API = texto plano formatado.** O Ekyte renderiza isso em fonte monospace dentro de uma caixa estilo code block (fundo escurecido), preservando quebras de linha, bullets, emojis numerados, etc. Fica perfeitamente legível e organizado — só não tem cores nem `<h1>` rich.
+
+Função `md_to_ekyte_plain(md_string) -> string`:
+
+```
+Regras (aplicadas linha-a-linha):
+
+ESTRUTURA (preservar como texto):
+1. Linha em branco                     → linha em branco (\n)
+2. Linha começando com "## "           → "<emoji-numerado> TÍTULO EM CAIXA ALTA" (substitui ## por emoji ou só CAIXA ALTA)
+3. Linha começando com "### "          → "TÍTULO Sub-seção:" (sem caixa alta)
+4. Linha começando com "- " ou "* "    → "• texto"
+5. Texto comum                         → mantém como está
+6. **negrito**                         → REMOVER asteriscos, manter texto plano (texto monospace já dá ênfase visual)
+7. *itálico*                           → REMOVER asteriscos, manter texto plano
+8. [texto](url)                        → "texto: url"  OU  só "url" se texto for vazio/redundante
+9. URLs soltas                         → manter como estão (Quill detecta e converte em link clicável automaticamente)
+
+CONVENÇÕES VISUAIS (já que não temos cor/negrito):
+- Cabeçalhos de seção principais: usar emojis numerados pré-fixos (1️⃣, 2️⃣, 3️⃣...) seguido de TÍTULO EM CAIXA ALTA
+- Sub-seções: TÍTULO em caixa alta + ":" no fim, sem emoji
+- Avisos / proibições: prefixar com ⚠️
+- Listas/produtos: numeração explícita "1. ", "2. ", etc.
+- Bullets: "•" (caractere unicode, mais limpo que "-")
+- Separadores entre seções: linha em branco dupla ou linha de "─" se quiser destacar
+```
+
+**Exemplo de output bem formatado (referência: o briefing que renderizou bem na #2783891 quando colado):**
+
+```
+BRIEFING — CLIENTE A — CRIATIVO ADS
+Tarefa: [22][CA][IA] Cliente A | Fotos ambientalizadas linha de colchões adultos
+
+🔗 ATIVOS DA CAMPANHA
+
+Drive do Cliente: https://drive.google.com/drive/folders/...
+NotebookLM: https://notebooklm.google.com/notebook/...
+⚠️ NotebookLM compartilhado entre Cliente A e Cliente B — esta task é Cliente A.
+
+1️⃣ DIRECIONAMENTO DA CAMPANHA
+
+Tema/Produto: Colchões — linha adulta completa do e-commerce
+Motivação: Renovar banco de imagens dos PDPs
+Observações Relevantes:
+• Escopo é a linha adulta — excluir Cliente A Baby e Cama Cliente A Pet
+• 2 variações de cena por produto (total 22 peças)
+
+2️⃣ OBJETIVO
+
+• Compra (uso primário: PDP)
+Nota: não é mídia paga, é foto editorial pra PDP
+```
+
+**O que NÃO fazer no padrão atual:**
+- Não enviar Markdown bruto com `**`, `##`, `[]()` esperando que o Ekyte converta.
+- Não enviar texto plano seco quando houver heads, labels ou listas.
+- Não usar `<h1>` ou `<h2>`.
+- Não usar CSS inline em texto corrido ou labels; usar `style="font-size: 18px;"` somente nas heads de seção.
+- Enviar HTML rico simples com `<div>`, `<strong>`, `<span>`, `<a>`, `<ul>` e `<li>`.
+
+### 10) Preview da `/ekyte-briefing` (modo subskill)
+
+Mostrar pra Fabio o briefing **renderizado em Markdown** (mais legível no chat) **antes** de devolver pra `/ekyte-task`:
+
+```
+📋 BRIEFING MONTADO — [09][CA][IA] Cliente A | Remarketing produto X
+
+[markdown completo aqui — Fabio lê, edita ou aprova]
+
+──────────────────────────────────────────────
+Confirma? (sim / editar campo X / regerar do zero)
+```
+
+Se Fabio aprovar, skill devolve **HTML rico formatado para Ekyte** pra `/ekyte-task` (que cuida do preview da task em si e da chamada MCP).
+
+Se modo avulso (não foi chamada pela `/ekyte-task`), perguntar se quer subir como task ("quer que eu invoque a /ekyte-task pra subir? sim/não").
+
+### 11) Devolver pra /ekyte-task
+
+Output estruturado:
+
+```json
+{
+  "briefing_ekyte_text": "<div><strong>Tarefa:</strong> ...</div><div><br></div>...",
+  "briefing_markdown": "BRIEFING — CLIENTE A...",
+  "campos_pendentes": [],
+  "notebook_consultado": true,
+  "notebook_isento": false,
+  "motivo_isencao_notebook": null,
+  "notebook_cache_usado": false,
+  "projeto_novo": false,
+  "notebook_artefato": "clientes/cliente-a/contexto-notebook/2026-04-30-1015-briefing-criativo-ca.md"
+}
+```
+
+A `/ekyte-task` injeta `briefing_ekyte_text` em `description_create_task` e segue o fluxo dela (preview de task, confirmação, MCP).
+
+## Guardrails
+
+1. **Cache de sessão NotebookLM é por cliente, não por sigla.** Sobreusar síntese de CA pra LP do mesmo cliente está OK — síntese trata do cliente, não do tipo. Mas pra cliente diferente, sempre re-consultar.
+
+2. **Nunca fabricar dados.** Se NotebookLM disse 'NAO ENCONTRADO' pra avatar, **não** inventar avatar. Pré-preenchimento só usa o que veio literalmente da síntese. Se síntese silenciou, campo fica vazio e vai pra pergunta ativa.
+
+3. **Perguntas ativas em lote única.** Não fragmentar em 12 perguntas separadas — faz UMA mensagem com todas, Fabio responde uma vez. Salvo se ele pedir uma por uma.
+
+4. **Modo 5W1H só ativa com link explícito + validação.** Não detectar 5W1H "no chute" porque o input parece um plano. Sem link explícito, modo é texto_livre.
+
+5. **Ekyte via API deve receber HTML rico simples.** Atualizado em 2026-06-15 após validação real em task: `<div>`, `<strong>`, `<span style="font-size: 18px;">`, `<a>`, `<ul>` e `<li>` renderizam melhor que texto plano. Cabeçalhos de seção devem sair maiores e em negrito; labels devem sair em negrito no tamanho normal. Não usar Markdown bruto nem `<h1>/<h2>`.
+
+6. **Cliente sem NotebookLM cadastrado** (CLAUDE.md sem bloco `## NotebookLM`): em modo subskill da `/ekyte-task`, pausar e pedir cadastro ou autorização explícita do gerente de projetos para seguir sem NotebookLM. Se autorizado, marcar no briefing: `NotebookLM: não consultado por autorização do gerente de projetos`. Não tentar adivinhar contexto.
+
+7. **Cliente sem Drive em `drives.md`** (Cliente H atualmente): perguntar no preview e oferecer `/ekyte-briefing-refresh` pra persistir.
+
+8. **Não chamar MCP do Ekyte.** Esta skill **não** sobe nada — só monta briefing. A subida é da `/ekyte-task`.
+
+9. **Cache de público não é compartilhado entre clientes**, mesmo quando NotebookLM é compartilhado (Cliente A+Cliente B). Cada cliente tem seu `publicos-cache.md` — público é por marca, não por notebook.
+
+10. **MISS de cliente sem NotebookLM cadastrado**: não cachear nada. Briefing de task Ekyte só segue se o gerente de projetos autorizar explicitamente seguir sem NotebookLM; o `publicos-cache.md` **não é criado** pra esse cliente até que ele tenha NotebookLM.
+
+11. **NotebookLM é default; isenção é whitelist.** Nunca inferir isenção porque a OBS está detalhada ou a tarefa parece fácil. Campo ausente ou classificação ambígua significa `notebook_obrigatorio: true`.
+
+## Como invocar
+
+- `/ekyte-briefing` — modo avulso, Fabio chama direto.
+- Invocação automática pela `/ekyte-task` no passo 6 do fluxo dela.
+
+## O que NÃO fazer
+
+- Não chamar `criar_tarefa_tool` (responsabilidade da `/ekyte-task`).
+- Não escrever briefing genérico de "uma linha" (motivo da skill existir).
+- Não inventar avatar/oferta/restrição se NotebookLM não retornou.
+- Não pular perguntas obrigatórias do template (Tema/Motivação são obrigatórios pra criativos).
+- Não usar `<h1>`/`<h2>`/`<p>`; usar `<div>`, `<strong>`, `<span style="font-size: 18px;">` para heads, `<a>`, `<ul>` e `<li>`.
+- Não rodar NotebookLM em paralelo (cara é browser automation lenta — sequencial).

--- a/.claude/skills/ekyte-refresh/SKILL.md
+++ b/.claude/skills/ekyte-refresh/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: ekyte-refresh
+description: Atualiza o cache local da skill ekyte-task — re-busca workspaces fixos, projetos do trimestre vigente para cada cliente, tipos de tarefa do workflow "Padrão Colli&Co (Oficial)", e regenera o cache de fluxos (fases por tipo) via MCP oficial. Use quando o Fabio rodar /ekyte-refresh, disser que entrou cliente novo, projeto novo, que mudou fluxo/fase de algum tipo, ou que o cache parece desatualizado.
+area: ekyte
+author: fabio
+version: 1.0.0
+user-invocable: true
+---
+
+# /ekyte-refresh — Atualizar cache do ekyte
+
+Re-popula `clientes/_skill-ekyte/cache.md` puxando dados frescos da MCP `ekyte`. Roda em <2 minutos.
+
+## Quando usar
+
+- `/ekyte-refresh` (invocação direta)
+- "atualiza o cache do ekyte"
+- "entrou cliente novo, atualiza"
+- "projeto Q3/2026 começou, atualiza"
+- Cache com mais de 30 dias
+
+## Pré-requisitos
+
+- MCP `ekyte` configurada
+- Arquivo `clientes/_skill-ekyte/cache.md` existente (criado pela skill `/ekyte-task`)
+
+## Fluxo
+
+### 1) Confirmar trimestre vigente
+
+Calcular trimestre atual com base na data de hoje:
+- Jan/Fev/Mar → Q1
+- Abr/Mai/Jun → Q2
+- Jul/Ago/Set → Q3
+- Out/Nov/Dez → Q4
+
+Mostrar pro Fabio: "Vou atualizar o cache pro **Q2/2026**. Confirma?"
+
+### 2) Workspaces
+
+Os 8 workspaces fixos não mudam (já estão hardcoded no cache). Pular esta etapa, a menos que o Fabio mencione cliente novo. Nesse caso:
+- Perguntar nome do cliente novo
+- Chamar `ekyte.listar_workspaces_tool({"name_list_workspaces": "<nome>", "squad_id_list_workspaces": "", "situation_id_list_workspaces": "1"})`
+- Confirmar com o Fabio qual é o ID certo (pode vir múltiplos)
+- Adicionar ao cache
+
+### 3) Projetos do trimestre vigente para cada workspace
+
+Para cada um dos 8 workspaces:
+- Chamar `ekyte.listar_projetos_tool` com:
+  - `workspace_id_list_projects`: ID do workspace
+  - `created_from_list_projects`: data 90 dias antes do início do trimestre (margem)
+  - `created_to_list_projects`: data de hoje
+- Filtrar projetos cujo nome contém `Q2/2026` (ou trimestre vigente)
+- Salvar `project_id` no cache
+
+Se um workspace não tiver projeto do trimestre: avisar o Fabio ("Cliente A não tem projeto Q2/2026 — quer que eu pule ou tem nome diferente?")
+
+### 4) Tipos de tarefa
+
+Chamar `ekyte.listar_tipos_de_tarefas_tool({"name_type_task": "", "parameters1_Value": "3535"})` (workflow Padrão Colli&Co Oficial).
+
+Filtrar tipos cujo nome casa o regex `^\[\d+\]\[([A-Z]+)\]`.
+
+Atualizar a tabela do cache com qualquer tipo novo. **Não remover** entradas existentes (podem aparecer em desambiguação).
+
+### 4.5) Fluxos por tipo (regenerar `flows.md`)
+
+Regenera `clientes/_skill-ekyte/flows.md` — as fases reais de cada tipo (com `phaseId`) + dicionário `nome da fase → phaseId`, usado pela `/ekyte-task` pra trocar responsável de etapa (passo 9.6 de lá).
+
+Roda o script bundlado (lê o token do MCP oficial direto do `~/.claude/mcp.json` — sem segredo no repo; parseia os tipos do `cache.md`; usa `get_task_type_flow` e fica só com fases `effort/duration > 0`):
+
+```bash
+python ".claude/skills/ekyte-refresh/scripts/fetch_flows.py"
+```
+
+- Rode **depois** do passo 4 (assim qualquer tipo novo já entra no `flows.md`).
+- Precisa do MCP `ekyte-oficial` configurado. Se faltar, o script avisa e você pula esta etapa (o resto do refresh segue).
+- Saída esperada: `OK -> ...flows.md: N/N tipos, M fases distintas`. Se algum tipo der `ERR`, ele entra no `flows.md` marcado com ⚠️ e o resto continua.
+- Paths customizados: `--cache "<...>"` / `--out "<...>"` (defaults relativos à raiz do repo).
+
+### 5) Salvar e reportar
+
+Atualizar `clientes/_skill-ekyte/cache.md`:
+- Atualizar campo "Última atualização total" no topo
+- Reescrever as seções que mudaram
+
+Reportar pro Fabio:
+```
+✅ Cache atualizado:
+  - 8 workspaces (sem mudanças)
+  - <N> projetos Q2/2026 descobertos
+  - <M> tipos de tarefa (<+X> novos)
+  - flows.md regenerado (<T> tipos, <P> fases distintas)
+```
+
+## O que NÃO fazer
+
+- Não rodar refresh sem confirmação do trimestre.
+- Não criar workspaces, projetos ou tipos. Skill é read-only no ekyte.
+- Não apagar entradas do cache automaticamente (preservar histórico de IDs).

--- a/.claude/skills/ekyte-refresh/scripts/fetch_flows.py
+++ b/.claude/skills/ekyte-refresh/scripts/fetch_flows.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""
+Regenera o cache de fluxos (flows.md) da skill ekyte-task.
+
+Lê o token do MCP oficial direto de ~/.claude/mcp.json (server "ekyte-oficial"),
+então NÃO há segredo hardcoded aqui — seguro pra compartilhar via /compartilhar-skill.
+
+Uso:
+    python fetch_flows.py [--cache "<path do cache.md>"] [--out "<path do flows.md>"]
+
+Defaults (relativos ao cwd = raiz do repo):
+    --cache  "CLIENTES V4/_skill-ekyte/cache.md"
+    --out    "CLIENTES V4/_skill-ekyte/flows.md"
+
+O que faz:
+  1. Descobre a URL do MCP oficial em ~/.claude/mcp.json.
+  2. Parseia os pares (sigla, task_type_id) da seção "Tipos de tarefa" do cache.md.
+  3. Pra cada tipo, chama get_task_type_flow e fica com as fases reais (effort/duration > 0).
+  4. Escreve flows.md: fluxo por tipo (em ordem, com phaseId) + dicionário mestre fase->phaseId.
+"""
+import argparse, json, os, re, sys, datetime, urllib.request
+
+def mcp_url():
+    p = os.path.expanduser("~/.claude/mcp.json")
+    cfg = json.load(open(p, encoding="utf-8"))
+    srv = cfg.get("mcpServers", {}).get("ekyte-oficial")
+    if not srv or not srv.get("url"):
+        sys.exit("ERRO: server 'ekyte-oficial' não encontrado em ~/.claude/mcp.json")
+    return srv["url"]
+
+def call(url, name, args):
+    body = json.dumps({"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+                       "params": {"name": name, "arguments": args}}).encode()
+    req = urllib.request.Request(url, data=body, headers={
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream"})
+    with urllib.request.urlopen(req, timeout=90) as r:
+        raw = r.read().decode()
+    msg = json.loads(raw)
+    if "error" in msg:
+        raise RuntimeError(msg["error"].get("message", "?")[:120])
+    return json.loads(msg["result"]["content"][0]["text"])
+
+def parse_types(cache_path):
+    """Extrai (sigla, id) de linhas tipo `| CA | `29740` | ...` na seção de tipos."""
+    txt = open(cache_path, encoding="utf-8").read()
+    # corta a partir do header de tipos pra não pegar workspaces/projetos
+    i = txt.find("## Tipos de tarefa")
+    scope = txt[i:] if i >= 0 else txt
+    seen, types = set(), []
+    for sig, tid in re.findall(r"\|\s*\**([A-Z]{1,8})\**\s*\|\s*`?(\d{3,7})`?\s*\|", scope):
+        if sig not in seen:
+            seen.add(sig); types.append((sig, int(tid)))
+    return types
+
+def real_phases(flow):
+    out = []
+    for fp in flow.get("flowPhases", []):
+        if (fp.get("effort") or 0) > 0 or (fp.get("duration") or 0) > 0:
+            ph = fp.get("phase", {})
+            out.append({"seq": fp.get("sequential"), "phaseId": fp.get("phaseId"),
+                        "name": (ph.get("name") or "").strip()})
+    out.sort(key=lambda x: x["seq"] or 0)
+    return out
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--cache", default="CLIENTES V4/_skill-ekyte/cache.md")
+    ap.add_argument("--out", default="CLIENTES V4/_skill-ekyte/flows.md")
+    a = ap.parse_args()
+
+    url = mcp_url()
+    types = parse_types(a.cache)
+    if not types:
+        sys.exit(f"ERRO: nenhum tipo encontrado em {a.cache}")
+    print(f"{len(types)} tipos pra buscar...")
+
+    data, master = [], {}
+    for sig, tid in types:
+        try:
+            flow = call(url, "get_task_type_flow", {"id": tid})
+            ph = real_phases(flow)
+            data.append({"sigla": sig, "id": tid,
+                         "name": (flow.get("name") or "").replace("[00]", "").strip(),
+                         "days": flow.get("daysToStart"), "phases": ph})
+            for p in ph:
+                master.setdefault(p["phaseId"], p["name"])
+            print(f"  OK {sig} {tid} -> {len(ph)} fases")
+        except Exception as e:
+            data.append({"sigla": sig, "id": tid, "error": str(e)[:80], "phases": []})
+            print(f"  ERR {sig} {tid}: {e}")
+
+    L = []
+    L.append("# Cache ekyte — Fluxos por tipo de tarefa")
+    L.append("")
+    L.append(f"Gerado {datetime.date.today().isoformat()} via `/ekyte-refresh` → "
+             f"`get_task_type_flow` (MCP oficial). Workflow base **Padrão Colli&Co (Oficial)** (3535).")
+    L.append("")
+    L.append("**O que é:** as fases REAIS (effort/duration > 0) de cada tipo, em ordem, com `phaseId`. "
+             "Usado pela `/ekyte-task` pra mostrar o fluxo e resolver `nome da fase → phaseId` ao trocar responsável de etapa.")
+    L.append("")
+    L.append("**phaseId é global** (compartilhado entre tipos: `1`=Briefing, `5`=Copywriter, `6`=Designer…). "
+             "Executor default não fica aqui (varia por workspace) — a skill lê o real via `get_detailed_task` em runtime.")
+    L.append("")
+    L.append("Refresh: `/ekyte-refresh`.")
+    L.append("")
+    L.append("---")
+    L.append("")
+    L.append("## Fluxo por tipo (fases reais, em ordem)")
+    L.append("")
+    for t in sorted(data, key=lambda x: x["sigla"]):
+        if t.get("error"):
+            L.append(f"### {t['sigla']} ({t['id']}) · ⚠️ erro: {t['error']}"); L.append("")
+            continue
+        if not t["phases"]:
+            L.append(f"### {t['sigla']} — {t.get('name','')} ({t['id']}) · sem fases de esforço")
+            L.append("Tipo de rotina/sem fluxo de produção. Ler em runtime via `get_detailed_task`.")
+            L.append("")
+            continue
+        L.append(f"### {t['sigla']} — {t.get('name','')} ({t['id']}) · {len(t['phases'])} fases · SLA {t.get('days')}d")
+        L.append(" → ".join(f"{p['name']} `#{p['phaseId']}`" for p in t["phases"]))
+        L.append("")
+    L.append("---")
+    L.append("")
+    L.append(f"## Dicionário mestre de fases (phaseId → nome) — {len(master)} fases distintas")
+    L.append("")
+    L.append("Lookup `nome da fase → phaseId` (case-insensitive, match parcial).")
+    L.append("")
+    L.append("| phaseId | Fase |")
+    L.append("|---|---|")
+    for pid in sorted(master):
+        L.append(f"| {pid} | {master[pid]} |")
+    L.append("")
+
+    open(a.out, "w", encoding="utf-8").write("\n".join(L))
+    ok = sum(1 for t in data if not t.get("error"))
+    print(f"\nOK -> {a.out}: {ok}/{len(data)} tipos, {len(master)} fases distintas")
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/ekyte-task/SKILL.md
+++ b/.claude/skills/ekyte-task/SKILL.md
@@ -1,0 +1,569 @@
+---
+name: ekyte-task
+description: Cria tarefas no Ekyte automaticamente via MCP, com briefing estruturado seguindo o padrão Colli&Co (Oficial). Use quando o Fabio pedir "criar/subir/abrir tarefa(s) no ekyte" — em texto livre ("quero 5 criativos ads pro Cliente I com foco em remarketing") OU apontando aba da planilha de demandas. Sempre mostra preview antes de disparar e bloqueia criação fora dos 8 workspaces conhecidos sem confirmação explícita.
+area: ekyte
+author: fabio
+version: 1.0.0
+user-invocable: true
+---
+
+# /ekyte-task — Criar tarefas no Ekyte com briefing estruturado
+
+Sobe tarefas no Ekyte via MCP `ekyte`, com briefing oficial puxado do próprio ekyte e título no formato `[NN][SIGLA][IA] Cliente | Demanda`. Substitui o trabalho manual de 15 min por task por preview + 1 confirmação.
+
+## Quando usar
+
+Use quando o Fabio:
+- Disser "cria/sobe/abre uma task no ekyte de [tipo] pro [cliente]"
+- Pedir lote de tasks ("sobe 5 criativos pro Cliente A")
+- Falar "tá na aba [nome] da planilha de demandas, sobe tudo"
+- Mencionar `/ekyte-task` ou `ekyte-task`
+
+**Não use** quando o pedido é só consultar dados do ekyte (listar projetos, listar workspaces) — a MCP `ekyte` cobre direto sem precisar dessa skill.
+
+## Pré-requisitos
+
+- MCP `ekyte` configurada em `~/.claude/mcp.json` (já está)
+- `clientes/_skill-ekyte/cache.md` — IDs de workspaces, projetos e tipos
+- `clientes/_skill-ekyte/sla.md` — tabela de prazos por tipo
+- `clientes/_skill-ekyte/flows.md` — **fluxo (fases) por tipo de tarefa** + dicionário `nome da fase → phaseId`. Usado pra mostrar o fluxo e pra trocar o responsável de uma etapa (passos 4.5 e 9.6).
+
+## Os dois MCPs do Ekyte (a partir de 2026-06)
+
+Há **dois servidores MCP do Ekyte** em `~/.claude/mcp.json`:
+
+| Servidor | Prefixo | Uso nesta skill |
+|---|---|---|
+| `ekyte` (n8n) | `mcp__ekyte__*` | **Criação principal** via `create_task` com `situation=10` — cria já Ativa, sem gerar-tarefas REST. Também leitura, BI e edições pós-criação (`update_task`, `update_task_tags`, etc.). **Desde 2026-06-11 é o api.ekyte.com oficial, não mais n8n.** |
+| `ekyte-oficial` (`api.ekyte.com`) | `mcp__ekyte-oficial__*` | Fallback/alternativo para operações não cobertas pelo prefixo `ekyte`. Token fixo na URL, não expira por uso. |
+
+Regra prática: **usar `mcp__ekyte__create_task` com `situation=10`** para criar tasks Prisma — tarefa nasce Ativa diretamente, passo 9.5 (generate-tasks REST) é desnecessário. Para edição pós-criação (mover fase, trocar executor, aplicar tags), usar as tools `mcp__ekyte__update_*`.
+
+**`phaseId` em `create_task`** pode ser qualquer fase do fluxo — não precisa ser Backlog. Usar a fase destino diretamente quando a task deve entrar já em Design (82181) ou outra fase avançada, ex: `phaseId: 82181, executorId: <andré>` com `phaseDueDate: hoje`.
+
+## Fluxo ponta a ponta do cliente até a task briefada
+
+A `/ekyte-task` é a ponta operacional da esteira: ela cria, ativa, ajusta e tagueia a tarefa no Ekyte. Para a task sair realmente briefada, ela deve se apoiar nas skills de base, contexto, NotebookLM e cache. Use este mapa quando o Fabio perguntar "qual fluxo usar" ou quando um cliente novo ainda não tem base suficiente.
+
+### Esteira ideal
+
+```text
+/novo-cliente
+-> /account-handoff
+-> /account-pesquisa-profunda-cliente
+-> /contexto
+-> /notebooklm-cadastrar, se faltar NotebookLM
+-> /ekyte-refresh
+-> /ekyte-briefing-refresh
+-> /ekyte-task
+   -> /ekyte-briefing
+      -> /cs-notebooklm-consulta-cliente
+   -> preview obrigatório
+   -> criar task
+   -> ativar task
+   -> aplicar responsáveis por etapa, se pedidos
+   -> aplicar tags finais
+```
+
+### Como cada skill soma
+
+- `/novo-cliente`: cria a pasta do cliente em `clientes/<cliente>/` com `CLAUDE.md`, `AGENTS.md`, `links.md`, `.env`, `calls/`, `checkins/`, `docs/` e `campanhas/`. Pode cadastrar NotebookLM, Drive, site e links úteis já na criação.
+- `/account-handoff`: primeira leitura da transição vendas → operação. Consome form de kickoff, transcript da reunião comercial e proposta opcional para gerar KB preliminar, riscos, promessas, perguntas de kickoff, Mission Control preliminar e deck HTML.
+- `/account-pesquisa-profunda-cliente`: depois que existem dados internos mínimos, consolida esses dados e entrega prompts para Gemini Deep Research sobre cliente, setor, consumidor e concorrência. Entra antes de demandas de copy, campanha, LP e posicionamento.
+- `/contexto`: consolida a KB local do cliente. Lê `calls/`, `docs/`, `campanhas/`, `links.md` e atualiza `CLAUDE.md`, `AGENTS.md` e `mission-control/`.
+- `/notebooklm-cadastrar`: adiciona ou troca o bloco `## NotebookLM` no `CLAUDE.md` de clientes existentes. Destrava `/cs-notebooklm-consulta-cliente` e, por consequência, `/ekyte-briefing`.
+- `/ekyte-refresh`: atualiza `clientes/_skill-ekyte/cache.md` e `flows.md` com workspaces, projetos do trimestre, tipos de tarefa e fases. Destrava `workspace_id`, `project_id`, `task_type_id` e overrides de fase.
+- `/ekyte-briefing-refresh`: atualiza `drives.md` e `backups-crm.md`, usados pela `/ekyte-briefing` para preencher links de Drive e planilhas de CRM.
+- `/cs-notebooklm-consulta-cliente`: consulta o NotebookLM do cliente com até 5 perguntas direcionadas, salva artefato em `clientes/<cliente>/contexto-notebook/` e devolve síntese executiva.
+- `/ekyte-briefing`: monta o briefing rico da task com template por sigla, Drive, NotebookLM, cache de público e perguntas ativas. Não cria task; devolve `briefing_ekyte_text` em HTML rico para o Ekyte.
+- `/ekyte-task`: resolve cliente/projeto/tipo/SLA/título, chama `/ekyte-briefing`, mostra preview, cria a task, ativa no Ekyte, corrige etapa se necessário, aplica tags e atualiza cache.
+
+### Regra prática
+
+Se o cliente ainda é novo ou pouco documentado, não trate `/ekyte-task` como primeiro passo. Primeiro criar ou consolidar a base do cliente, cadastrar NotebookLM/Drive, atualizar caches do Ekyte e só então subir a tarefa.
+
+Sem essa fundação, a skill ainda consegue criar uma task, mas a entrega tende a virar "pedido preenchido". Com a cadeia completa, a task nasce com contexto, público, objetivo, referências, riscos e guardrails.
+
+## Fluxo
+
+### 0) Pre-fly check (obrigatório em lotes ≥ 3 tasks)
+
+**Antes** de carregar cache, ler input ou montar preview, fazer um varredura de pendências e reportar TUDO numa mensagem só. Em lotes a maior perda é round-trip — uma pergunta de cada vez transforma 5 min de trabalho em 30 min de chat.
+
+**Princípio chave (lição 2026-05-05):** Fabio responde "pode seguir" pra listas de perguntas abertas — ele delega defaults. Em vez de fazer 5 perguntas, **propor defaults razoáveis inline** e pedir só "confirma ou ajusta?". Bloquear de verdade só pra coisas SEM default seguro.
+
+Checar e propor:
+1. **NotebookLM cadastrado** pra cada cliente do lote: `ls clientes/<x>/CLAUDE.md` + grep `## NotebookLM`. **SEM default automático** — se faltar, listar e perguntar: "Cliente D e Cliente F não têm NotebookLM cadastrado. Quer cadastrar agora, ou o gerente de projetos autoriza seguir sem NotebookLM?". Só seguir sem NotebookLM com comando explícito do gerente de projetos.
+2. **Quantificação implícita**: se algum item menciona "X por produto", "todos os produtos", "fotos da categoria Y" ou similar — **SEM default seguro** — perguntar explícito: "Essas linhas de fotos viram 1 task com lote de N peças, ou quer que cada linha vire `[N×SKUs]` no título?"
+3. **Workspaces fora dos 8 fixos**: **SEM default** — bloquear até confirmação explícita.
+4. **Tipos com sigla ambígua** (CA, CJ, GP, MT, AUX, CRM, PMM, RI, SM, EV): **PROPOR default** baseado no contexto da demanda ("vou usar `34435` Configuração de CRM — match óbvio pra Chatwoot. Confirma ou ajusta?"). Não listar as 12 variantes pedindo escolha.
+5. **SLA dos tipos sem entrada** na tabela: **PROPOR default** ("AN sem SLA tabelado — vou usar 3 dias úteis. Ok?"). Não perguntar aberto.
+6. **Quantidade [NN] quando o lote indica claramente 1-task-1-entrega**: **PROPOR `[01]` direto** sem perguntar.
+
+Formato preferido do pre-fly:
+```
+Vou seguir com defaults razoáveis:
+- #X → tipo Y (justificativa de 1 linha)
+- #Z → SLA W (justificativa)
+Bloqueando só em: [item sem default seguro]
+Confirma ou ajusta?
+```
+
+Sair desse passo só com **uma resposta consolidada** do Fabio (pode ser só "pode seguir").
+
+### 1) Carregar contexto (sempre)
+
+Logo no início, ler:
+1. `clientes/_skill-ekyte/cache.md` — workspaces, projetos descobertos, tipos
+2. `clientes/_skill-ekyte/sla.md` — SLA por sigla
+3. `clientes/_skill-ekyte/flows.md` — fases por tipo + `nome da fase → phaseId` (carregar só quando o Fabio especificar responsável por etapa ou pedir o fluxo)
+
+Não chamar a MCP do ekyte sem antes consultar o cache.
+
+### 2) Identificar o modo de input
+
+**Modo A — texto livre no chat:**
+Exemplos:
+- "cria uma task de criativos ads pro Cliente A com foco em remarketing produto X, 6 peças"
+- "sobe 3 LPs pro Cliente C: blackfriday, prospect, retorno"
+- "preciso de uma publicação de campanha pra Cliente E amanhã"
+
+Extrair:
+- **Cliente** (alias → workspace_id via cache)
+- **Sigla/tipo** ("criativos ads" → CA → 29740)
+- **Quantidade [NN]** ("3 LPs" → 03; default 01 se não especificado)
+- **Demanda específica** (parte que vira o título depois do `|`)
+- **Prazo** (default = SLA da tabela; sobrescrever se usuário disser "urgente", "amanhã", "X dias")
+
+**Modo B — aba da planilha:**
+Quando o Fabio disser "tá na aba `<nome>`" ou similar, ler:
+- URL: `https://docs.google.com/spreadsheets/d/1SAWHbC3dog5_IrwCYY1_buF5yGtV_lMTiXL_v9iGrns/edit`
+- Usar WebFetch com prompt pedindo: "lista todas as linhas da aba `<nome>` com colunas sequencial, titulo, data inicio, data entrega, tipo de tarefa (id), email executor, esforço, descricao, Qtd Peças, Tags, Fase"
+- Cada linha vira 1 task. A planilha já tem o `task_type_id` numérico, datas em ISO, email do executor — **não precisa inferir IDs**.
+
+### 3) Resolver workspace e projeto
+
+**Workspace:**
+- Procurar o cliente no cache (8 fixos + apelidos + workspaces internos)
+- Se ambíguo (ex: usuário disse só "Cliente B" mas cache tem variações): perguntar qual
+- Se não estiver nos 8 fixos NEM nos internos conhecidos: PARAR e pedir confirmação explícita ("Esse cliente não está na sua lista habitual. Confirma criar mesmo?"). **Workspaces internos recorrentes** (V4 Company / Billions Timesheet, qualquer setup interno V4 que o Fabio usa toda semana) ficam no cache na seção "Workspaces internos" e NÃO disparam essa confirmação.
+
+**Projeto (Q vigente):**
+- Padrão de nome: `<Cliente> | Q2/2026` (Q2 ativo até virar trimestre)
+- Se já tem `project_id` no cache para esse workspace + período: usar
+- Se não tem: marcar `projeto_novo: true` no pacote da task, chamar MCP `ekyte.listar_projetos_tool` com `workspace_id`, `created_from` = início do trimestre, `created_to` = fim do trimestre. Encontrar projeto cujo nome contém `Q2/2026`. Salvar no cache.
+- Se aparecer >1 match: perguntar qual
+
+**Regra de projeto novo:** quando o `project_id` não estava no cache no início do fluxo, tratar como projeto novo para a geração do briefing. Projeto novo **sempre** exige fluxo formal `/ekyte-briefing` + `/cs-notebooklm-consulta-cliente`; não usar modo inline rápido, briefing manual, nem script que não tenha síntese NotebookLM por task/cliente.
+
+### 4) Resolver tipo de tarefa (sigla → task_type_id)
+
+- Se o Fabio falou em palavras ("criativos ads"): mapear pra sigla (CA) e buscar no cache.
+- Se a sigla tem 1 só ID: usar.
+- Se a sigla tem múltiplos (CA, CJ, GP, MT, AUX, CRM, PMM, RI, SM): **desambiguação obrigatória** — listar opções e perguntar qual.
+- Se não achar a sigla no cache: chamar `ekyte.listar_tipos_de_tarefas_tool({"name_type_task": "<termo>", "parameters1_Value": "3535"})` (workflow Padrão Colli&Co), filtrar resultado, perguntar.
+
+**Caso especial WEB:** se o pedido é "demanda web", usar o título com `[WEB]` no slot da sigla. Tipo de tarefa = "Personalizada". Se ainda não temos `task_type_id` da Personalizada no cache, perguntar ao Fabio qual ID usar e salvar.
+
+### 4.5) Fluxo da tarefa e responsável por etapa
+
+Cada tipo tem um **fluxo de fases** (ex: CA = Briefing → Copywriter → Designer → … → Monitoramento), e cada fase tem um **executor default** que vem do tipo/workspace. Por padrão **não mexemos nisso** — a task nasce com os executores default do tipo. Só agimos quando o Fabio **especifica** um responsável pra uma etapa.
+
+- **De onde vem o fluxo:** `clientes/_skill-ekyte/flows.md` lista, por sigla, as fases reais (com `phaseId`) em ordem, mais um dicionário mestre `nome da fase → phaseId`. O `phaseId` é global (compartilhado entre tipos: `1`=Briefing, `5`=Copywriter, `6`=Designer…). Se o tipo não estiver no `flows.md` (ou aparecer como "sem fases de esforço"), buscar em runtime com `mcp__ekyte-oficial__get_task_type_flow({"id": <task_type_id>})` e filtrar as fases com `effort`/`duration > 0`.
+
+- **Quando o Fabio especifica responsável por etapa** — gatilhos como "o briefing fica com a Marina", "design com o João", "copy com fulano", "manda pro Pedro na publicação". Capturar isso como uma lista de overrides `{fase → pessoa}` por task. Resolver:
+  - **fase → phaseId**: match (case-insensitive, parcial) no fluxo do tipo em `flows.md`. Se ambíguo (ex: "aprovação" casa com várias), perguntar qual.
+  - **pessoa → userId (GUID)**: `mcp__ekyte-oficial__list_all_users_with_profile({"textSearch": "<nome>"})`. Se >1 match, desambiguar. Guardar o GUID.
+
+- **Não aplicar agora** — só registrar os overrides. A troca de executor acontece **depois** da criação+ativação, no passo 9.6 (o `update_task_executor` precisa da task já existindo). Mostrar os overrides no preview (passo 8).
+
+Se o Fabio **não** falar nada de responsável por etapa, pular 4.5 e 9.6 inteiros — comportamento idêntico ao de antes.
+
+### 5) Montar o título
+
+```
+[NN][SIGLA][IA] Cliente | Demanda específica
+```
+
+Onde:
+- `NN` = quantidade em 2 dígitos (`01`, `09`, `15`)
+- `SIGLA` = sigla do tipo (CA, LP, PC, RV, GP…) ou `WEB` para personalizadas
+- `[IA]` = sempre, marca que foi gerada via skill
+- `Cliente` = nome curto do cliente (sem `[BILLIONS]`, sem brackets)
+- `Demanda específica` = parte livre, descritiva
+
+Exemplos:
+- `[09][CA][IA] Cliente A | Remarketing produto X`
+- `[01][LP][IA] Cliente C | Página obrigado transceivers`
+- `[03][WEB][IA] Cliente B | Ajustes header e footer site institucional`
+
+### 6) Montar o briefing (description) — **delegado pra `/ekyte-briefing`**
+
+A partir de 2026-04-30, a montagem de briefing é responsabilidade da skill `/ekyte-briefing`. Esta skill (`/ekyte-task`) **não** monta mais o `description_create_task` por conta própria.
+
+**Regra obrigatória a partir de 2026-06-15:** toda task criada pela `/ekyte-task` precisa passar pelo fluxo formal `/ekyte-briefing`. A consulta `/cs-notebooklm-consulta-cliente` é o **default obrigatório** para toda tarefa que não estiver na whitelist operacional abaixo. Não decidir pela quantidade de texto da OBS, pelo tipo de projeto ou por parecer uma demanda simples: se não estiver explicitamente isenta, consulta NotebookLM.
+
+**Whitelist operacional sem NotebookLM:**
+- Otimização de campanhas recorrente.
+- Atualização de Growth Pack/GrowthPack recorrente.
+- Apontamento de horas/timesheet.
+- Atendimento/comunicação recorrente de rotina.
+- Envio recorrente de NPS/CSAT.
+- Atualização administrativa interna recorrente, sem decisão estratégica e sem necessidade de contexto do cliente.
+
+**Regra de dúvida:** se houver qualquer componente de análise, criação, implementação, tracking, CRM, automação, projeção, campanha, público, pesquisa, planejamento ou decisão sobre o cliente, **não é exceção** e deve consultar NotebookLM. Projeto novo continua exigindo consulta mesmo que a descrição pareça operacional. Se faltar NotebookLM, login ou resposta válida numa tarefa não isenta, parar antes do preview de criação e pedir decisão: cadastrar/corrigir NotebookLM ou o gerente de projetos autorizar explicitamente seguir sem NotebookLM.
+
+**Como invocar:** depois de resolver workspace, projeto, sigla e tipo (passos 3-4), montar o pacote de entrada e chamar `/ekyte-briefing`:
+
+```json
+{
+  "cliente": "Cliente A",
+  "cliente_alias": "cliente-a",
+  "sigla": "CA",
+  "task_type_name": "Criativo Ads",
+  "task_type_id": "29740",
+  "qtd": 9,
+  "titulo": "[09][CA][IA] Cliente A | Remarketing produto X",
+  "input_livre": "<input original do Fabio>",
+  "modo": "texto_livre",          // ou "planilha_demandas" ou "5w1h"
+  "projeto_novo": false,
+  "notebook_obrigatorio": true,   // false somente para whitelist operacional
+  "motivo_isencao_notebook": null,
+  "planilha_5w1h_url": null,
+  "planilha_demanda_row": null    // preenchido se modo=planilha_demandas
+}
+```
+
+A `/ekyte-briefing` faz: carrega template da sigla, lê Drive em `drives.md`, consulta o NotebookLM quando `notebook_obrigatorio: true`, faz perguntas ativas em lote ao Fabio, monta briefing em Markdown e converte para HTML rico aceito pelo Ekyte. Quando `notebook_obrigatorio: false`, registra a isenção e monta o briefing com a descrição operacional, links de rotina e caches aplicáveis.
+
+**Devolve:**
+```json
+{
+  "briefing_ekyte_text": "<div><strong>Tarefa:</strong> ...</div><div><br></div>...",
+  "briefing_markdown": "BRIEFING — ...",
+  "campos_pendentes": [],
+  "notebook_consultado": true,
+  "notebook_isento": false,
+  "notebook_artefato": "clientes/cliente-a/contexto-notebook/2026-04-30-1015-...md"
+}
+```
+
+A `/ekyte-task` injeta `briefing_ekyte_text` direto em `description_create_task`/`description` na chamada de criação. **Não converter para texto plano e não remover HTML**.
+
+**Importante (atualizado 2026-06-15):** o padrão atual de briefing no Ekyte é HTML rico simples. Seções principais devem virar `<div><strong><span style="font-size: 18px;">HEAD</span></strong></div>`, labels devem virar `<strong>Label:</strong>` no tamanho normal, links devem usar `<a>`, e listas devem usar `<ul><li>`. Não usar Markdown bruto nem `<h1>/<h2>`. CSS inline só é permitido nas heads para aumentar fonte. Se a API quebrar acentos, preferir texto ASCII dentro do HTML.
+
+**Modo planilha de demandas (Modo B antigo):** quando o input vem da aba da planilha (`https://docs.google.com/.../edit`), a `/ekyte-task` extrai a linha (`descricao`, `task_type_id`, `email`, etc) e passa pra `/ekyte-briefing` com `modo: "planilha_demandas"` + `planilha_demanda_row` preenchido. Se a coluna `descricao` for substancial, a `/ekyte-briefing` usa como base e enriquece via NotebookLM. Se for vazia/genérica, monta do template normal.
+
+**Modo 5W1H:** quando Fabio menciona link de planilha 5W1H ("plano de ação"), passar `modo: "5w1h"` + `planilha_5w1h_url`. A `/ekyte-briefing` valida o cabeçalho e usa layout 5W1H.
+
+### 7) Calcular prazo e datas de etapa
+
+Consultar `sla.md`:
+- Tipo na tabela → `current_due_date_create_task` = hoje + SLA
+- Tipo NÃO na tabela → perguntar no preview, ou usar default genérico (3 dias úteis) se o usuário disser "padrão"
+- Usuário disse "urgente" / "amanhã" / data específica → sobrescrever
+
+`phase_start_date_create_task` = sempre hoje.
+
+**Regra crítica de datas no Ekyte (aprendizado 2026-06-02):**
+
+- Task nova nunca pode nascer atrasada.
+- O SLA entra no campo **"Concluir tarefa até"** (`current_due_date_create_task`).
+- A etapa atual precisa ficar com **"Executar etapa até" = data de subida** (hoje), mesmo quando a tarefa tem SLA longo.
+- Depois de criar e rodar "Gerar tarefas", conferir a resposta/listagem: se a etapa atual apareceu atrasada ou com data anterior a hoje, corrigir antes de encerrar. O Ekyte pode redistribuir fases para trás a partir do prazo final em tipos como LP/CA; não aceite esse estado como final.
+
+### 8) Preview obrigatório
+
+Antes de chamar `criar_tarefa_tool`, mostrar pra Fabio:
+
+```
+📋 PREVIEW — Task #1 de N
+
+Workspace: Cliente A (id: 999001)
+Projeto: Cliente A | Q2/2026 (id: <X>)
+Tipo: [CA] Criativo Ads (id: 29740)
+Responsável: seu.usuario@v4company.com
+Início: 2026-04-28
+Prazo: 2026-05-09 (SLA CA = 11 dias)
+
+Título: [09][CA][IA] Cliente A | Remarketing produto X
+
+Briefing:
+<<resumo do briefing — primeiras 5 linhas>>
+[ver completo abaixo]
+
+Responsável por etapa (só quando especificado — passo 4.5):
+  • Briefing (#1) → Marina Souza
+  • Designer (#6) → João Pedro
+  (demais fases ficam com o executor default do tipo)
+
+Após criação: vou disparar `generate-tasks` no projeto pra
+sair de "Não planejada" → "Ativa" automaticamente (passo 9.5),
+e trocar o executor das etapas acima (passo 9.6).
+
+---
+
+Confirma criação + geração? (sim/não/editar)
+```
+
+Se for lote (modo B com planilha): mostrar tabela resumida (linha | título | tipo | prazo) e pedir aprovação **única** pro lote, OU "1 a 1" se o Fabio preferir.
+
+**Nunca** dispara `criar_tarefa_tool` sem ver o "sim".
+
+### 8.4) Modo Inline Rápido — desativado como bypass de briefing
+
+O modo inline rápido antigo **não pode mais pular** `/ekyte-briefing`. Quando lote é **3-5 tasks** + a coluna `OBS/Descrição` da planilha já tem texto substancial (objetivo claro, link de transcrição/referência), usar isso como `planilha_demanda_row.descricao` e chamar `/ekyte-briefing` normalmente com `modo: "planilha_demandas"`.
+
+Regra prática:
+- Lote ≤5 + OBS substancial + cliente conhecido → `/ekyte-briefing` formal, usando a OBS como base e enriquecendo via NotebookLM/cache.
+- Lote ≤5 + OBS vazia/genérica OU cliente/projeto novo → `/ekyte-briefing` formal obrigatório, tentando `/cs-notebooklm-consulta-cliente`; seguir sem NotebookLM só com autorização explícita do gerente de projetos.
+- Lote ≥6 → modo script Python (8.5), mas o script só pode gerar textos depois que a síntese NotebookLM da `/ekyte-briefing` existir para cada cliente/linha relevante.
+
+Motivo: briefing de task Ekyte não pode nascer só da OBS ou de interpretação manual quando existe NotebookLM do cliente. A OBS acelera o preenchimento; ela não substitui consulta.
+
+Validado em 2026-05-05 com lote de 5 tasks (Cliente C x2 + Cliente D x3): 5 criações em paralelo, ~30s.
+
+#### 8.4.1) Público vem do cache persistente, mas não substitui briefing
+
+Lição 2026-05-14: a v1 do modo inline pulava NotebookLM totalmente — campo público acabava saindo "a consultar" ou genérico. Conflito direto com a regra [public sempre vem do NotebookLM](../../../memory/feedback_publico_notebook.md).
+
+**Resolução:** a `/ekyte-briefing` consulta `clientes/<cliente>/publicos-cache.md` antes de montar briefing. Layout e TTL: ver [_publicos-cache-template.md](../../../clientes/_skill-ekyte/_publicos-cache-template.md). Cache de público pode evitar repetir pergunta de público, mas não elimina a obrigação de chamar `/ekyte-briefing`; em projeto novo, também não elimina a consulta `/cs-notebooklm-consulta-cliente`.
+
+Fluxo:
+
+1. **Identificar a linha** de cada task do lote (Colchões adultos / Cliente A Baby / Geral / etc).
+2. **Para cada linha distinta no lote**, abrir o cache uma vez:
+   - **HIT** (< 75d) → usa direto para público. O briefing formal ganha bloco "Público" preenchido (avatar + faixa + sexo + consciência + ganchos) com marcador `[do cache: <linha> · <N>d]`. Se `projeto_novo: true`, ainda consultar NotebookLM para contexto geral da task.
+   - **STALE** (75-90d) → pergunta no pre-fly: `⚠️ cache de público da linha "Cliente A Baby" tem 78d. Atualizar antes do lote? (sim/não)`. Sem resposta = HIT silencioso.
+   - **MISS** (≥ 90d OU inexistente) → invocar `/cs-notebooklm-consulta-cliente` **uma única vez por linha do lote**, com 1 pergunta dirigida só de público (não as 5 padrão). ~1min/linha. Após resposta, escrever bloco no cache.
+3. **Não consultar NotebookLM mais de uma vez por linha por lote.** Se 4 tasks são todas "Colchões adultos", consulta roda 1x (no MISS) e as 4 reusam.
+
+Quando MISS rola, o cache populado fica disponível pras próximas sessões — paga o investimento em 2-3 lotes. Mesmo com cache, a saída final precisa vir da `/ekyte-briefing`.
+
+### 8.5) Modo Lote — script Python (≥6 tasks)
+
+Quando o lote for ≥6 tasks, montar briefing na chat custa contexto e fica frágil. **Default a partir de 6:** gerar os textos via script Python parametrizado, mas somente depois de rodar `/ekyte-briefing` e obter síntese NotebookLM por cliente/linha relevante. O script reaproveita a síntese e os templates; ele não substitui a consulta.
+
+Estrutura recomendada:
+1. Criar pasta de trabalho `<workspace_user>/briefings-ekyte-<YYYY-MM-DD>/`.
+2. Escrever `gerar_briefings.py` que define funções reaproveitáveis por padrão de demanda (ex: `web_pdp(cliente, ws_id, proj_id)`, `fotos(filename, qtd_por_sku, total_skus, ...)`) e chama essas funções pra cada task. Saída: 1 `.docx` por task (use `python-docx`).
+3. Escrever `extrair_textos.py` que converte os .docx em HTML rico simples para Ekyte (`<div>`, `<strong>`, `<span style="font-size: 18px;">` somente em heads, `<a>`, `<ul>`, `<li>`; sem `<h1>/<h2>`). **Pular o bloco "Metadados (Ekyte)"** — esses dados já vão nos campos próprios da MCP. Salva tudo num `_briefings_textos.json` chave→HTML.
+4. Disparar as MCP `criar_tarefa_tool` em paralelo (várias por mensagem) com `description_create_task` lendo do JSON gerado a partir da síntese aprovada.
+
+Vantagens medidas (lote de 25 em 2026-05-04):
+- Estrutura uniforme (toda task cobre Objetivo / Contexto / Escopo / Entregáveis / Perguntas / Referências).
+- Reaproveitamento de padrão (8 fotos Cliente A = 1 função × 6 chamadas, não 6 briefings escritos à mão).
+- Os .docx ficam de subproduto pro Fabio revisar antes do disparo se quiser.
+
+### 9) Chamar a MCP
+
+Após confirmação, chamar `ekyte.criar_tarefa_tool` com os 8 campos:
+
+```json
+{
+  "workspace_id_create_task": "999001",
+  "ctc_task_type_id_create_task": "29740",
+  "user_email_create_task": "seu.usuario@v4company.com",
+  "title_create_task": "[09][CA][IA] Cliente A | Remarketing produto X",
+  "description_create_task": "<HTML rico formatado do briefing>",
+  "current_due_date_create_task": "2026-05-09",
+  "ctc_task_project_id_create_task": "<id do projeto>",
+  "phase_start_date_create_task": "2026-04-28"
+}
+```
+
+Reportar sucesso/erro de cada criação. Se erro: parar, mostrar a mensagem, não tentar a próxima sem aprovação.
+
+### 9.5) Gerar tarefas (sair de "Não planejada" → "Ativa") — revisado 2026-06-17
+
+> **Quando pular este passo:** se a task foi criada via `mcp__ekyte__create_task` com `situation=10`, ela já nasce Ativa — este passo inteiro pode ser ignorado. Confirmar com `list_tasks` filtrando `situation=10` se houver dúvida.
+
+O passo abaixo é necessário apenas quando a criação foi feita pelo fluxo legado n8n (`criar_tarefa_tool`), que cria a task como **"Não planejada"** e exige ativação project-level via REST.
+
+**Após ativar, validar datas de etapa:** na resposta do `generate-tasks` ou em listagem posterior, toda task criada nesta execução precisa ter a etapa atual sem atraso. A coluna **"Executar etapa até"** deve ser hoje (data da subida). A coluna **"Concluir tarefa até"** deve seguir o SLA/prazo final. Se o Ekyte gerar fase inicial no passado, corrigir imediatamente via ferramenta/API de edição de task/fase antes de finalizar o relatório.
+
+> **Nota (MCP oficial):** o servidor `ekyte-oficial` expõe `create_task` com `situation=10` (cria já Ativa) e `update_task_phase` (move uma task específica de fase). Não substituem o "Gerar tarefas" project-level — são alternativas por-task que exigem montar o `flow`/`phaseId` na criação. Por ora mantemos a criação via `ekyte` (n8n) + ativação REST; o oficial fica como caminho de **edição/correção** pós-criação. Reavaliar migrar a criação inteira pro oficial quando o `flow` estiver mapeado no cache.
+
+**Endpoint:**
+```
+POST https://api.ekyte.com/api/v2/companies/{company_id}/projects/{project_id}/generate-tasks
+Headers:
+  Authorization: Bearer <EKYTE_TOKEN>
+  Content-Type: application/json
+Body: []
+```
+
+**Atenção ao body:** é **array vazio `[]`**, não objeto `{}`. Mandar `{}` retorna 422 com `"requires a JSON array"`. O backend é .NET e desserializa em `System.Int64[]`. `[]` ativa **todas** as "Não planejadas" do projeto de uma vez — não é por-task, é por-projeto.
+
+**Pegadinha crítica do 500 (descoberta 2026-05-16):** se o projeto **não tem mais tasks "Não planejada"** (já foram ativadas manualmente OU outra chamada generate-tasks rodou antes), o endpoint retorna **HTTP 500 com body vazio** — não 200, não 204, não erro descritivo. Isso **não é erro de verdade**, é "nada pra ativar". Sempre validar via listagem antes/depois.
+
+**Implementação no fluxo (sempre seguir nesta ordem):**
+
+1. **Pré-check via MCP — task já está ativa?**
+   Pra cada task criada no passo 9, chamar `listar_tarefas_tool` com:
+   - `project_id` = projeto da task
+   - `created_from` / `created_to` = data de hoje
+   - `status_list_task` = `10` (ativas)
+
+   Se a task aparece na resposta com `situation: 10`, ela **já está ativa** — outro fluxo (Fabio manual, ou generate-tasks anterior do lote) já cuidou. **Pular essa task silenciosamente.** Não chamar o REST.
+
+2. **Ler `clientes/_skill-ekyte/.env`** (formato em `.env.example`). Se arquivo não existe, avisar Fabio:
+   ```
+   ⚠️ clientes/_skill-ekyte/.env não cadastrado. Tasks criadas vão ficar como
+   'Não planejada' até você gerar manualmente no Ekyte.
+
+   Pra cadastrar o token (~3 min):
+   1. F12 em app.ekyte.com → aba Network → no filtro digita 'api.ekyte'
+   2. Clica em "Gerar tarefas" em qualquer projeto (força uma request real)
+   3. Na request POST que aparece, aba Headers → copia o valor de
+      'authorization: Bearer eyJhbGc...'
+   4. Cola só o JWT (sem 'Bearer ') em EKYTE_TOKEN= no .env
+
+   Quer cadastrar agora? (sim/não)
+   ```
+   Se "não", pular passo 9.5 inteiro e seguir pro 10. **Não insistir** depois — Fabio sabe que pode gerar manual no Ekyte web.
+
+3. **Agrupar tasks criadas (que ainda não estão ativas) por `ctc_task_project_id_create_task`**. Lote de 5 tasks em projetos diferentes = até 5 chamadas; 10 tasks todas no mesmo Q2 do Cliente A = 1 chamada.
+
+4. **Pra cada `project_id` único**, disparar:
+   ```bash
+   curl -X POST "$EKYTE_API_BASE/companies/$EKYTE_COMPANY_ID/projects/<project_id>/generate-tasks" \
+     -H "Authorization: Bearer $EKYTE_TOKEN" \
+     -H "Content-Type: application/json" \
+     -H "Origin: https://app.ekyte.com" \
+     -H "Referer: https://app.ekyte.com/" \
+     -d '[]'
+   ```
+
+5. **Tratamento de resposta:**
+   - **200 OK** → reportar `✅ Projeto <nome> ativado`. Re-listar via MCP só pra confirmar contagem.
+   - **500 com body vazio** → **não é erro de verdade.** Provavelmente projeto não tinha mais "Não planejada" no momento da chamada (Fabio gerou em paralelo via UI, ou já foi ativado). Re-listar via MCP `listar_tarefas_tool` filtrando o `project_id` + criadas hoje + `status_list_task: 10`. Se a task aparece ativa, reportar `✅ Projeto <nome>: tasks já ativas (500 é falso erro do Ekyte quando não há "Não planejada")`. Se não aparece, aí sim é erro real — escalar.
+   - **401 Unauthorized** → token expirou. Avisar:
+     ```
+     ❌ Token EKYTE_TOKEN expirou. As tasks foram criadas mas ficaram como 'Não planejada'.
+
+     Renovar (~2 min):
+     1. F12 em app.ekyte.com → Network → filtro 'api.ekyte'
+     2. Clica em "Gerar tarefas" em qualquer projeto
+     3. Copia o header 'authorization: Bearer eyJhbGc...' da request POST
+     4. Cola só o JWT (sem 'Bearer ') em EKYTE_TOKEN= no .env
+
+     Token NÃO está em localStorage — só vem via Network durante interação real.
+     ```
+     Não tentar refresh automático.
+   - **Outros erros** → reportar status + body, não interromper outras chamadas, avisar no relatório final.
+
+6. **Relatório consolidado** após todas as chamadas:
+   ```
+   ✅ 4 tasks criadas
+   ✅ Ativas: Cliente A | Q2/2026 (2 tasks), Cliente C | Q2/2026 (2 tasks)
+   ```
+
+   Se alguma falhou de verdade:
+   ```
+   ✅ 4 tasks criadas
+   ✅ Ativas: Cliente A | Q2/2026 (2 tasks)
+   ⚠️ NÃO ativadas: Cliente C | Q2/2026 (2 tasks) — token expirado, renova e retenta
+   ```
+
+**Token TTL:** JWT do Ekyte vale ~180 dias. Quando 401, renovar via Network (NÃO localStorage — Ekyte usa httpOnly cookie + JWT no header só durante requests). Capturar via Console JS / localStorage **não funciona** — única forma é interceptar Network durante ação real na UI.
+
+### 9.6) Trocar responsável de etapa (só se especificado no passo 4.5)
+
+Roda **depois** da criação+ativação (9/9.5), e **só** se o Fabio especificou responsável por etapa. Sem overrides, pular.
+
+Via MCP **oficial** (`ekyte-oficial`) — sem JWT manual, token fixo na URL. Pra cada override `{fase → pessoa}` da task:
+
+1. **Pegar o `taskId` real** da task recém-criada/ativada. Se não tiver em mãos, achar via `mcp__ekyte-oficial__list_tasks` filtrando projeto + criadas hoje + título, ou `get_detailed_task` pra confirmar as fases reais.
+
+2. **Confirmar o `phaseId`** da fase: do `flows.md` (passo 4.5) ou das fases reais da task via `get_detailed_task`. A fase precisa existir no fluxo da task.
+
+3. **Aplicar:**
+   ```
+   mcp__ekyte-oficial__update_task_executor(
+     taskId: <id>,
+     phaseId: <phaseId da fase>,
+     patchDoc: [{"op":"replace","path":"/executorId","value":"<userId GUID>"}]
+   )
+   ```
+   > O schema do `patchDoc` não detalha o campo; o path `/executorId` segue a estrutura do fluxo (`executorId` por fase) e a convenção do `update_task`. **Confirmar no 1º uso** — se a API rejeitar, inspecionar `get_detailed_task` pra ver o nome exato do campo e ajustar este passo + esta nota.
+   > Se a fase for a **etapa atual** da task, o Ekyte troca também o executor corrente da task (comportamento documentado da tool).
+
+4. **Relatório** — somar ao consolidado do 9.5:
+   ```
+   👤 Responsáveis ajustados:
+      • #9342321 Briefing → Marina Souza ✅
+      • #9342321 Designer → João Pedro ✅
+   ```
+   Se uma troca falhar, reportar a fase + erro e seguir as outras (não abortar o lote).
+
+**Guardrail:** nunca trocar executor de fase que o Fabio não pediu. Default do tipo é sagrado — só sobrescrever o que foi explicitamente especificado.
+
+### 9.7) Aplicar somente a tag IA
+
+Ao final de toda criação via `/ekyte-task`, depois de criar, ativar, corrigir datas de etapa e aplicar overrides de responsável, adicionar somente:
+
+- `IA` **em vermelho** (resolver `tagId` pela lista/cache de tags; se houver mais de uma tag `IA`, usar a vermelha)
+
+Regra de aplicação:
+
+1. Resolver o `tagId` da tag `IA` vermelha. Buscar por nome exato `IA` e conferir a cor/metadado visual. Se a tag `IA` existir mas não for vermelha, avisar no relatório e não usar a tag errada. Se não existir tag `IA` vermelha e a API disponível permitir criação/edição de tags, criar/ajustar para vermelho antes de aplicar; se não permitir, pedir ao Fabio para criar a tag vermelha e deixar claro que a task ficou sem essa tag.
+2. Ler as tags atuais da task.
+3. Fazer merge: tags atuais + `IA` vermelha. **Não adicionar `SPRINT GROWTH`, `SEMANA NN` nem qualquer outra tag automática.**
+4. Aplicar a lista completa via MCP oficial `update_task_tags` quando disponível. Se usar REST, endpoint:
+   `PUT /api/v2/companies/{company_id}/ctc-tasks/{task_id}/tags`
+   com body:
+   ```json
+   [{"ctcTaskId": 9500983, "tagId": "<IA_VERMELHA>"}]
+   ```
+
+**Nunca substituir tags preexistentes sem merge.** O endpoint de tags substitui a lista inteira. Em task nova sem tags anteriores, a lista final deve conter somente `IA` vermelha.
+
+### 10) Atualizar cache
+
+Sempre que descobrir um `project_id` novo (ou um `task_type_id` confirmado de tipo Personalizada), atualizar `clientes/_skill-ekyte/cache.md` antes de encerrar. Se descobrir o fluxo de um tipo que não estava em `flows.md` (buscado em runtime no 4.5), salvar lá também. Refresh total dos fluxos: re-rodar o fetch de `get_task_type_flow` por tipo (ainda não embutido no `/ekyte-refresh` — wire pendente).
+
+---
+
+## Guardrails (não-negociáveis)
+
+1. **Lock de cliente por sessão.** Se o Fabio começou trabalhando "Cliente A", não criar tasks em outro workspace sem confirmação explícita ("acabamos com Cliente A, agora estou indo pra Cliente C").
+
+2. **Desambiguação obrigatória** em:
+   - Cliente com >1 match (rara, mas possível com nomes parecidos)
+   - Sigla com >1 task_type_id (CA, CJ, GP, MT, AUX, CRM, PMM, RI, SM)
+   - Projeto com >1 match para o período pedido
+
+3. **Preview obrigatório** antes de cada criação. Sem exceção. Mesmo no modo B em lote, exibir resumo + esperar "ok".
+
+4. **Workspace fora dos 8** → PARAR e pedir confirmação explícita. A conta é master Collie, blast radius alto.
+
+5. **Erro = parar.** Se uma criação falhar (HTTP error, timeout, schema rejeitado), pausar o fluxo e reportar. Não seguir pra próxima task do lote sem aprovação.
+
+6. **Sem auto-execução.** Mesmo que o Fabio diga "confia, manda tudo", insistir no preview da primeira task pelo menos.
+
+7. **Gerar tarefas é parte obrigatória do fluxo.** Toda task criada deve sair de "Não planejada" no final da execução. Se token expirou ou `.env` não existe, **avisar explicitamente** que as tasks ficaram em rascunho — Fabio não pode descobrir isso depois.
+
+8. **Nunca entregar task atrasada.** Antes de encerrar, validar individualmente que nenhuma task criada caiu em "Atrasado". O campo "Executar etapa até" precisa ser a data de criação/subida; o SLA só controla "Concluir tarefa até". Se houver backdating automático do Ekyte, corrigir antes de considerar a execução concluída. Uma task ainda atrasada é falha pendente, não sucesso.
+
+9. **Somente tag IA.** Toda task criada pela skill deve receber somente a tag automática `IA` em vermelho. Não adicionar `SPRINT GROWTH`, `SEMANA NN` ou qualquer outra tag automática. Preservar tags que já existiam na task por merge; em task nova sem tags anteriores, o resultado final é apenas `IA`.
+
+10. **Token Ekyte é sensível.** Nunca logar/imprimir o valor de `EKYTE_TOKEN` nas mensagens pro Fabio (mesmo truncado). Só dizer "token presente/ausente/expirado".
+
+---
+
+## Como invocar
+
+- `/ekyte-task` — usuário chama explicitamente
+- Detectar automaticamente quando o Fabio:
+  - Disser "cria/sobe/abre uma task/tarefa no ekyte"
+  - Mencionar uma sigla `[CA]`, `[LP]`, etc. seguida de cliente
+  - Apontar aba da planilha de demandas pra subida em lote
+
+## O que NÃO fazer
+
+- Não inventar `task_type_id`, `workspace_id` ou `project_id`. Se não está no cache, buscar ou perguntar.
+- Não criar workspace, projeto ou tipo novos por conta própria. Skill v1 só **cria task**, nunca infraestrutura.
+- Não pular o preview, mesmo que o Fabio peça pressa.
+- Não escrever briefing do zero quando o tipo tem template oficial — sempre usar o template e preencher.
+- Não tentar aplicar tag nativa na chamada de criação da MCP — o schema não expõe. Marcar IA pelo título `[IA]` e aplicar a tag `IA` vermelha no pós-criação, via passo 9.7.

--- a/.claude/skills/ekyte-templates-refresh/SKILL.md
+++ b/.claude/skills/ekyte-templates-refresh/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: ekyte-templates-refresh
+description: Atualiza, adiciona ou ajusta os templates de briefing por sigla usados pela `/ekyte-briefing` em `clientes/_skill-ekyte/briefing-templates/`. Use quando o Fabio rodar `/ekyte-templates-refresh`, mencionar que quer "criar template novo" pra uma sigla que ainda não tem (ex: KV, MT, EM, EV), "ajustar o template de CA" pra adicionar/remover seção, ou quando rodar 5 tasks reais e quiser refinar perguntas/campos.
+area: ekyte
+author: fabio
+version: 1.0.0
+user-invocable: true
+---
+
+# /ekyte-templates-refresh — Manutenção dos templates de briefing
+
+Cuida do diretório `clientes/_skill-ekyte/briefing-templates/`. Adicionar sigla nova, ajustar template existente, ou propagar uma melhoria pra múltiplos templates.
+
+## Quando usar
+
+- `/ekyte-templates-refresh` (direto)
+- "cria template pro KV" / "preciso de template pra MT (Motion)"
+- "no template de CA, adiciona pergunta sobre [X]"
+- "remove a seção [Y] do PC"
+- "depois de 5 tasks, quero refinar o template de CA"
+
+## Pré-requisitos
+
+- Diretório `clientes/_skill-ekyte/briefing-templates/` existente, com pelo menos:
+  - `_header-universal.md`
+  - `_base-criativo.md`
+  - `_5w1h.md`
+  - `CA.md`, `LP.md`, `RV.md`, `PC.md`, `AN.md`, `CRM.md`
+
+## Fluxo
+
+### 1) Identificar a operação
+
+```
+O que você quer fazer?
+
+1) Adicionar template novo (sigla que ainda não tem .md)
+2) Ajustar template existente (adicionar/remover/modificar seção ou pergunta)
+3) Atualizar arquivo compartilhado (_header-universal, _base-criativo, _5w1h)
+4) Listar templates atuais (saber o que já existe)
+```
+
+### 2) Modo "Adicionar template novo"
+
+Perguntar:
+- **Sigla** (ex: `MT`, `EM`, `KV`)
+- **Tipo de tarefa** (nome legível, ex: "Motion", "E-mail Marketing")
+- **task_type_id** (puxar do `cache.md` se já existe; se não, perguntar)
+- **Família** (qual base usar):
+  - Criativo (importa `_base-criativo.md`) → CA, LP, RV, KV, MT, EV, DC, DLP, DE, AC, OCA, SM, EM, PAPP, PI, PMS, PPSH, PSMS, PWPP
+  - Operacional (só `_header-universal.md`) → PC, RI, EKT, REL, OVERVIEW
+  - Analítica (só `_header-universal.md`, sem KV) → AN, AUX
+  - CRM/Relacionamento (`_header-universal.md` + bloco extra de infra CRM) → CRM, ACRM, ATM, CB
+  - Outra → criar do zero, perguntar estrutura
+
+Skill propõe um esqueleto baseado na família + perguntas comuns + perguntas específicas que **Fabio** define. Mostra preview do template antes de salvar.
+
+### 3) Modo "Ajustar template existente"
+
+Perguntar:
+- Qual sigla ajustar?
+- Qual tipo de ajuste:
+  - Adicionar seção/pergunta nova
+  - Remover seção/pergunta
+  - Modificar pergunta (texto, opções, default)
+  - Reordenar seções
+
+Mostrar diff (linhas antes/depois) antes de aplicar.
+
+### 4) Modo "Atualizar arquivo compartilhado"
+
+`_header-universal.md`, `_base-criativo.md`, `_5w1h.md`. **Cuidado redobrado** — mudança aqui afeta TODOS os templates que importam.
+
+Avisar: "Esta mudança vai afetar os templates X, Y, Z. Confirma?"
+
+### 5) Modo "Listar templates atuais"
+
+Output:
+```
+📂 Templates em clientes/_skill-ekyte/briefing-templates/
+
+Compartilhados:
+  • _header-universal.md (vai em todo briefing)
+  • _base-criativo.md (CA, LP, RV)
+  • _5w1h.md (modo plano de ação)
+
+Por sigla:
+  • CA.md — Criativo Ads
+  • LP.md — Landing Page
+  • RV.md — Roteiro de Vídeo
+  • PC.md — Publicação de Campanha
+  • AN.md — Análise de Dados
+  • CRM.md — CRM / Relacionamento
+
+Siglas SEM template ainda (cairão no fallback genérico):
+  • KV, MT, EV, EM, OCA, SM, ... (lista do cache.md filtrando os que já existem)
+```
+
+### 6) Salvar e reportar
+
+Diff antes de cada Write/Edit. Após salvar:
+```
+✅ Template atualizado:
+  - clientes/_skill-ekyte/briefing-templates/CA.md (3 linhas adicionadas)
+```
+
+## Guardrails
+
+1. **Diff obrigatório.** Antes de qualquer Write/Edit, mostrar mudanças linha-a-linha.
+2. **Mudança em compartilhado afeta múltiplos.** Listar templates afetados antes.
+3. **Não criar template duplicado** sem confirmação. Se sigla já tem `.md`, perguntar se é pra sobrescrever ou se é variante (ex: `CA-v4s.md` pra task_type_id 37979).
+4. **Manter o padrão de conversão Markdown→HTML.** Toda nova seção precisa seguir as regras: `<div>` por linha, `<strong>` em CAIXA ALTA pra título de seção, sem `<h>`/`<p>`/`<ul>`.
+5. **Validar referências cruzadas.** Se template importa `_base-criativo.md`, ele precisa existir. Se referência sigla mas pula uma seção dela, alertar.
+
+## Como invocar
+
+- `/ekyte-templates-refresh` (direto).
+- "cria template pro [SIGLA]".
+- "ajusta o template de [SIGLA]".
+
+## O que NÃO fazer
+
+- Não tocar em `drives.md` ou `backups-crm.md` (use `/ekyte-briefing-refresh`).
+- Não tocar em `cache.md` (use `/ekyte-refresh`).
+- Não escrever templates sem validar a família primeiro (cliente vai querer brieffar uma analítica como criativo se template estiver errado).
+- Não esquecer da regra de KV: aplicável **só** pra siglas criativas (CA/LP/RV/etc). Templates analíticos/operacionais omitem KV.


### PR DESCRIPTION
## Skills sendo compartilhadas

**Area:** ekyte
**Autor:** @junioraiellogestaodetrafego-maker
**Versao:** 1.0.0

## O que fazem

Pipeline completo de criacao de tarefa no Ekyte:

- `ekyte-task` — orquestra a criacao de tarefas no Ekyte via MCP, com preview obrigatorio e briefing estruturado.
- `ekyte-briefing` — monta o briefing rico (HTML) da task, puxando contexto do NotebookLM do cliente e templates por sigla.
- `ekyte-refresh` — atualiza o cache local (workspaces, projetos do trimestre, tipos de tarefa e fluxos/fases via MCP oficial).
- `ekyte-briefing-refresh` — atualiza os caches de Drive e backup de CRM usados pela `ekyte-briefing`.
- `ekyte-templates-refresh` — mantem os templates de briefing por sigla.

Exemplos de clientes nos SKILL.md foram anonimizados (Cliente A, B, C...) antes do envio, ja que o repositorio e publico.

## Como testar

1. Rode `/sync-hub` pra puxar a branch localmente.
2. Rode `/ekyte-refresh` pra popular o cache, depois `/ekyte-task` descrevendo uma demanda de teste.
3. Valide que o preview aparece antes de qualquer criacao real e que o briefing vem formatado.

## Checklist do contribuidor

- [x] Nome segue prefixo de fonte (`ekyte-*`)
- [x] Frontmatter completo (name, description, area, author, version)
- [x] Duplo-write em .claude/ e .agents/ (conteudo identico)
- [x] Testada em producao ha varias semanas
- [x] Sem credenciais, tokens, clientes reais ou dados pessoais (nomes de clientes anonimizados)
- [x] Portugues brasileiro

---

_Gerado via `/compartilhar-skill`._