### PR TITLE
feat(skills): add criativo-construtor-de-site

### DIFF
--- a/.agents/skills/criativo-construtor-de-site/SKILL.md
+++ b/.agents/skills/criativo-construtor-de-site/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: criativo-construtor-de-site
+description: Constrói um site de marketing completo e de alta qualidade para um cliente de qualquer nicho — da coleta de conteúdo real e definição de escopo até a validação por screenshot, iterando contra um dev server. Use sempre que o usuário quiser criar, refazer, montar ou "subir" um site, landing page, one-page, hotsite ou presença web para um cliente, negócio ou projeto, mesmo que ele só diga "faz um site pra X", "refaz o site da empresa Y", "preciso de uma página pro meu produto" ou descreva um nicho querendo site. Orquestra a skill ui-ux-pro-max e usa Vite + React + TypeScript + Tailwind + Framer Motion + react-router.
+area: criativo
+author: esdras-onlaine
+version: 1.2.0
+---
+
+# Construtor de Site
+
+Constrói um site de marketing completo para um cliente de **qualquer nicho**, com processo repetível e barra de qualidade fixa — sem clonar o visual de nenhum cliente anterior.
+
+A skill **não reinventa design** (orquestra a `ui-ux-pro-max`) e mantém consistência via **arquivos de contexto do projeto**: grava o conteúdo real e o design-system em `dados-reais.md` + `design-system.md` (e um `CLAUDE.md` enxuto no root do site), pra dar as regras **uma vez** e o agente aplicar em todas as páginas — sem re-perguntar a cada seção.
+
+**Stack travada:** Vite + React + TypeScript + Tailwind v3 + **Framer Motion** (`motion`) + **react-router-dom** (multipágina) + `lucide-react`. O que muda por cliente é a marca, o conteúdo, o escopo e as seções; a stack não.
+
+## Pré-requisitos (skills)
+
+Esta skill **orquestra**, não reimplementa design. Antes de usar, garanta que estas skills estão no ambiente:
+
+- **`ui-ux-pro-max`** — **obrigatória**. É ela que define o sistema de design (estilo, paleta OKLCH, par de fontes, padrões de UX) no passo 3, via `search.py --design-system`. **Não faz parte do Builders Hub** — instale à parte a partir do marketplace de skills. Sem ela, o passo de marca não roda.
+- **`frontend-design`** — **já incluída no hub** (skill base). Usada só pra um componente isolado genuinamente novo; não precisa instalar à parte.
+- **`deploy-to-vercel`** — **opcional**, só pro deploy final (passo 7). Também vem de fora do hub.
+
+## Quando usar
+- "Faz um site pra [negócio]", "refaz o site da [empresa]", "preciso de uma landing pro [produto]".
+- Refatorar/redesenhar um site existente de um cliente.
+
+## Quando NÃO usar
+- Só auditoria de UX de algo pronto → `ui-ux-pro-max`. Componente isolado → `frontend-design`. App com backend/auth/dashboard → é produto, não site de marketing.
+
+---
+
+## Pré-voo (cheque antes de começar)
+Confirme o que está disponível e tenha plano B — **não trave no meio**:
+- **Firecrawl** (raspar site/redes atuais): se indisponível, peça o conteúdo e as fotos ao usuário.
+- **Playwright MCP** (screenshots de validação): se indisponível, peça pro usuário olhar a tela e descrever.
+- **Pillow (Python)** e **Node**: necessários pra imagens e build; se faltar, instale/avise.
+
+## Ferramentas que a skill orquestra
+
+| Etapa | Ferramenta | Pra quê |
+|---|---|---|
+| Coletar | **Firecrawl** (`firecrawl_map` → `firecrawl_scrape` **seletivo**) | Mapear o site atual e raspar **só** as páginas que definem arquitetura + as com assets — não tudo |
+| Coletar | **Read** (docs/PDF/planilhas) | Material enviado: briefing, portfólio, catálogo |
+| Coletar | **WebSearch** / `firecrawl_search` | Fatos reais do nicho/local **com fonte** quando o material é raso — nunca inventar |
+| Definir | **AskUserQuestion** | Fechar tipo/escopo de entrega e aprovar arquitetura/garfos com opções (preview) |
+| Contexto | **Arquivos do projeto** (`dados-reais.md`, `design-system.md`, `CLAUDE.md`) | Persistir conteúdo + regras de design; o agente lê e fica consistente sem re-perguntar |
+| Curar/otimizar fotos | **Pillow** (folha de contato + **batch** WebP) | Identificar fotos; converter em lote pra WebP |
+| Marca | **`ui-ux-pro-max`** (`search.py --design-system`) | **Um passe** de estilo/paleta/tipografia/UX |
+| Construir | **Vite + React + TS + Tailwind + Framer Motion + react-router + lucide** | Site multipágina, animações/reveals, rotas |
+| Iterar/validar | **`npm run dev` (HMR)** + **Playwright** (screenshot **cirúrgico**) | Iterar em segundos; screenshot só do que mudou |
+| Entregar | **PowerShell/Bash**; `deploy-to-vercel` | `build`+`preview` no final; deploy opcional |
+| (opcional) Escalar | **subagents** | Construir páginas independentes em paralelo num site grande |
+
+---
+
+## Princípios inegociáveis
+
+1. **Feche o TIPO e o ESCOPO da entrega ANTES de construir.** "Faz um site pra X" não é one-page. Padrão p/ cliente contratado = **site institucional multipágina**. Analise, recomende, e **pergunte o que foi combinado comercialmente / a expectativa** — a skill não infere isso. (Erro nº 1 num build real: saiu LP no lugar de site.)
+2. **Conteúdo real, nunca inventar.** Vem do cliente (KB, material, site/redes). Faltou contexto do nicho → **pesquise e cite a fonte**. Sem dado → pendência declarada. Demos (inclusive de ChatGPT) servem só de estrutura.
+3. **Contexto em arquivo, não na cabeça.** Grave o conteúdo em `dados-reais.md` e o design em `design-system.md` (+ `CLAUDE.md` enxuto, ~100 linhas). Assim você define as regras **uma vez** e não re-pergunta design a cada seção. Mantenha enxuto (evita "context rot").
+4. **Nada de placeholder em produção.** Falta foto → estado "Foto em breve" desenhado + lista do que falta. Real do acervo > interina do acervo > placeholder declarado.
+5. **Orquestre, não duplique.** Um passe de `ui-ux-pro-max` define o sistema; reconsulte só pra um **componente genuinamente novo**.
+6. **Decisões de garfo são do usuário.** Bifurcações (tipo de entrega, paleta, navbar, blog) → **2–4 opções com preview** (AskUserQuestion). Se ele estiver, na sua leitura, errado, **questione com argumento**.
+7. **Itere contra o dev server.** Construa com **`npm run dev` (HMR)** — segundos por mudança. `build`+`preview` é só pra **validação final / compartilhar / deploy** (e evita o estouro de memória do rolldown que vem do rebuild a cada troca).
+8. **Screenshot é caro — use cirúrgico.** Valide com Playwright **só a página/seção que mudou**; varredura completa (desktop 1440 + mobile 375) só num **marco de review**.
+9. **Checkpoints certos.** Obrigatórios: escopo (GATE), direção de marca, review final. O resto **agrupe** — construa um lote de páginas e revise junto; não peça aprovação por seção.
+10. **Estude o site atual** (`firecrawl_map`) e derive a **arquitetura** — não achate em LP. Avise o **tamanho/esforço** depois de aprovar (ex.: "9 páginas + 40 obras = build grande").
+11. **A11y e mobile desde o começo.** Foco de teclado, focus-trap em modal, `aria`, toque ≥44px, hover nunca como única via, teste 375px.
+12. **Não trave o gosto de um cliente** e **otimize imagens** (WebP ~1600px/q82, `lazy`).
+
+---
+
+## Fluxo
+
+### 1. Coletar (enxuto) → `dados-reais.md`
+Read no material do cliente; `firecrawl_map` pra ver as páginas e `firecrawl_scrape` **seletivo** nas que importam (arquitetura + assets); WebSearch p/ fatos do nicho com fonte. **Consolide o conteúdo real em `dados-reais.md`** (enxuto). Se o Firecrawl estiver fora, peça ao usuário.
+
+### 2. Definir entrega + arquitetura (GATE — não pule)
+Apresente análise e **peça aprovação** antes de codar: tipo de entrega (padrão multipágina; **pergunte o combinado**), mapa de páginas derivado do site atual + objetivo, e o **porquê**. Use AskUserQuestion se houver alternativas. Aprovado → diga o tamanho/esforço.
+
+### 3. Marca → `design-system.md` (um passe)
+Invoque `ui-ux-pro-max` → estilo + paleta (OKLCH) + par de fontes. **Grave em `design-system.md`** (tokens + padrões de seção) e materialize no `index.css`/`tailwind.config`. Itere cor/fonte com o usuário (é garfo). Daqui pra frente, construa a partir desse arquivo.
+
+### 4. Scaffold + dev server
+Vite+React+TS, Tailwind v3, `motion`, `react-router-dom` (rotas aprovadas), `lucide-react`. Suba **`npm run dev`** e itere contra ele.
+
+### 5. Construir (em lote, do design-system)
+Página a página / seção a seção, lendo `design-system.md` (não re-perguntando à ui-ux-pro-max). Folha de contato pra curar fotos; **converta em batch** pra WebP. Garfos → opções com preview. Blog/artigo = **padrão editorial** (~68ch). Em site grande, páginas independentes podem ir pra **subagents** em paralelo.
+
+### 6. Validar e iterar (cirúrgico)
+HMR mostra na hora; **screenshot só do que mudou** (truque: desligar animação + rolar pra disparar reveals) → auditoria a11y/mobile → mostra um **lote** ao usuário → ajusta.
+
+### 7. Entregar
+**Aí sim** `npm run build` + `preview` (`--host` libera na rede). Deploy (Vercel + rewrite SPA) opcional. Declare o que é WIP.
+
+---
+
+## Playbook de arquitetura por objetivo
+
+A **hero + prova social + CTA + rodapé** são quase universais; o miolo muda. Em multipágina, cada bloco pode virar **página**.
+
+| Objetivo | Páginas/seções | CTA |
+|---|---|---|
+| Lead B2B (serviço, indústria) | Home, A Empresa, **1 página por serviço**, Equipamentos, Cases/Obras (filtrável), Trabalhe Conosco, Contato | Solicitar orçamento |
+| Reserva (hotelaria, eventos) | Acomodações/ingressos, experiências, galeria, localização | Reservar |
+| Trial (SaaS, app) | Features, como funciona, planos, FAQ | Começar grátis |
+| Compra (e-commerce) | Produtos, benefícios, reviews, garantia | Comprar |
+| Conteúdo (blog, mídia) | Destaque editorial, grade, newsletter | Assinar |
+
+Sempre: prova social real, rodapé/contato completo, blog (editorial) se o cliente produz conteúdo. Form sem backend pode montar a mensagem e abrir o **WhatsApp** do cliente.
+
+---
+
+## Anti-padrões
+- Achatar o site numa LP quando o combinado é multipágina; construir antes de aprovar escopo/arquitetura.
+- **Iterar com `build`+`preview`** em vez de dev/HMR; **screenshotar tudo** a cada passo; re-perguntar design por seção.
+- Inventar dado; placeholder/foto genérica como real; reescrever o que a `ui-ux-pro-max` já sabe; decidir garfo de gosto sozinho.
+- Travar no meio quando um MCP cai (degrade — veja Pré-voo).
+
+---
+
+## Exemplo (build real, mineração B2B)
+"Faz um site pra [empresa], objetivo orçamento; tenho uma demo do ChatGPT só de estrutura." → Read da demo + `firecrawl_map`/scrape seletivo do site atual + WebSearch dos termos técnicos; conteúdo real em `dados-reais.md`. **GATE:** "isso parece **site institucional multipágina**, não LP — o que foi combinado?" → confirma site completo; aprova arquitetura (Home, Empresa, 1 página/serviço, Equipamentos, Obras, Trabalhe Conosco, Contato) + esforço. `ui-ux-pro-max` → industrial bold em `design-system.md` (sem seguir a logo legada, decisão do usuário). Scaffold + `npm run dev`. Folha de contato + WebP batch; constrói em lote; form abre WhatsApp. Screenshot cirúrgico + auditoria → mostra lote → ajusta. No final, build+preview.
+
+## Receitas concretas
+Comandos em **`references/recipes.md`** (scaffold + dev server, tokens OKLCH, batch WebP, folha de contato, pesquisa de nicho, Firecrawl seletivo, screenshot cirúrgico, arquivos de contexto, build/preview, deploy SPA).

