### PR TITLE
feat(skills): add gestao-ekyte batch tools (rename, tags)

### DIFF
--- a/.agents/skills/gestao-ekyte-rename-tasks/SKILL.md
+++ b/.agents/skills/gestao-ekyte-rename-tasks/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: gestao-ekyte-rename-tasks
+description: Renomeia títulos de tarefas no Ekyte em lote via MCP oficial (update_task) com fallback PATCH REST. Aceita lista de IDs ou filtro (projeto, workspace, tipo). Operações find-replace (ex: [WEB]→[P&P], V4 Company→V4 Company Colli & Co). Output: relatório com sucessos/falhas por task. Use sempre que precisar renomear múltiplas tasks de uma vez — é muito mais rápido que editar uma por uma na UI.
+area: gestao
+author: fabio
+version: 2.0.0
+---
+
+# Gestão — Renomear Tasks Ekyte em Lote
+
+Edita títulos de múltiplas tarefas no Ekyte em paralelo. Ideal para operações de rename em lote: mudar tags (ex: `[WEB]` → `[P&P]`), atualizar nomes de clientes, padronizar prefixos, etc.
+
+## Os dois MCPs do Ekyte
+
+A partir de 2026-06 há **dois servidores MCP do Ekyte** configurados (`~/.claude/mcp.json`):
+
+| Servidor | Prefixo das tools | Uso |
+|---|---|---|
+| `ekyte-oficial` (`api.ekyte.com`) | `mcp__ekyte-oficial__*` | **Escrita/edição** — `update_task`, `update_task_phase`, `update_task_responsibles`, `create_task`, comentários. Token fixo na URL (não expira a cada uso). |
+| `ekyte` (n8n) | `mcp__ekyte__*` | **Leitura/BI** — insights, performance por fase, BI de projetos/workspaces, time tracking por dia. |
+
+Para esta skill (rename = escrita), o caminho **primário** é `mcp__ekyte-oficial__update_task`. O PATCH REST cru (com JWT manual) vira **fallback** caso o MCP oficial esteja indisponível.
+
+## Pré-requisitos
+
+- **Caminho primário (recomendado):** MCP `ekyte-oficial` ativo. Não precisa de token manual — ele já vai na URL do servidor. Confirme que as tools `mcp__ekyte-oficial__update_task` / `mcp__ekyte-oficial__list_tasks` estão disponíveis na sessão.
+
+- **Fallback (REST):** `Token Ekyte` em `clientes/_skill-ekyte/.env`:
+  ```
+  EKYTE_TOKEN=eyJhbGc...
+  EKYTE_COMPANY_ID=3597
+  EKYTE_API_BASE=https://api.ekyte.com/api/v2
+  ```
+  Só necessário se for usar o fallback REST. Veja "Setup do Token" no final.
+
+- **IDs das tasks** a renomear — obtém via `mcp__ekyte-oficial__list_tasks` (ou `mcp__ekyte__list_tasks`). Use o `id`/`taskId` retornado pela listagem, não o id da criação.
+
+## Como usar
+
+### Modo 1: IDs explícitos + find-replace
+
+Passe uma lista de IDs e operações find-replace:
+
+```
+Renomeia as seguintes tasks no Ekyte (IDs: 9342321, 9342322, 9342323):
+- Troca: [WEB] → [P&P]
+
+Tira um relatório com sucessos e falhas.
+```
+
+Skill vai:
+1. Buscar título atual de cada task via GET
+2. Aplicar find-replace
+3. Disparar PATCH em paralelo
+4. Retornar relatório: ✅ 3/3 ok, 0 falhas
+
+### Modo 2: Filtro + find-replace
+
+Se não tiver IDs na mão, pedida filtro (projeto, workspace, tipo) e a skill lista as tasks:
+
+```
+No projeto "People & Performance" (workspace V4 Company), renomeia:
+- Troca: V4 Company | → V4 Company Colli & Co |
+```
+
+Skill vai:
+1. Listar tasks do projeto via `listar_tarefas_tool`
+2. Extrair IDs
+3. Aplicar rename
+4. Retornar relatório
+
+## Operações suportadas
+
+- **Find-replace simples**: `[WEB]` → `[P&P]`, `V4 Company` → `V4 Company Colli & Co`
+- **Múltiplas substituições em sequência**: lista de find-replace é aplicada na ordem
+- **Case-sensitive**: respeita maiúsculas/minúsculas no pattern
+
+Exemplos:
+- `Substitui: "Urgente -" → ""`  (remove prefixo)
+- `Substitui: "[01]" → "[02]"`  (altera quantity prefix)
+- `Substitui: "Cliente A |" → "Cliente A |"` (expande nome curto)
+
+## Output esperado
+
+Relatório estruturado:
+```
+✅ SUCCESSO: 22 tasks renomeadas
+   • 9342321: [01][P&P][IA] V4 Company Colli & Co | Política de Paternidade
+   • 9342322: [01][P&P][IA] V4 Company Colli & Co | Ferramentas para TAs
+   ...
+   • 9342342: [01][P&P][IA] V4 Company Colli & Co | PCI — Social Media
+
+⏱️ Tempo total: ~5s (22 tasks em paralelo)
+```
+
+Ou se tiver falhas:
+```
+⚠️ PARCIAL: 20/22 ok, 2 falhas
+
+✅ OK (20):
+   • 9342321: ...
+
+❌ FALHAS (2):
+   • 9342350 (HTTP 500): título não pode ser vazio
+   • 9342351 (HTTP 401): token expirado
+```
+
+## Detalhes técnicos
+
+### Caminho primário — MCP oficial `update_task`
+
+A tool `mcp__ekyte-oficial__update_task` recebe **o mesmo JSON Patch** que o PATCH REST, sem token manual:
+
+```
+mcp__ekyte-oficial__update_task(
+  taskId: 9342321,                                              // integer, da listagem
+  patchDoc: [{"op":"replace","path":"/title","value":"novo título"}]
+)
+```
+
+- `taskId` = id da task (inteiro). `patchDoc` = array de operações JSON Patch RFC 6902 — idêntico ao body REST.
+- Disparar várias chamadas em paralelo (uma por task) numa mesma mensagem.
+- Acentos e `&` vão literais no `value` — o MCP cuida do encoding, sem `--data-binary`.
+- Antes de renomear, busque o título atual via `mcp__ekyte-oficial__list_tasks` (ou `get_detailed_task`) e aplique o find-replace sobre ele.
+
+### Fallback — PATCH REST (só se o MCP oficial estiver fora)
+
+**Endpoint usado:**
+```
+PATCH https://api.ekyte.com/api/v2/companies/{company_id}/ctc-tasks/{task_id}?type=grid&updateAllTickets=undefined
+```
+
+**Headers:**
+- `Authorization: Bearer {EKYTE_TOKEN}`
+- `Content-Type: application/json`
+- `Origin: https://app.ekyte.com`
+- `Referer: https://app.ekyte.com/`
+
+**Body (JSON Patch RFC 6902):**
+```json
+[{"op":"replace","path":"/title","value":"novo título"}]
+```
+
+**Encoding crítico:** payload é enviado via `--data-binary @file` com bytes UTF-8 corretos. Acentos + `&` devem ser literais no JSON, não escapados.
+
+## Setup do Token
+
+Se não tiver `EKYTE_TOKEN` em `.env`:
+
+1. Abre `https://app.ekyte.com` e faz login
+2. F12 → aba **Network** → filtra por `api.ekyte`
+3. Clica em qualquer task → edita o título → salva
+4. Procura na Network pela request `9342XXX?type=grid&updateAllTickets=undefined` (POST/PATCH)
+5. Headers → `Authorization: Bearer eyJhbGc...` → copia só o JWT (sem "Bearer ")
+6. Cola em `clientes/_skill-ekyte/.env`:
+   ```
+   EKYTE_TOKEN=eyJhbGc...
+   ```
+
+Token vale ~180 dias. Quando expirar (skill retorna HTTP 401), renova repetindo os passos acima.
+
+## Limitações
+
+- **Sem validação de título**: se o novo título viola regras do Ekyte (vazio, caracteres inválidos), a task falha (HTTP 400/422). Revise o find-replace antes de rodar.
+- **Sem undo**: renames são imediatos e permanentes. Se precisar reverter, pode rodar a skill de novo com find-replace inverso.
+- **Sem garantia de idempotência**: se rodar a skill 2× com mesmo find-replace, a segunda rodada faz nada (ou encontra o novo título e tenta "substituir" de novo, resultando em noop).
+
+## Exemplos reais
+
+**Exemplo 1: Rename de tags**
+```
+IDs: 9342321 a 9342342 (22 tasks People & Performance)
+Substitui: [WEB] → [P&P]
+```
+Resultado: 22/22 ok em ~5s
+
+**Exemplo 2: Atualizar nome de cliente**
+```
+Projeto: "Cliente A | Q2/2026"
+Substitui: "Cliente A" → "Cliente A — Novembro"
+```
+Resultado: 15/15 ok (todas as tasks do projeto Cliente A atualizadas)
+
+**Exemplo 3: Cleanup de urgência**
+```
+Workspace: V4 Company
+Substitui: "🔴 URGENTE — " → ""
+```
+Resultado: 8/8 ok (remove prefix antigo de urgência)
+
+---
+
+**Quando usar essa skill:**
+- Múltiplas tasks (3+) pra renomear — evita UI click-by-click
+- Find-replace repetitivo (mesma operação em lote)
+- Lotes de geração automática onde prefixo/suffix precisa atualizar
+
+**Quando NÃO usar:**
+- 1-2 tasks — mais rápido editar direto na UI
+- Edições complexas (alterar responsável, prazo, fase, briefing) — agora possíveis via MCP oficial: `mcp__ekyte-oficial__update_task_responsibles`, `update_task_phase`, ou `update_task` com o `patchDoc` apontando o campo certo. Esta skill cobre só título; para o resto, chame essas tools direto.

