### PR TITLE
docs: add guia de instalacao do MCP oficial do Ekyte

### DIFF
--- a/docs/mcp-ekyte-instalacao.md
+++ b/docs/mcp-ekyte-instalacao.md
@@ -1,0 +1,57 @@
+# Instalacao do MCP oficial do Ekyte
+
+Guia baseado na documentacao oficial ([developers.ekyte.com/docs/mcp](https://developers.ekyte.com/docs/mcp/)) para conectar o MCP do Ekyte no Claude Code.
+
+## Passo 1 — Gerar o token de acesso
+
+1. Entre na plataforma Ekyte com seu usuario.
+2. Va em **Configuracoes** (cadastro de usuario).
+3. Localize o campo **Token de Acesso para MCP** e gere/copie o token.
+
+O token e pessoal — as acoes feitas via MCP ficam registradas na sua conta, e as tools so acessam os dados que a empresa autenticada tem permissao de ver.
+
+## Passo 2 — Montar a URL do servidor
+
+```
+https://api.ekyte.com/mcp?token=SEU_TOKEN_AQUI
+```
+
+Troque `SEU_TOKEN_AQUI` pelo token gerado no Passo 1. **Nunca** commite essa URL com o token real em nenhum arquivo do repositorio.
+
+## Passo 3 — Registrar no Claude Code
+
+Adicione o servidor no `~/.claude/mcp.json` (formato padrao de MCP server via HTTP):
+
+```json
+{
+  "mcpServers": {
+    "ekyte-oficial": {
+      "url": "https://api.ekyte.com/mcp?token=SEU_TOKEN_AQUI"
+    }
+  }
+}
+```
+
+**Nota:** a documentacao oficial do Ekyte nao publica um exemplo pronto de configuracao para Claude Desktop/Claude Code — o bloco acima segue o formato padrao de servidor MCP via URL/HTTP. Se o Ekyte mudar o transporte (SSE, streamable-http, etc), ajuste conforme a mensagem de erro ao conectar.
+
+Alternativa via CLI (sem editar o JSON na mao):
+
+```bash
+claude mcp add ekyte-oficial "https://api.ekyte.com/mcp?token=SEU_TOKEN_AQUI"
+```
+
+## Passo 4 — Validar a conexao
+
+1. Reinicie o Claude Code (ou rode `/mcp` para ver os servidores conectados).
+2. Confirme que `ekyte-oficial` aparece como conectado.
+3. Teste com uma tool simples, ex: `list_projects` ou `list_workspaces`, para confirmar que o token tem acesso aos dados esperados.
+
+## Escopo e permissoes
+
+- O token valida permissoes pelo **perfil do usuario** dentro do Ekyte — mesmas regras de visibilidade da UI se aplicam via MCP.
+- A empresa autenticada so enxerga dados que ela tem permissao de acessar (nao ha vazamento cross-empresa).
+- Se o token expirar ou for revogado, gere um novo em Configuracoes e atualize o `mcp.json`.
+
+## Skills que dependem desse MCP
+
+As skills do Ekyte no hub (`ekyte-task`, `ekyte-briefing`, `ekyte-refresh`, `ekyte-briefing-refresh`, `ekyte-templates-refresh`, `gestao-ekyte-rename-tasks`, `gestao-ekyte-tags`) assumem que o servidor `ekyte-oficial` (ou equivalente) ja esta configurado e conectado antes de rodar. Sem o MCP, essas skills nao conseguem criar/listar/atualizar tarefas.


### PR DESCRIPTION
## O que adiciona

`docs/mcp-ekyte-instalacao.md` — guia passo a passo pra conectar o MCP oficial do Ekyte (`api.ekyte.com/mcp`) no Claude Code, baseado na documentacao oficial ([developers.ekyte.com/docs/mcp](https://developers.ekyte.com/docs/mcp/)):

- Como gerar o token de acesso (Configuracoes do usuario no Ekyte).
- Como montar a URL do servidor MCP.
- Exemplo de registro no `~/.claude/mcp.json` (formato padrao MCP via URL — a doc oficial nao traz um exemplo pronto para Claude Desktop/Code, isso fica sinalizado no proprio doc).
- Como validar a conexao.
- Nota de escopo/permissao (token e por usuario, empresa so ve o que tem permissao).

Sem token real em lugar nenhum do arquivo — so placeholder `SEU_TOKEN_AQUI`.

## Como testar

1. Seguir o passo a passo com um token de Ekyte valido.
2. Confirmar que `ekyte-oficial` aparece conectado em `/mcp`.
3. Rodar uma tool simples (`list_projects`) pra validar acesso.

---

_Gerado via `/compartilhar-skill`._