--- a/.agents/skills/criativo-construtor-de-site/references/recipes.md
+++ b/.agents/skills/criativo-construtor-de-site/references/recipes.md
@@ -1,0 +1,106 @@
+# Receitas concretas
+
+Comandos por etapa. Exemplos em Windows/PowerShell (adapte em outros SOs). Nunca cole tokens/credenciais reais aqui.
+
+## 1. Scaffold + dev server (loop de iteração)
+
+```bash
+npm create vite@latest <nome-do-site> -- --template react-ts
+cd <nome-do-site>
+npm i
+npm i -D tailwindcss@3 postcss autoprefixer && npx tailwindcss init -p
+npm i react-router-dom motion lucide-react
+npm run dev            # ITERE contra isto (HMR, reload em segundos)
+```
+- **Iteração = `npm run dev`** (HMR). Não use `build`+`preview` pra iterar — é lento e dispara o estouro de memória do rolldown. `build`+`preview` só no **final** (recipe 9).
+- **Rotas (multipágina):** `App.tsx` com `<BrowserRouter>`/`<Routes>`/`<Route>` p/ as páginas aprovadas no GATE. `<Navigate>` p/ redirecionar rotas antigas.
+- **Framer Motion:** `import { motion } from 'motion/react'`; reveal: `initial`/`whileInView`/`viewport={{ once: true }}`; respeite `useReducedMotion`.
+
+## 2. Arquivos de contexto do projeto (dê as regras uma vez)
+
+Crie no projeto do cliente, e mantenha **enxutos**:
+- **`dados-reais.md`** — todo o conteúdo real consolidado (textos, números, depoimentos, contatos, lista de assets). Fonte da verdade pro conteúdo.
+- **`design-system.md`** — tokens (OKLCH), par de fontes, e os padrões de seção/componente decididos com a `ui-ux-pro-max`.
+- **`CLAUDE.md`** (~100 linhas, no root do site) — convenções: stack, onde ficam as coisas, regras (conteúdo real, WebP, a11y), e ponteiros pros dois acima.
+
+Construa **lendo esses arquivos** em vez de re-perguntar design a cada seção. Lean de propósito: arquivo grande causa "context rot".
+
+## 3. Mapear + raspar o site atual (Firecrawl) — seletivo
+
+`firecrawl_map` → lista de URLs. Depois `firecrawl_scrape` **só** nas páginas que (a) definem a arquitetura e (b) têm assets — **não raspe tudo** (infla contexto e queima créditos). `formats:["json"]` com schema pedindo textos/listas/URLs de imagem. Sites antigos servem imagens reduzidas — pra original, baixe a URL base de mídia (sem o transform) ou peça um transform grande. Baixe com User-Agent de navegador:
+```powershell
+Invoke-WebRequest -Uri $url -OutFile $out -Headers @{ "User-Agent"="Mozilla/5.0 ... Chrome/124" }
+```
+Se o Firecrawl estiver fora, peça o conteúdo/fotos ao usuário (não trave).
+
+## 4. Converter imagens → WebP (batch é o padrão)
+
+Pra mais de ~3 fotos, use um **`build-assets.py`** no projeto (um processo, não um por imagem):
+```python
+# build-assets.py — rode com: PYTHONUTF8=1 python build-assets.py
+from PIL import Image, ImageOps
+import os
+JOBS = {
+  'assets-raw/hero.jpg': 'public/images/hero.webp',
+  'assets-raw/servico-1.jpg': 'public/images/servico-1.webp',
+  # ...
+}
+for src, dst in JOBS.items():
+    im = ImageOps.exif_transpose(Image.open(src)).convert('RGB')
+    w, h = im.size; r = min(1.0, 1600 / max(w, h))
+    if r < 1: im = im.resize((int(w*r), int(h*r)))
+    os.makedirs(os.path.dirname(dst), exist_ok=True)
+    im.save(dst, 'WEBP', quality=82, method=6); print('ok', dst, im.size)
+```
+Uma foto só → o one-liner `python -c "..."` resolve.
+
+## 5. Folha de contato (curar fotos)
+Lote de fotos sem nome → monte uma contact sheet pra identificar antes de plotar:
+```bash
+PYTHONUTF8=1 python -c "
+from PIL import Image, ImageOps, ImageDraw
+import glob, os
+files=sorted(glob.glob('assets-raw/*'))[:24]
+cols=3; t=460; p=12; rows=(len(files)+cols-1)//cols
+W=cols*t+(cols+1)*p; H=rows*t+(rows+1)*p
+sheet=Image.new('RGB',(W,H),'white'); d=ImageDraw.Draw(sheet)
+for i,f in enumerate(files):
+    try: im=ImageOps.exif_transpose(Image.open(f)).convert('RGB')
+    except: continue
+    im.thumbnail((t,t)); x=p+(i%cols)*(t+p); y=p+(i//cols)*(t+p)
+    sheet.paste(im,(x,y)); d.text((x+4,y+4), os.path.basename(f), fill='red')
+sheet.save('contact-sheet.jpg', quality=80); print('ok', sheet.size)
+"
+```
+
+## 6. Pesquisa de nicho/local (WebSearch / firecrawl_search)
+Material raso → pesquise fatos **reais** do nicho/local e **cite a fonte** (atrações de uma cidade, normas técnicas de um setor, o que o público procura). Pesquisa fundamenta, não substitui o dado do cliente. Liste as fontes.
+
+## 7. Screenshot de validação (Playwright) — cirúrgico
+Screenshot **só a página/seção que mudou** (imagem = caro em contexto). Varredura completa (1440 + 375) só num marco de review. Antes de capturar, desligue animação e dispare reveals:
+```js
+const s=document.createElement('style');
+s.textContent='*{animation:none !important;transition:none !important}';
+document.head.appendChild(s);
+document.querySelectorAll('img').forEach(i=>i.loading='eager');
+const h=document.body.scrollHeight;
+for(let y=0;y<h;y+=600){ window.scrollTo(0,y); await new Promise(r=>setTimeout(r,50)); }
+window.scrollTo(0,0); await new Promise(r=>setTimeout(r,250));
+```
+Audite: mocks, botão sem handler, contraste, hover-only, imagem quebrada, menu mobile. Playwright fora → peça pro usuário olhar.
+
+## 8. Tokens OKLCH
+`:root` com canais OKLCH + helper no Tailwind (`oklch(var(--x) / <alpha-value>)`). Valores escolhidos com a `ui-ux-pro-max` e gravados no `design-system.md`. Ex.: `--primary: 0.646 0.222 41;` (laranja-segurança). *Por quê OKLCH:* luminosidade perceptual → contraste previsível.
+
+## 9. Build / preview — só no final (Windows-aware)
+```bash
+npm run build
+npm run preview -- --port 4174 --host   # --host libera na rede local
+```
+- Porta livre por cliente (4174 pode estar ocupada por outro preview).
+- Build falhou com "WebAssembly.Memory.grow(): Unable to grow" → é pressão de memória (não erro de código): mate o preview/dev pra liberar RAM e rebuilde.
+- Matar porta no Windows: `Get-NetTCPConnection -LocalPort <porta> -State Listen` → `Stop-Process -Id <pid> -Force`.
+- Rede local: outro PC na mesma Wi-Fi abre `http://<IP>:<porta>/`; pode precisar de regra de firewall (admin/UAC).
+
+## 10. Deploy (opcional)
+SPA precisa de fallback. `vercel.json`: `{ "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }] }`. `.vercelignore` com `dist` + imagens-fonte + temporários. Preview por padrão; produção só se pedirem. Cuidado com o "Vercel Authentication" (Deployment Protection) que exige login por padrão — desligue no painel se o link precisa ser público.