--- a/.agents/skills/gestao-ekyte-tags/SKILL.md
+++ b/.agents/skills/gestao-ekyte-tags/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: gestao-ekyte-tags
+description: Aplica etiquetas (tags) padronizadas em tarefas do Ekyte em lote via MCP oficial, seguindo o Playbook de Tags da Colli & Co. Dois modos — ROTINA (rotina + semana, ex: SPRINT GROWTH + SEMANA 23) e TIPO de entregável (LANDING PAGE, Criativo Ads). Faz merge seguro com as tags atuais (nunca sobrescreve), resolve IDs automaticamente e mostra preview antes de aplicar. Use sempre que precisar taguear tarefas de rotina (Sprint Growth, Weekly Expansão, Ação Gerencial, Quality Control, WAR, Alinhamento Comitê), marcar a semana do ano, ou etiquetar entregáveis de landing page / criativo ads — em uma ou várias tasks de uma vez.
+area: gestao
+author: fabio
+version: 1.0.0
+---
+
+# Gestão — Tags/Etiquetas no Ekyte em Lote
+
+Aplica tags padronizadas em tarefas do Ekyte respeitando o **Playbook de Tags da Colli & Co**. Substitui o trabalho manual de abrir task por task na UI por: resolver IDs → merge com as tags atuais → preview → aplicar em paralelo.
+
+A regra de ouro vem do comportamento da API: **`update_task_tags` SUBSTITUI a lista inteira de tags da task.** Se você mandar só a tag nova, apaga todas as outras. Por isso esta skill **sempre** lê as tags atuais e envia o conjunto completo (atuais + novas). Errar isso = perder tag de cliente. É o coração da skill.
+
+## Pré-requisitos
+
+- MCP `ekyte-oficial` (`api.ekyte.com`) ativo em `~/.claude/mcp.json` — token fixo na URL, autentica a empresa Colli (companyId 3597). Tools usadas: `mcp__ekyte-oficial__list_tags`, `mcp__ekyte-oficial__get_detailed_task`, `mcp__ekyte-oficial__update_task_tags`.
+- **IDs das tasks** a taguear — você passa, ou a skill lista por filtro (projeto/workspace) via `mcp__ekyte-oficial__list_tasks`. Sempre filtrar: `list_tasks` sem filtro e com `limit:200` **dá timeout** na conta Colli.
+
+> Os dois MCPs do Ekyte: `ekyte-oficial` (escrita — esta skill) e `ekyte` n8n (leitura/BI). Ver `gestao-ekyte-rename-tasks` para o contexto completo.
+
+## Os dois modos
+
+### Modo ROTINA (governado pelo Playbook)
+
+Toda tarefa que nasce de uma rotina recorrente leva **exatamente duas tags**: a tag da **rotina** + a tag da **semana do ano**. Isso é o que deixa coordenador/gestor filtrar no "Controle de Tarefas" com cláusula **E** (rotina + semana) e validar o que cada squad subiu na semana.
+
+**Tags de rotina** (permanentes, IDs sequenciais 250506–250511):
+
+| Rotina | Tag no Ekyte | ID |
+|---|---|---|
+| Ação Gerencial | `AÇÃO GERENCIAL` | 250510 |
+| Sprint Growth | `SPRINT GROWTH` | 250506 |
+| Weekly Expansão | `WEEKLY EXPANSÃO` | 250507 |
+| Alinhamento Comitê | `ALINHAMENTO COMITÊ` | 250508 |
+| Quality Control | `QUALITY CONTROL` | 250509 |
+| WAR | `WAR` | 250511 |
+
+**Tag de semana** — formato `SEMANA NN` (maiúsculo, **zero-padded a 2 dígitos**: `SEMANA 01` … `SEMANA 52`). A semana é a do **calendário ISO** da demanda. Default = semana ISO de hoje; o usuário pode fixar outra ("essas são da semana 22").
+
+Calcular a semana (Python):
+```python
+import datetime; datetime.date.today().isocalendar()[1]   # ex: 2026-06-02 → 23
+```
+Referência de sanidade (Playbook 2026): SEMANA 22 = 25–31 mai · **SEMANA 23 = 01–07 jun** · SEMANA 24 = 08–14 jun. O ISO bate com a tabela do Playbook.
+
+IDs de semana conhecidos (cache; resolver o resto via `list_tags`):
+
+| Tag | ID | | Tag | ID |
+|---|---|---|---|---|
+| SEMANA 20 | 250535 | | SEMANA 25 | 250540 |
+| SEMANA 21 | 250536 | | SEMANA 26 | 250541 |
+| SEMANA 22 | 250537 | | SEMANA 27 | 250542 |
+| SEMANA 23 | 250538 | | SEMANA 28 | 250543 |
+| SEMANA 24 | 250539 | | SEMANA 29 | 250544 |
+
+### Modo TIPO (entregável)
+
+Tags de **tipo de entregável** — independentes da rotina, podem coexistir com as duas tags de rotina/semana. Detectadas pela **sigla no título** (`[NN][SIGLA][IA] Cliente | Demanda`):
+
+| Gatilho | Tag no Ekyte | ID |
+|---|---|---|
+| sigla `[LP]` | `LANDING PAGE` | 90834 |
+| sigla `[CA]` | `Criativo Ads` | 79390 |
+| criativo **em vídeo** (só quando você sinalizar) | `criativo em vídeo` | 228775 |
+
+`[CA]` → `Criativo Ads` por padrão. `criativo em vídeo` (228775) é aplicado **só quando você sinalizar** que aquele lote é vídeo — não há tag `CRIAÇÃO DE VIDEO` no Ekyte e o MCP não cria tags, então usamos a existente. Se quiser a nomenclatura exata `CRIAÇÃO DE VIDEO`, crie a tag manual na UI e me avise pra cadastrar o ID.
+
+## Fluxo de execução
+
+Para cada task do lote:
+
+1. **Resolver os IDs das tags-alvo.** Use o cache acima. Para semana fora do cache (ou pra confirmar), `list_tags(type:0, textSearch:"SEMANA NN")` e pegue o match **exato** da série canônica (2505xx) — ignore variantes ("SEMANA 20 " com espaço, "Sprint Growth - Semana 20", "Expansão semana 23 - Nayara"). Se a tag não existir, **PARE e reporte** (não dá pra criar tag via MCP).
+
+2. **Ler tags atuais:** `get_detailed_task(taskId)` → extrair a lista de tags já aplicadas (cada uma tem seu `tagId`/`id`). Esse é o estado que NÃO pode ser perdido.
+
+3. **Merge:** `conjunto_final = tags_atuais ∪ tags_novas` (dedupe por ID). Se todas as novas já estão lá, é **no-op** — reportar "já taguada" e pular.
+
+4. **Preview obrigatório** (ver formato abaixo) — esperar "ok".
+
+5. **Aplicar:** `update_task_tags(taskId, tags)` onde `tags` é a lista **completa** no formato:
+   ```json
+   [{"ctcTaskId": 9342321, "tagId": 250538}, {"ctcTaskId": 9342321, "tagId": 250506}, ...]
+   ```
+   Um item por tag do conjunto final, todos com o mesmo `ctcTaskId`. Disparar em paralelo (uma chamada por task).
+
+6. **Relatório** consolidado: ✅ aplicadas / ⏭️ já tinham / ❌ falhas.
+
+## Preview (obrigatório antes de aplicar)
+
+```
+🏷️  Tags a aplicar — 3 tasks (modo ROTINA: Weekly Expansão · Semana 23)
+
+• 9342321  [02][CA][IA] Cliente X | Remarketing
+     atuais:  Criativo Ads
+     +novas:  WEEKLY EXPANSÃO (250507), SEMANA 23 (250538)
+     final →  Criativo Ads, WEEKLY EXPANSÃO, SEMANA 23
+
+• 9342322  [01][LP][IA] Cliente X | LP Black Friday
+     atuais:  (nenhuma)
+     +novas:  WEEKLY EXPANSÃO (250507), SEMANA 23 (250538), LANDING PAGE (90834)
+     final →  WEEKLY EXPANSÃO, SEMANA 23, LANDING PAGE
+
+• 9342323  já tem WEEKLY EXPANSÃO + SEMANA 23 → ⏭️ pula (no-op)
+
+Confirma aplicar? (ok / ajusta)
+```
+
+Mostrar sempre **atuais → final** pra deixar explícito que nada está sendo apagado.
+
+## Output esperado
+
+```
+✅ 2 tasks taguadas · ⏭️ 1 já estava · ❌ 0 falhas
+
+✅ 9342321: + WEEKLY EXPANSÃO, SEMANA 23
+✅ 9342322: + WEEKLY EXPANSÃO, SEMANA 23, LANDING PAGE
+⏭️ 9342323: já tinha as tags
+```
+
+Se falha:
+```
+⚠️ PARCIAL: 1/2 ok
+✅ 9342321: + SEMANA 23, SPRINT GROWTH
+❌ 9342322 (erro): get_detailed_task não retornou — task pode ter sido excluída
+```
+
+## Guardrails (não-negociáveis)
+
+1. **Nunca aplicar sem merge.** Sempre `get_detailed_task` antes. Mandar `update_task_tags` só com as novas apaga o resto. É o erro que destrói trabalho.
+2. **Preview sempre**, mesmo em lote. Mostrar atuais → final por task.
+3. **Tag inexistente = parar e reportar.** O MCP não cria tags. Não inventar ID, não usar tag "parecida" (ex: combinar "SPRINT GROWTH - SEMANA 21" no lugar de "SEMANA 23"). Resolver pelo match exato da série canônica.
+4. **Modo ROTINA = exatamente 2 tags** (rotina + semana). Não adicionar tag de rotina sem semana nem vice-versa — o filtro com cláusula E do coordenador depende do par.
+5. **Idempotência:** rodar 2× não duplica nem apaga — o merge dedupe e no-op em quem já tem.
+6. **Companhia:** o token MCP já é da Colli (3597). Não passar `companyId` salvo se mudar de empresa.
+
+## Exemplos de uso
+
+**Ex 1 — Rotina, lote por projeto:**
+```
+Taguea as tasks do projeto "Cliente X | Q2/2026" criadas hoje como Weekly Expansão.
+```
+→ resolve `WEEKLY EXPANSÃO` (250507) + `SEMANA 23` (250538, semana atual) → merge → preview → aplica.
+
+**Ex 2 — Rotina, semana fixada + IDs explícitos:**
+```
+IDs 9342321, 9342322, 9342323 → Sprint Growth, semana 22.
+```
+→ `SPRINT GROWTH` (250506) + `SEMANA 22` (250537).
+
+**Ex 3 — Tipo por sigla (auto):**
+```
+Nessas 5 tasks, aplica a tag de tipo pelo título.
+```
+→ `[LP]`→LANDING PAGE, `[CA]`→Criativo Ads, lendo a sigla de cada título.
+
+**Ex 4 — Rotina + tipo juntos:**
+```
+Tasks do Sprint Growth dessa semana; as de criativo são vídeo.
+```
+→ cada task: SPRINT GROWTH + SEMANA 23; as `[CA]` sinalizadas vídeo recebem também `criativo em vídeo` (228775).
+
+## Quando NÃO usar
+
+- Renomear título → `gestao-ekyte-rename-tasks`.
+- Criar a task → `ekyte-task` (que já aceita tags na criação; esta skill é pra taguear o que já existe ou corrigir).
+- Mudar responsável/fase/prazo → tools `mcp__ekyte-oficial__update_task_responsibles` / `update_task_phase` / `update_task` direto.
+
+## Manutenção do cache de IDs
+
+Tags de rotina são permanentes (set 250506–250511 estável). Tags de semana são criadas no início do ano (`SEMANA 01`–`52`). Se um ID mudar ou faltar, reabrir via `list_tags(type:0, textSearch:"...")` e atualizar a tabela aqui. Tipos de entregável (LANDING PAGE 90834, Criativo Ads 79390, criativo em vídeo 228775) raramente mudam.