--- a/.claude/skills/criativo-construtor-de-site/SKILL.md
+++ b/.claude/skills/criativo-construtor-de-site/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: criativo-construtor-de-site
+description: Constrói um site de marketing completo e de alta qualidade para um cliente de qualquer nicho — da coleta de conteúdo real e definição de escopo até a validação por screenshot, iterando contra um dev server. Use sempre que o usuário quiser criar, refazer, montar ou "subir" um site, landing page, one-page, hotsite ou presença web para um cliente, negócio ou projeto, mesmo que ele só diga "faz um site pra X", "refaz o site da empresa Y", "preciso de uma página pro meu produto" ou descreva um nicho querendo site. Orquestra a skill ui-ux-pro-max e usa Vite + React + TypeScript + Tailwind + Framer Motion + react-router.
+area: criativo
+author: esdras-onlaine
+version: 1.2.0
+---
+
+# Construtor de Site
+
+Constrói um site de marketing completo para um cliente de **qualquer nicho**, com processo repetível e barra de qualidade fixa — sem clonar o visual de nenhum cliente anterior.
+
+A skill **não reinventa design** (orquestra a `ui-ux-pro-max`) e mantém consistência via **arquivos de contexto do projeto**: grava o conteúdo real e o design-system em `dados-reais.md` + `design-system.md` (e um `CLAUDE.md` enxuto no root do site), pra dar as regras **uma vez** e o agente aplicar em todas as páginas — sem re-perguntar a cada seção.
+
+**Stack travada:** Vite + React + TypeScript + Tailwind v3 + **Framer Motion** (`motion`) + **react-router-dom** (multipágina) + `lucide-react`. O que muda por cliente é a marca, o conteúdo, o escopo e as seções; a stack não.
+
+## Pré-requisitos (skills)
+
+Esta skill **orquestra**, não reimplementa design. Antes de usar, garanta que estas skills estão no ambiente:
+
+- **`ui-ux-pro-max`** — **obrigatória**. É ela que define o sistema de design (estilo, paleta OKLCH, par de fontes, padrões de UX) no passo 3, via `search.py --design-system`. **Não faz parte do Builders Hub** — instale à parte a partir do marketplace de skills. Sem ela, o passo de marca não roda.
+- **`frontend-design`** — **já incluída no hub** (skill base). Usada só pra um componente isolado genuinamente novo; não precisa instalar à parte.
+- **`deploy-to-vercel`** — **opcional**, só pro deploy final (passo 7). Também vem de fora do hub.
+
+## Quando usar
+- "Faz um site pra [negócio]", "refaz o site da [empresa]", "preciso de uma landing pro [produto]".
+- Refatorar/redesenhar um site existente de um cliente.
+
+## Quando NÃO usar
+- Só auditoria de UX de algo pronto → `ui-ux-pro-max`. Componente isolado → `frontend-design`. App com backend/auth/dashboard → é produto, não site de marketing.
+
+---
+
+## Pré-voo (cheque antes de começar)
+Confirme o que está disponível e tenha plano B — **não trave no meio**:
+- **Firecrawl** (raspar site/redes atuais): se indisponível, peça o conteúdo e as fotos ao usuário.
+- **Playwright MCP** (screenshots de validação): se indisponível, peça pro usuário olhar a tela e descrever.
+- **Pillow (Python)** e **Node**: necessários pra imagens e build; se faltar, instale/avise.
+
+## Ferramentas que a skill orquestra
+
+| Etapa | Ferramenta | Pra quê |
+|---|---|---|
+| Coletar | **Firecrawl** (`firecrawl_map` → `firecrawl_scrape` **seletivo**) | Mapear o site atual e raspar **só** as páginas que definem arquitetura + as com assets — não tudo |
+| Coletar | **Read** (docs/PDF/planilhas) | Material enviado: briefing, portfólio, catálogo |
+| Coletar | **WebSearch** / `firecrawl_search` | Fatos reais do nicho/local **com fonte** quando o material é raso — nunca inventar |
+| Definir | **AskUserQuestion** | Fechar tipo/escopo de entrega e aprovar arquitetura/garfos com opções (preview) |
+| Contexto | **Arquivos do projeto** (`dados-reais.md`, `design-system.md`, `CLAUDE.md`) | Persistir conteúdo + regras de design; o agente lê e fica consistente sem re-perguntar |
+| Curar/otimizar fotos | **Pillow** (folha de contato + **batch** WebP) | Identificar fotos; converter em lote pra WebP |
+| Marca | **`ui-ux-pro-max`** (`search.py --design-system`) | **Um passe** de estilo/paleta/tipografia/UX |
+| Construir | **Vite + React + TS + Tailwind + Framer Motion + react-router + lucide** | Site multipágina, animações/reveals, rotas |
+| Iterar/validar | **`npm run dev` (HMR)** + **Playwright** (screenshot **cirúrgico**) | Iterar em segundos; screenshot só do que mudou |
+| Entregar | **PowerShell/Bash**; `deploy-to-vercel` | `build`+`preview` no final; deploy opcional |
+| (opcional) Escalar | **subagents** | Construir páginas independentes em paralelo num site grande |
+
+---
+
+## Princípios inegociáveis
+
+1. **Feche o TIPO e o ESCOPO da entrega ANTES de construir.** "Faz um site pra X" não é one-page. Padrão p/ cliente contratado = **site institucional multipágina**. Analise, recomende, e **pergunte o que foi combinado comercialmente / a expectativa** — a skill não infere isso. (Erro nº 1 num build real: saiu LP no lugar de site.)
+2. **Conteúdo real, nunca inventar.** Vem do cliente (KB, material, site/redes). Faltou contexto do nicho → **pesquise e cite a fonte**. Sem dado → pendência declarada. Demos (inclusive de ChatGPT) servem só de estrutura.
+3. **Contexto em arquivo, não na cabeça.** Grave o conteúdo em `dados-reais.md` e o design em `design-system.md` (+ `CLAUDE.md` enxuto, ~100 linhas). Assim você define as regras **uma vez** e não re-pergunta design a cada seção. Mantenha enxuto (evita "context rot").
+4. **Nada de placeholder em produção.** Falta foto → estado "Foto em breve" desenhado + lista do que falta. Real do acervo > interina do acervo > placeholder declarado.
+5. **Orquestre, não duplique.** Um passe de `ui-ux-pro-max` define o sistema; reconsulte só pra um **componente genuinamente novo**.
+6. **Decisões de garfo são do usuário.** Bifurcações (tipo de entrega, paleta, navbar, blog) → **2–4 opções com preview** (AskUserQuestion). Se ele estiver, na sua leitura, errado, **questione com argumento**.
+7. **Itere contra o dev server.** Construa com **`npm run dev` (HMR)** — segundos por mudança. `build`+`preview` é só pra **validação final / compartilhar / deploy** (e evita o estouro de memória do rolldown que vem do rebuild a cada troca).
+8. **Screenshot é caro — use cirúrgico.** Valide com Playwright **só a página/seção que mudou**; varredura completa (desktop 1440 + mobile 375) só num **marco de review**.
+9. **Checkpoints certos.** Obrigatórios: escopo (GATE), direção de marca, review final. O resto **agrupe** — construa um lote de páginas e revise junto; não peça aprovação por seção.
+10. **Estude o site atual** (`firecrawl_map`) e derive a **arquitetura** — não achate em LP. Avise o **tamanho/esforço** depois de aprovar (ex.: "9 páginas + 40 obras = build grande").
+11. **A11y e mobile desde o começo.** Foco de teclado, focus-trap em modal, `aria`, toque ≥44px, hover nunca como única via, teste 375px.
+12. **Não trave o gosto de um cliente** e **otimize imagens** (WebP ~1600px/q82, `lazy`).
+
+---
+
+## Fluxo
+
+### 1. Coletar (enxuto) → `dados-reais.md`
+Read no material do cliente; `firecrawl_map` pra ver as páginas e `firecrawl_scrape` **seletivo** nas que importam (arquitetura + assets); WebSearch p/ fatos do nicho com fonte. **Consolide o conteúdo real em `dados-reais.md`** (enxuto). Se o Firecrawl estiver fora, peça ao usuário.
+
+### 2. Definir entrega + arquitetura (GATE — não pule)
+Apresente análise e **peça aprovação** antes de codar: tipo de entrega (padrão multipágina; **pergunte o combinado**), mapa de páginas derivado do site atual + objetivo, e o **porquê**. Use AskUserQuestion se houver alternativas. Aprovado → diga o tamanho/esforço.
+
+### 3. Marca → `design-system.md` (um passe)
+Invoque `ui-ux-pro-max` → estilo + paleta (OKLCH) + par de fontes. **Grave em `design-system.md`** (tokens + padrões de seção) e materialize no `index.css`/`tailwind.config`. Itere cor/fonte com o usuário (é garfo). Daqui pra frente, construa a partir desse arquivo.
+
+### 4. Scaffold + dev server
+Vite+React+TS, Tailwind v3, `motion`, `react-router-dom` (rotas aprovadas), `lucide-react`. Suba **`npm run dev`** e itere contra ele.
+
+### 5. Construir (em lote, do design-system)
+Página a página / seção a seção, lendo `design-system.md` (não re-perguntando à ui-ux-pro-max). Folha de contato pra curar fotos; **converta em batch** pra WebP. Garfos → opções com preview. Blog/artigo = **padrão editorial** (~68ch). Em site grande, páginas independentes podem ir pra **subagents** em paralelo.
+
+### 6. Validar e iterar (cirúrgico)
+HMR mostra na hora; **screenshot só do que mudou** (truque: desligar animação + rolar pra disparar reveals) → auditoria a11y/mobile → mostra um **lote** ao usuário → ajusta.
+
+### 7. Entregar
+**Aí sim** `npm run build` + `preview` (`--host` libera na rede). Deploy (Vercel + rewrite SPA) opcional. Declare o que é WIP.
+
+---
+
+## Playbook de arquitetura por objetivo
+
+A **hero + prova social + CTA + rodapé** são quase universais; o miolo muda. Em multipágina, cada bloco pode virar **página**.
+
+| Objetivo | Páginas/seções | CTA |
+|---|---|---|
+| Lead B2B (serviço, indústria) | Home, A Empresa, **1 página por serviço**, Equipamentos, Cases/Obras (filtrável), Trabalhe Conosco, Contato | Solicitar orçamento |
+| Reserva (hotelaria, eventos) | Acomodações/ingressos, experiências, galeria, localização | Reservar |
+| Trial (SaaS, app) | Features, como funciona, planos, FAQ | Começar grátis |
+| Compra (e-commerce) | Produtos, benefícios, reviews, garantia | Comprar |
+| Conteúdo (blog, mídia) | Destaque editorial, grade, newsletter | Assinar |
+
+Sempre: prova social real, rodapé/contato completo, blog (editorial) se o cliente produz conteúdo. Form sem backend pode montar a mensagem e abrir o **WhatsApp** do cliente.
+
+---
+
+## Anti-padrões
+- Achatar o site numa LP quando o combinado é multipágina; construir antes de aprovar escopo/arquitetura.
+- **Iterar com `build`+`preview`** em vez de dev/HMR; **screenshotar tudo** a cada passo; re-perguntar design por seção.
+- Inventar dado; placeholder/foto genérica como real; reescrever o que a `ui-ux-pro-max` já sabe; decidir garfo de gosto sozinho.
+- Travar no meio quando um MCP cai (degrade — veja Pré-voo).
+
+---
+
+## Exemplo (build real, mineração B2B)
+"Faz um site pra [empresa], objetivo orçamento; tenho uma demo do ChatGPT só de estrutura." → Read da demo + `firecrawl_map`/scrape seletivo do site atual + WebSearch dos termos técnicos; conteúdo real em `dados-reais.md`. **GATE:** "isso parece **site institucional multipágina**, não LP — o que foi combinado?" → confirma site completo; aprova arquitetura (Home, Empresa, 1 página/serviço, Equipamentos, Obras, Trabalhe Conosco, Contato) + esforço. `ui-ux-pro-max` → industrial bold em `design-system.md` (sem seguir a logo legada, decisão do usuário). Scaffold + `npm run dev`. Folha de contato + WebP batch; constrói em lote; form abre WhatsApp. Screenshot cirúrgico + auditoria → mostra lote → ajusta. No final, build+preview.
+
+## Receitas concretas
+Comandos em **`references/recipes.md`** (scaffold + dev server, tokens OKLCH, batch WebP, folha de contato, pesquisa de nicho, Firecrawl seletivo, screenshot cirúrgico, arquivos de contexto, build/preview, deploy SPA).

--- a/.claude/skills/criativo-construtor-de-site/references/recipes.md
+++ b/.claude/skills/criativo-construtor-de-site/references/recipes.md
@@ -1,0 +1,106 @@
+# Receitas concretas
+
+Comandos por etapa. Exemplos em Windows/PowerShell (adapte em outros SOs). Nunca cole tokens/credenciais reais aqui.
+
+## 1. Scaffold + dev server (loop de iteração)
+
+```bash
+npm create vite@latest <nome-do-site> -- --template react-ts
+cd <nome-do-site>
+npm i
+npm i -D tailwindcss@3 postcss autoprefixer && npx tailwindcss init -p
+npm i react-router-dom motion lucide-react
+npm run dev            # ITERE contra isto (HMR, reload em segundos)
+```
+- **Iteração = `npm run dev`** (HMR). Não use `build`+`preview` pra iterar — é lento e dispara o estouro de memória do rolldown. `build`+`preview` só no **final** (recipe 9).
+- **Rotas (multipágina):** `App.tsx` com `<BrowserRouter>`/`<Routes>`/`<Route>` p/ as páginas aprovadas no GATE. `<Navigate>` p/ redirecionar rotas antigas.
+- **Framer Motion:** `import { motion } from 'motion/react'`; reveal: `initial`/`whileInView`/`viewport={{ once: true }}`; respeite `useReducedMotion`.
+
+## 2. Arquivos de contexto do projeto (dê as regras uma vez)
+
+Crie no projeto do cliente, e mantenha **enxutos**:
+- **`dados-reais.md`** — todo o conteúdo real consolidado (textos, números, depoimentos, contatos, lista de assets). Fonte da verdade pro conteúdo.
+- **`design-system.md`** — tokens (OKLCH), par de fontes, e os padrões de seção/componente decididos com a `ui-ux-pro-max`.
+- **`CLAUDE.md`** (~100 linhas, no root do site) — convenções: stack, onde ficam as coisas, regras (conteúdo real, WebP, a11y), e ponteiros pros dois acima.
+
+Construa **lendo esses arquivos** em vez de re-perguntar design a cada seção. Lean de propósito: arquivo grande causa "context rot".
+
+## 3. Mapear + raspar o site atual (Firecrawl) — seletivo
+
+`firecrawl_map` → lista de URLs. Depois `firecrawl_scrape` **só** nas páginas que (a) definem a arquitetura e (b) têm assets — **não raspe tudo** (infla contexto e queima créditos). `formats:["json"]` com schema pedindo textos/listas/URLs de imagem. Sites antigos servem imagens reduzidas — pra original, baixe a URL base de mídia (sem o transform) ou peça um transform grande. Baixe com User-Agent de navegador:
+```powershell
+Invoke-WebRequest -Uri $url -OutFile $out -Headers @{ "User-Agent"="Mozilla/5.0 ... Chrome/124" }
+```
+Se o Firecrawl estiver fora, peça o conteúdo/fotos ao usuário (não trave).
+
+## 4. Converter imagens → WebP (batch é o padrão)
+
+Pra mais de ~3 fotos, use um **`build-assets.py`** no projeto (um processo, não um por imagem):
+```python
+# build-assets.py — rode com: PYTHONUTF8=1 python build-assets.py
+from PIL import Image, ImageOps
+import os
+JOBS = {
+  'assets-raw/hero.jpg': 'public/images/hero.webp',
+  'assets-raw/servico-1.jpg': 'public/images/servico-1.webp',
+  # ...
+}
+for src, dst in JOBS.items():
+    im = ImageOps.exif_transpose(Image.open(src)).convert('RGB')
+    w, h = im.size; r = min(1.0, 1600 / max(w, h))
+    if r < 1: im = im.resize((int(w*r), int(h*r)))
+    os.makedirs(os.path.dirname(dst), exist_ok=True)
+    im.save(dst, 'WEBP', quality=82, method=6); print('ok', dst, im.size)
+```
+Uma foto só → o one-liner `python -c "..."` resolve.
+
+## 5. Folha de contato (curar fotos)
+Lote de fotos sem nome → monte uma contact sheet pra identificar antes de plotar:
+```bash
+PYTHONUTF8=1 python -c "
+from PIL import Image, ImageOps, ImageDraw
+import glob, os
+files=sorted(glob.glob('assets-raw/*'))[:24]
+cols=3; t=460; p=12; rows=(len(files)+cols-1)//cols
+W=cols*t+(cols+1)*p; H=rows*t+(rows+1)*p
+sheet=Image.new('RGB',(W,H),'white'); d=ImageDraw.Draw(sheet)
+for i,f in enumerate(files):
+    try: im=ImageOps.exif_transpose(Image.open(f)).convert('RGB')
+    except: continue
+    im.thumbnail((t,t)); x=p+(i%cols)*(t+p); y=p+(i//cols)*(t+p)
+    sheet.paste(im,(x,y)); d.text((x+4,y+4), os.path.basename(f), fill='red')
+sheet.save('contact-sheet.jpg', quality=80); print('ok', sheet.size)
+"
+```
+
+## 6. Pesquisa de nicho/local (WebSearch / firecrawl_search)
+Material raso → pesquise fatos **reais** do nicho/local e **cite a fonte** (atrações de uma cidade, normas técnicas de um setor, o que o público procura). Pesquisa fundamenta, não substitui o dado do cliente. Liste as fontes.
+
+## 7. Screenshot de validação (Playwright) — cirúrgico
+Screenshot **só a página/seção que mudou** (imagem = caro em contexto). Varredura completa (1440 + 375) só num marco de review. Antes de capturar, desligue animação e dispare reveals:
+```js
+const s=document.createElement('style');
+s.textContent='*{animation:none !important;transition:none !important}';
+document.head.appendChild(s);
+document.querySelectorAll('img').forEach(i=>i.loading='eager');
+const h=document.body.scrollHeight;
+for(let y=0;y<h;y+=600){ window.scrollTo(0,y); await new Promise(r=>setTimeout(r,50)); }
+window.scrollTo(0,0); await new Promise(r=>setTimeout(r,250));
+```
+Audite: mocks, botão sem handler, contraste, hover-only, imagem quebrada, menu mobile. Playwright fora → peça pro usuário olhar.
+
+## 8. Tokens OKLCH
+`:root` com canais OKLCH + helper no Tailwind (`oklch(var(--x) / <alpha-value>)`). Valores escolhidos com a `ui-ux-pro-max` e gravados no `design-system.md`. Ex.: `--primary: 0.646 0.222 41;` (laranja-segurança). *Por quê OKLCH:* luminosidade perceptual → contraste previsível.
+
+## 9. Build / preview — só no final (Windows-aware)
+```bash
+npm run build
+npm run preview -- --port 4174 --host   # --host libera na rede local
+```
+- Porta livre por cliente (4174 pode estar ocupada por outro preview).
+- Build falhou com "WebAssembly.Memory.grow(): Unable to grow" → é pressão de memória (não erro de código): mate o preview/dev pra liberar RAM e rebuilde.
+- Matar porta no Windows: `Get-NetTCPConnection -LocalPort <porta> -State Listen` → `Stop-Process -Id <pid> -Force`.
+- Rede local: outro PC na mesma Wi-Fi abre `http://<IP>:<porta>/`; pode precisar de regra de firewall (admin/UAC).
+
+## 10. Deploy (opcional)
+SPA precisa de fallback. `vercel.json`: `{ "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }] }`. `.vercelignore` com `dist` + imagens-fonte + temporários. Preview por padrão; produção só se pedirem. Cuidado com o "Vercel Authentication" (Deployment Protection) que exige login por padrão — desligue no painel se o link precisa ser público.