--- a/.claude/skills/gestao-ekyte-rename-tasks/SKILL.md
+++ b/.claude/skills/gestao-ekyte-rename-tasks/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: gestao-ekyte-rename-tasks
+description: Renomeia títulos de tarefas no Ekyte em lote via MCP oficial (update_task) com fallback PATCH REST. Aceita lista de IDs ou filtro (projeto, workspace, tipo). Operações find-replace (ex: [WEB]→[P&P], V4 Company→V4 Company Colli & Co). Output: relatório com sucessos/falhas por task. Use sempre que precisar renomear múltiplas tasks de uma vez — é muito mais rápido que editar uma por uma na UI.
+area: gestao
+author: fabio
+version: 2.0.0
+---
+
+# Gestão — Renomear Tasks Ekyte em Lote
+
+Edita títulos de múltiplas tarefas no Ekyte em paralelo. Ideal para operações de rename em lote: mudar tags (ex: `[WEB]` → `[P&P]`), atualizar nomes de clientes, padronizar prefixos, etc.
+
+## Os dois MCPs do Ekyte
+
+A partir de 2026-06 há **dois servidores MCP do Ekyte** configurados (`~/.claude/mcp.json`):
+
+| Servidor | Prefixo das tools | Uso |
+|---|---|---|
+| `ekyte-oficial` (`api.ekyte.com`) | `mcp__ekyte-oficial__*` | **Escrita/edição** — `update_task`, `update_task_phase`, `update_task_responsibles`, `create_task`, comentários. Token fixo na URL (não expira a cada uso). |
+| `ekyte` (n8n) | `mcp__ekyte__*` | **Leitura/BI** — insights, performance por fase, BI de projetos/workspaces, time tracking por dia. |
+
+Para esta skill (rename = escrita), o caminho **primário** é `mcp__ekyte-oficial__update_task`. O PATCH REST cru (com JWT manual) vira **fallback** caso o MCP oficial esteja indisponível.
+
+## Pré-requisitos
+
+- **Caminho primário (recomendado):** MCP `ekyte-oficial` ativo. Não precisa de token manual — ele já vai na URL do servidor. Confirme que as tools `mcp__ekyte-oficial__update_task` / `mcp__ekyte-oficial__list_tasks` estão disponíveis na sessão.
+
+- **Fallback (REST):** `Token Ekyte` em `clientes/_skill-ekyte/.env`:
+  ```
+  EKYTE_TOKEN=eyJhbGc...
+  EKYTE_COMPANY_ID=3597
+  EKYTE_API_BASE=https://api.ekyte.com/api/v2
+  ```
+  Só necessário se for usar o fallback REST. Veja "Setup do Token" no final.
+
+- **IDs das tasks** a renomear — obtém via `mcp__ekyte-oficial__list_tasks` (ou `mcp__ekyte__list_tasks`). Use o `id`/`taskId` retornado pela listagem, não o id da criação.
+
+## Como usar
+
+### Modo 1: IDs explícitos + find-replace
+
+Passe uma lista de IDs e operações find-replace:
+
+```
+Renomeia as seguintes tasks no Ekyte (IDs: 9342321, 9342322, 9342323):
+- Troca: [WEB] → [P&P]
+
+Tira um relatório com sucessos e falhas.
+```
+
+Skill vai:
+1. Buscar título atual de cada task via GET
+2. Aplicar find-replace
+3. Disparar PATCH em paralelo
+4. Retornar relatório: ✅ 3/3 ok, 0 falhas
+
+### Modo 2: Filtro + find-replace
+
+Se não tiver IDs na mão, pedida filtro (projeto, workspace, tipo) e a skill lista as tasks:
+
+```
+No projeto "People & Performance" (workspace V4 Company), renomeia:
+- Troca: V4 Company | → V4 Company Colli & Co |
+```
+
+Skill vai:
+1. Listar tasks do projeto via `listar_tarefas_tool`
+2. Extrair IDs
+3. Aplicar rename
+4. Retornar relatório
+
+## Operações suportadas
+
+- **Find-replace simples**: `[WEB]` → `[P&P]`, `V4 Company` → `V4 Company Colli & Co`
+- **Múltiplas substituições em sequência**: lista de find-replace é aplicada na ordem
+- **Case-sensitive**: respeita maiúsculas/minúsculas no pattern
+
+Exemplos:
+- `Substitui: "Urgente -" → ""`  (remove prefixo)
+- `Substitui: "[01]" → "[02]"`  (altera quantity prefix)
+- `Substitui: "Cliente A |" → "Cliente A |"` (expande nome curto)
+
+## Output esperado
+
+Relatório estruturado:
+```
+✅ SUCCESSO: 22 tasks renomeadas
+   • 9342321: [01][P&P][IA] V4 Company Colli & Co | Política de Paternidade
+   • 9342322: [01][P&P][IA] V4 Company Colli & Co | Ferramentas para TAs
+   ...
+   • 9342342: [01][P&P][IA] V4 Company Colli & Co | PCI — Social Media
+
+⏱️ Tempo total: ~5s (22 tasks em paralelo)
+```
+
+Ou se tiver falhas:
+```
+⚠️ PARCIAL: 20/22 ok, 2 falhas
+
+✅ OK (20):
+   • 9342321: ...
+
+❌ FALHAS (2):
+   • 9342350 (HTTP 500): título não pode ser vazio
+   • 9342351 (HTTP 401): token expirado
+```
+
+## Detalhes técnicos
+
+### Caminho primário — MCP oficial `update_task`
+
+A tool `mcp__ekyte-oficial__update_task` recebe **o mesmo JSON Patch** que o PATCH REST, sem token manual:
+
+```
+mcp__ekyte-oficial__update_task(
+  taskId: 9342321,                                              // integer, da listagem
+  patchDoc: [{"op":"replace","path":"/title","value":"novo título"}]
+)
+```
+
+- `taskId` = id da task (inteiro). `patchDoc` = array de operações JSON Patch RFC 6902 — idêntico ao body REST.
+- Disparar várias chamadas em paralelo (uma por task) numa mesma mensagem.
+- Acentos e `&` vão literais no `value` — o MCP cuida do encoding, sem `--data-binary`.
+- Antes de renomear, busque o título atual via `mcp__ekyte-oficial__list_tasks` (ou `get_detailed_task`) e aplique o find-replace sobre ele.
+
+### Fallback — PATCH REST (só se o MCP oficial estiver fora)
+
+**Endpoint usado:**
+```
+PATCH https://api.ekyte.com/api/v2/companies/{company_id}/ctc-tasks/{task_id}?type=grid&updateAllTickets=undefined
+```
+
+**Headers:**
+- `Authorization: Bearer {EKYTE_TOKEN}`
+- `Content-Type: application/json`
+- `Origin: https://app.ekyte.com`
+- `Referer: https://app.ekyte.com/`
+
+**Body (JSON Patch RFC 6902):**
+```json
+[{"op":"replace","path":"/title","value":"novo título"}]
+```
+
+**Encoding crítico:** payload é enviado via `--data-binary @file` com bytes UTF-8 corretos. Acentos + `&` devem ser literais no JSON, não escapados.
+
+## Setup do Token
+
+Se não tiver `EKYTE_TOKEN` em `.env`:
+
+1. Abre `https://app.ekyte.com` e faz login
+2. F12 → aba **Network** → filtra por `api.ekyte`
+3. Clica em qualquer task → edita o título → salva
+4. Procura na Network pela request `9342XXX?type=grid&updateAllTickets=undefined` (POST/PATCH)
+5. Headers → `Authorization: Bearer eyJhbGc...` → copia só o JWT (sem "Bearer ")
+6. Cola em `clientes/_skill-ekyte/.env`:
+   ```
+   EKYTE_TOKEN=eyJhbGc...
+   ```
+
+Token vale ~180 dias. Quando expirar (skill retorna HTTP 401), renova repetindo os passos acima.
+
+## Limitações
+
+- **Sem validação de título**: se o novo título viola regras do Ekyte (vazio, caracteres inválidos), a task falha (HTTP 400/422). Revise o find-replace antes de rodar.
+- **Sem undo**: renames são imediatos e permanentes. Se precisar reverter, pode rodar a skill de novo com find-replace inverso.
+- **Sem garantia de idempotência**: se rodar a skill 2× com mesmo find-replace, a segunda rodada faz nada (ou encontra o novo título e tenta "substituir" de novo, resultando em noop).
+
+## Exemplos reais
+
+**Exemplo 1: Rename de tags**
+```
+IDs: 9342321 a 9342342 (22 tasks People & Performance)
+Substitui: [WEB] → [P&P]
+```
+Resultado: 22/22 ok em ~5s
+
+**Exemplo 2: Atualizar nome de cliente**
+```
+Projeto: "Cliente A | Q2/2026"
+Substitui: "Cliente A" → "Cliente A — Novembro"
+```
+Resultado: 15/15 ok (todas as tasks do projeto Cliente A atualizadas)
+
+**Exemplo 3: Cleanup de urgência**
+```
+Workspace: V4 Company
+Substitui: "🔴 URGENTE — " → ""
+```
+Resultado: 8/8 ok (remove prefix antigo de urgência)
+
+---
+
+**Quando usar essa skill:**
+- Múltiplas tasks (3+) pra renomear — evita UI click-by-click
+- Find-replace repetitivo (mesma operação em lote)
+- Lotes de geração automática onde prefixo/suffix precisa atualizar
+
+**Quando NÃO usar:**
+- 1-2 tasks — mais rápido editar direto na UI
+- Edições complexas (alterar responsável, prazo, fase, briefing) — agora possíveis via MCP oficial: `mcp__ekyte-oficial__update_task_responsibles`, `update_task_phase`, ou `update_task` com o `patchDoc` apontando o campo certo. Esta skill cobre só título; para o resto, chame essas tools direto.