### PR DESCRIPTION
## Skill sendo compartilhada

**Nome:** `criativo-construtor-de-site`
**Area:** criativo
**Autor:** @esdras-onlaine
**Versao:** 1.2.0

## O que ela faz

Constroi um site de marketing completo e de alta qualidade para um cliente de qualquer nicho, da coleta de conteudo real e definicao de escopo ate a validacao por screenshot, iterando contra um dev server. Orquestra a `ui-ux-pro-max` e usa a stack Vite + React + TypeScript + Tailwind + Framer Motion + react-router.

## Dependencias

- **`ui-ux-pro-max`** (obrigatoria) — define o sistema de design (estilo, paleta OKLCH, fontes, UX) no passo 3. **Nao faz parte do hub** — vem do marketplace de skills. Documentado na secao "Pre-requisitos" do SKILL.md.
- **`frontend-design`** — ja incluida no hub (skill base).
- **`deploy-to-vercel`** — opcional, so pro deploy final.

## Como testar

1. Rode `/sync-hub` pra puxar a branch localmente (e garanta a `ui-ux-pro-max` instalada)
2. Peca algo como: "faz um site pra [negocio de qualquer nicho]"
3. Valide que ela fecha escopo (GATE), faz um passe de marca via ui-ux-pro-max, faz scaffold Vite+React e itera contra o dev server com screenshots cirurgicos

## Checklist do contribuidor

- [x] Nome segue `{area}-{slug}` em kebab-case
- [x] Frontmatter completo (name, description, area, author, version)
- [x] Duplo-write em .claude/ e .agents/ (conteudo identico)
- [x] Testada em builds reais (mineracao B2B, entre outros)
- [x] Sem credenciais, tokens, clientes reais, dados pessoais
- [x] Portugues brasileiro

---

_Gerado via `/compartilhar-skill`._