--- a/.claude/skills/gestao-ekyte-tags/SKILL.md
+++ b/.claude/skills/gestao-ekyte-tags/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: gestao-ekyte-tags
+description: Aplica etiquetas (tags) padronizadas em tarefas do Ekyte em lote via MCP oficial, seguindo o Playbook de Tags da Colli & Co. Dois modos — ROTINA (rotina + semana, ex: SPRINT GROWTH + SEMANA 23) e TIPO de entregável (LANDING PAGE, Criativo Ads). Faz merge seguro com as tags atuais (nunca sobrescreve), resolve IDs automaticamente e mostra preview antes de aplicar. Use sempre que precisar taguear tarefas de rotina (Sprint Growth, Weekly Expansão, Ação Gerencial, Quality Control, WAR, Alinhamento Comitê), marcar a semana do ano, ou etiquetar entregáveis de landing page / criativo ads — em uma ou várias tasks de uma vez.
+area: gestao
+author: fabio
+version: 1.0.0
+---
+
+# Gestão — Tags/Etiquetas no Ekyte em Lote
+
+Aplica tags padronizadas em tarefas do Ekyte respeitando o **Playbook de Tags da Colli & Co**. Substitui o trabalho manual de abrir task por task na UI por: resolver IDs → merge com as tags atuais → preview → aplicar em paralelo.
+
+A regra de ouro vem do comportamento da API: **`update_task_tags` SUBSTITUI a lista inteira de tags da task.** Se você mandar só a tag nova, apaga todas as outras. Por isso esta skill **sempre** lê as tags atuais e envia o conjunto completo (atuais + novas). Errar isso = perder tag de cliente. É o coração da skill.
+
+## Pré-requisitos
+
+- MCP `ekyte-oficial` (`api.ekyte.com`) ativo em `~/.claude/mcp.json` — token fixo na URL, autentica a empresa Colli (companyId 3597). Tools usadas: `mcp__ekyte-oficial__list_tags`, `mcp__ekyte-oficial__get_detailed_task`, `mcp__ekyte-oficial__update_task_tags`.
+- **IDs das tasks** a taguear — você passa, ou a skill lista por filtro (projeto/workspace) via `mcp__ekyte-oficial__list_tasks`. Sempre filtrar: `list_tasks` sem filtro e com `limit:200` **dá timeout** na conta Colli.
+
+> Os dois MCPs do Ekyte: `ekyte-oficial` (escrita — esta skill) e `ekyte` n8n (leitura/BI). Ver `gestao-ekyte-rename-tasks` para o contexto completo.
+
+## Os dois modos
+
+### Modo ROTINA (governado pelo Playbook)
+
+Toda tarefa que nasce de uma rotina recorrente leva **exatamente duas tags**: a tag da **rotina** + a tag da **semana do ano**. Isso é o que deixa coordenador/gestor filtrar no "Controle de Tarefas" com cláusula **E** (rotina + semana) e validar o que cada squad subiu na semana.
+
+**Tags de rotina** (permanentes, IDs sequenciais 250506–250511):
+
+| Rotina | Tag no Ekyte | ID |
+|---|---|---|
+| Ação Gerencial | `AÇÃO GERENCIAL` | 250510 |
+| Sprint Growth | `SPRINT GROWTH` | 250506 |
+| Weekly Expansão | `WEEKLY EXPANSÃO` | 250507 |
+| Alinhamento Comitê | `ALINHAMENTO COMITÊ` | 250508 |
+| Quality Control | `QUALITY CONTROL` | 250509 |
+| WAR | `WAR` | 250511 |
+
+**Tag de semana** — formato `SEMANA NN` (maiúsculo, **zero-padded a 2 dígitos**: `SEMANA 01` … `SEMANA 52`). A semana é a do **calendário ISO** da demanda. Default = semana ISO de hoje; o usuário pode fixar outra ("essas são da semana 22").
+
+Calcular a semana (Python):
+```python
+import datetime; datetime.date.today().isocalendar()[1]   # ex: 2026-06-02 → 23
+```
+Referência de sanidade (Playbook 2026): SEMANA 22 = 25–31 mai · **SEMANA 23 = 01–07 jun** · SEMANA 24 = 08–14 jun. O ISO bate com a tabela do Playbook.
+
+IDs de semana conhecidos (cache; resolver o resto via `list_tags`):
+
+| Tag | ID | | Tag | ID |
+|---|---|---|---|---|
+| SEMANA 20 | 250535 | | SEMANA 25 | 250540 |
+| SEMANA 21 | 250536 | | SEMANA 26 | 250541 |
+| SEMANA 22 | 250537 | | SEMANA 27 | 250542 |
+| SEMANA 23 | 250538 | | SEMANA 28 | 250543 |
+| SEMANA 24 | 250539 | | SEMANA 29 | 250544 |
+
+### Modo TIPO (entregável)
+
+Tags de **tipo de entregável** — independentes da rotina, podem coexistir com as duas tags de rotina/semana. Detectadas pela **sigla no título** (`[NN][SIGLA][IA] Cliente | Demanda`):
+
+| Gatilho | Tag no Ekyte | ID |
+|---|---|---|
+| sigla `[LP]` | `LANDING PAGE` | 90834 |
+| sigla `[CA]` | `Criativo Ads` | 79390 |
+| criativo **em vídeo** (só quando você sinalizar) | `criativo em vídeo` | 228775 |
+
+`[CA]` → `Criativo Ads` por padrão. `criativo em vídeo` (228775) é aplicado **só quando você sinalizar** que aquele lote é vídeo — não há tag `CRIAÇÃO DE VIDEO` no Ekyte e o MCP não cria tags, então usamos a existente. Se quiser a nomenclatura exata `CRIAÇÃO DE VIDEO`, crie a tag manual na UI e me avise pra cadastrar o ID.
+
+## Fluxo de execução
+
+Para cada task do lote:
+
+1. **Resolver os IDs das tags-alvo.** Use o cache acima. Para semana fora do cache (ou pra confirmar), `list_tags(type:0, textSearch:"SEMANA NN")` e pegue o match **exato** da série canônica (2505xx) — ignore variantes ("SEMANA 20 " com espaço, "Sprint Growth - Semana 20", "Expansão semana 23 - Nayara"). Se a tag não existir, **PARE e reporte** (não dá pra criar tag via MCP).
+
+2. **Ler tags atuais:** `get_detailed_task(taskId)` → extrair a lista de tags já aplicadas (cada uma tem seu `tagId`/`id`). Esse é o estado que NÃO pode ser perdido.
+
+3. **Merge:** `conjunto_final = tags_atuais ∪ tags_novas` (dedupe por ID). Se todas as novas já estão lá, é **no-op** — reportar "já taguada" e pular.
+
+4. **Preview obrigatório** (ver formato abaixo) — esperar "ok".
+
+5. **Aplicar:** `update_task_tags(taskId, tags)` onde `tags` é a lista **completa** no formato:
+   ```json
+   [{"ctcTaskId": 9342321, "tagId": 250538}, {"ctcTaskId": 9342321, "tagId": 250506}, ...]
+   ```
+   Um item por tag do conjunto final, todos com o mesmo `ctcTaskId`. Disparar em paralelo (uma chamada por task).
+
+6. **Relatório** consolidado: ✅ aplicadas / ⏭️ já tinham / ❌ falhas.
+
+## Preview (obrigatório antes de aplicar)
+
+```
+🏷️  Tags a aplicar — 3 tasks (modo ROTINA: Weekly Expansão · Semana 23)
+
+• 9342321  [02][CA][IA] Cliente X | Remarketing
+     atuais:  Criativo Ads
+     +novas:  WEEKLY EXPANSÃO (250507), SEMANA 23 (250538)
+     final →  Criativo Ads, WEEKLY EXPANSÃO, SEMANA 23
+
+• 9342322  [01][LP][IA] Cliente X | LP Black Friday
+     atuais:  (nenhuma)
+     +novas:  WEEKLY EXPANSÃO (250507), SEMANA 23 (250538), LANDING PAGE (90834)
+     final →  WEEKLY EXPANSÃO, SEMANA 23, LANDING PAGE
+
+• 9342323  já tem WEEKLY EXPANSÃO + SEMANA 23 → ⏭️ pula (no-op)
+
+Confirma aplicar? (ok / ajusta)
+```
+
+Mostrar sempre **atuais → final** pra deixar explícito que nada está sendo apagado.
+
+## Output esperado
+
+```
+✅ 2 tasks taguadas · ⏭️ 1 já estava · ❌ 0 falhas
+
+✅ 9342321: + WEEKLY EXPANSÃO, SEMANA 23
+✅ 9342322: + WEEKLY EXPANSÃO, SEMANA 23, LANDING PAGE
+⏭️ 9342323: já tinha as tags
+```
+
+Se falha:
+```
+⚠️ PARCIAL: 1/2 ok
+✅ 9342321: + SEMANA 23, SPRINT GROWTH
+❌ 9342322 (erro): get_detailed_task não retornou — task pode ter sido excluída
+```
+
+## Guardrails (não-negociáveis)
+
+1. **Nunca aplicar sem merge.** Sempre `get_detailed_task` antes. Mandar `update_task_tags` só com as novas apaga o resto. É o erro que destrói trabalho.
+2. **Preview sempre**, mesmo em lote. Mostrar atuais → final por task.
+3. **Tag inexistente = parar e reportar.** O MCP não cria tags. Não inventar ID, não usar tag "parecida" (ex: combinar "SPRINT GROWTH - SEMANA 21" no lugar de "SEMANA 23"). Resolver pelo match exato da série canônica.
+4. **Modo ROTINA = exatamente 2 tags** (rotina + semana). Não adicionar tag de rotina sem semana nem vice-versa — o filtro com cláusula E do coordenador depende do par.
+5. **Idempotência:** rodar 2× não duplica nem apaga — o merge dedupe e no-op em quem já tem.
+6. **Companhia:** o token MCP já é da Colli (3597). Não passar `companyId` salvo se mudar de empresa.
+
+## Exemplos de uso
+
+**Ex 1 — Rotina, lote por projeto:**
+```
+Taguea as tasks do projeto "Cliente X | Q2/2026" criadas hoje como Weekly Expansão.
+```
+→ resolve `WEEKLY EXPANSÃO` (250507) + `SEMANA 23` (250538, semana atual) → merge → preview → aplica.
+
+**Ex 2 — Rotina, semana fixada + IDs explícitos:**
+```
+IDs 9342321, 9342322, 9342323 → Sprint Growth, semana 22.
+```
+→ `SPRINT GROWTH` (250506) + `SEMANA 22` (250537).
+
+**Ex 3 — Tipo por sigla (auto):**
+```
+Nessas 5 tasks, aplica a tag de tipo pelo título.
+```
+→ `[LP]`→LANDING PAGE, `[CA]`→Criativo Ads, lendo a sigla de cada título.
+
+**Ex 4 — Rotina + tipo juntos:**
+```
+Tasks do Sprint Growth dessa semana; as de criativo são vídeo.
+```
+→ cada task: SPRINT GROWTH + SEMANA 23; as `[CA]` sinalizadas vídeo recebem também `criativo em vídeo` (228775).
+
+## Quando NÃO usar
+
+- Renomear título → `gestao-ekyte-rename-tasks`.
+- Criar a task → `ekyte-task` (que já aceita tags na criação; esta skill é pra taguear o que já existe ou corrigir).
+- Mudar responsável/fase/prazo → tools `mcp__ekyte-oficial__update_task_responsibles` / `update_task_phase` / `update_task` direto.
+
+## Manutenção do cache de IDs
+
+Tags de rotina são permanentes (set 250506–250511 estável). Tags de semana são criadas no início do ano (`SEMANA 01`–`52`). Se um ID mudar ou faltar, reabrir via `list_tags(type:0, textSearch:"...")` e atualizar a tabela aqui. Tipos de entregável (LANDING PAGE 90834, Criativo Ads 79390, criativo em vídeo 228775) raramente mudam.


### PR DESCRIPTION
## Skills sendo compartilhadas

**Area:** gestao
**Autor:** @junioraiellogestaodetrafego-maker
**Versao:** gestao-ekyte-rename-tasks 2.0.0 / gestao-ekyte-tags 1.0.0

## O que fazem

- `gestao-ekyte-rename-tasks` — renomeia titulos de tarefas no Ekyte em lote (find-replace) via MCP oficial (`update_task`) com fallback PATCH REST. Aceita lista de IDs ou filtro por projeto/workspace/tipo.
- `gestao-ekyte-tags` — aplica tags padronizadas em lote seguindo o Playbook de Tags da Colli & Co (modo ROTINA + SEMANA, ou modo TIPO de entregavel). Faz merge seguro com as tags atuais, nunca sobrescreve.

## Como testar

1. Rode `/sync-hub` pra puxar a branch localmente.
2. Rode `/gestao-ekyte-rename-tasks` ou `/gestao-ekyte-tags` apontando pra um filtro de projeto/workspace de teste.
3. Valide que o preview aparece antes de qualquer alteracao real em lote.

## Checklist do contribuidor

- [x] Nome segue prefixo de papel (`gestao-*`)
- [x] Frontmatter completo (name, description, area, author, version)
- [x] Duplo-write em .claude/ e .agents/ (conteudo identico)
- [x] Testada em producao
- [x] Sem credenciais, tokens, clientes reais ou dados pessoais
- [x] Portugues brasileiro

---

_Gerado via `/compartilhar-skill`._