### PR TITLE
feat(skills): add geral-postar-conteudo-meta

### DIFF
--- a/.agents/skills/geral-postar-conteudo-meta/SKILL.md
+++ b/.agents/skills/geral-postar-conteudo-meta/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: geral-postar-conteudo-meta
+description: Agenda posts estáticos e Reels de um lote de conteúdo social direto no Meta Business Suite (Facebook + Instagram), de verdade, via automação de browser real conectado à sessão logada do cliente. Use sempre que o usuário tiver uma pasta de vídeos/imagens + um documento de copy pra agendar/publicar no Facebook ou Instagram, mencionar "agendar posts", "postar no Meta Business Suite", "programar reels", "automatizar publicação de calendário de conteúdo", ou pedir pra você "postar" um lote de criativos aprovados. Não é a skill certa pra gerenciar campanhas de anúncios pagos (use notfair:meta-ads ou adkit pra isso) — é especificamente sobre conteúdo orgânico agendado no Planner.
+area: geral
+author: juan
+version: 1.0.0
+---
+
+# Postar conteúdo social no Meta Business Suite
+
+Pega um lote de conteúdo (vídeos + estáticos + doc de copy) e agenda os posts de verdade no Meta Business Suite, via Playwright conectado por CDP num Chrome real já aberto (não headless) — assim a sessão logada do cliente é reaproveitada, sem precisar automatizar login.
+
+## Antes de começar — pergunte, não assuma
+
+Esta skill é usada por pessoas diferentes, em máquinas diferentes, com clientes diferentes. **Nunca assuma nenhum destes pontos** — pergunte diretamente (pode usar uma pergunta de múltipla escolha ou texto livre, o importante é não adivinhar):
+
+1. **Nome do cliente.** Curto, sem espaço/acento (ex: `ClienteExemplo`, `ClinicaXYZ`) — vai isolar o perfil de automação desse cliente dos outros, pra não misturar logins.
+2. **Onde estão os arquivos de mídia** no computador da pessoa (pasta com os vídeos/imagens do lote).
+3. **Qual perfil do Chrome já está logado** na conta do Meta Business Suite desse cliente. Oriente a pessoa a: abrir o Chrome normal dela (o que já usa pra entrar nesse cliente), digitar `chrome://version` na barra de endereço, e te passar o valor de **"Profile Path"** — só a última pasta do caminho (ex: `Profile 3`, `Default`).
+4. **Se já existe um perfil de automação pra esse cliente** (pergunte se essa pessoa já rodou essa skill antes pra esse cliente nessa máquina). Se não existe, ela vai precisar **logar manualmente uma vez** — você nunca deve tentar logar por ela nem pedir senha/2FA. Só oriente e espere ela confirmar que logou.
+5. **Regras de cronograma**: cadência (todo dia? um dia sim um dia não? datas fixas?), horário(s), se pula fim de semana, e a partir de quando começa. Depois de definidas, **valide contra o calendário real** (rode algo como `date -d <data> +%A` — nunca assuma que "amanhã" cai num dia útil sem checar).
+
+Só depois de ter essas respostas, siga pro passo a passo.
+
+## Passo a passo
+
+### 1. Mapear arquivo ↔ post
+
+Os nomes de arquivo quase nunca batem com o número/nome do post no doc de copy. **Abra cada imagem/vídeo e compare visualmente** com o headline/tema de cada post antes de montar o plano — não assuma pela ordem alfabética ou numérica do nome do arquivo. Erro aqui é o mais comum e o mais fácil de não perceber até tarde (ver item 7 de `references/gotchas-tecnicos.md`).
+
+### 2. Limpar a legenda (se aplicável)
+
+Se o doc de copy do usuário tiver convenções específicas (ex: label "CTA:" antes do call-to-action, travessões `–`/`—` no meio das frases), pergunte se ele quer que você limpe isso antes de postar — não aplique regras de limpeza que não foram pedidas. Um padrão comum que já apareceu: remover a label "CTA:" (o texto vira só mais uma frase no fim da legenda) e trocar travessões por vírgula/ponto/dois-pontos.
+
+### 3. Calcular o cronograma
+
+Com as regras confirmadas no passo "antes de começar", gere as datas concretas e valide cada uma contra o dia da semana real. Se cair em dia que deveria ser pulado (fim de semana, por exemplo), ajuste e avise o usuário do ajuste.
+
+### 4. Gerar o plano.json
+
+Ver `references/plano-exemplo.json` pro formato exato. Por post: número, tema, tipo (`ESTATICO`/`VIDEO`), ação no Meta Business Suite (`Criar post`/`Criar Reel`), nome do arquivo, data (`YYYY-MM-DD`), dia da semana, hora (`HH:MM`), legenda já limpa, hashtags. Salvar num arquivo acessível (ex: pasta do cliente/campanha do usuário).
+
+### 5. Preparar o Chrome com debug remoto
+
+**Primeira vez com esse cliente nessa máquina** (depois de já ter o nome do perfil Chrome via `chrome://version`):
+```
+scripts\setup_perfil_automacao.bat NOME_CLIENTE "NOME_DO_PERFIL_CHROME_JA_LOGADO"
+```
+Isso cria um perfil de automação isolado pra esse cliente, copiando os dados essenciais (sem cache) do perfil real, e abre o Chrome nele. **A sessão não vem logada automaticamente** (cookies não sobrevivem à cópia — ver item 2 de `references/gotchas-tecnicos.md`) — a pessoa precisa logar manualmente ali, uma vez só, e confirmar que a página/conta certa do Meta Business Suite está selecionada.
+
+**Já configurado antes:**
+```
+scripts\abrir_chrome_automacao.bat NOME_CLIENTE
+```
+Fecha qualquer Chrome aberto e reabre o perfil de automação desse cliente, já logado, com a porta de debug ativa.
+
+Confirmar que funcionou: `curl -s http://127.0.0.1:9222/json/version` deve devolver um JSON com a versão do Chrome. Se não responder, ver item 1 de `references/gotchas-tecnicos.md`.
+
+### 6. Rodar o script, post por post
+
+```
+python scripts\postar_conteudo.py --plan <plano.json> --media-dir <pasta> --post <numero>
+```
+Sem `--confirm`: monta tudo (upload, legenda, agendamento) e **para antes de publicar**, salvando uma prévia em `preview_post<N>.png`. **Sempre mostrar essa prévia pro usuário e confirmar antes de publicar de fato** — publicar em conta real de cliente é uma ação visível externamente e difícil de desfazer, então essa confirmação não é opcional.
+
+Depois de aprovado, rodar de novo com `--confirm` (não continua de onde parou — refaz o fluxo inteiro e desta vez clica em Programar de verdade):
+```
+python scripts\postar_conteudo.py --plan <plano.json> --media-dir <pasta> --post <numero> --confirm
+```
+
+Repetir pra cada post do lote. O próprio Meta mostra um popup de confirmação ("Seu post foi programado" / "Reel programado") depois de cada `--confirm` bem-sucedido — essa é a fonte da verdade, não precisa reabrir o calendário pra conferir (ver item 8 de `references/gotchas-tecnicos.md` sobre por que isso é arriscado).
+
+## Quando algo quebrar
+
+Ler `references/gotchas-tecnicos.md` — cobre os 9 problemas reais já encontrados (porta de debug não sobe, login não sobrevive a cópia de perfil, upload de arquivo grande, botões duplicados no Meta, etc.), cada um com sintoma, causa e a solução que já está embutida nos scripts.
+
+## Limites conhecidos
+
+- Não automatiza login (nunca deve pedir senha/2FA ao usuário nem tentar preencher esses campos).
+- Assume Windows + Google Chrome instalado no caminho padrão (`C:\Program Files\Google\Chrome\Application\chrome.exe`).
+- Um perfil de automação por cliente evita conflito de sessão entre clientes diferentes, mas ainda depende da pessoa ter, ela mesma, acesso de login à conta do Meta Business Suite daquele cliente.

--- a/.agents/skills/geral-postar-conteudo-meta/references/gotchas-tecnicos.md
+++ b/.agents/skills/geral-postar-conteudo-meta/references/gotchas-tecnicos.md
@@ -1,0 +1,75 @@
+# Gotchas técnicos (por que o script é do jeito que é)
+
+Ler isto quando algo der errado no meio da automação — cada item explica o sintoma, a causa real e a solução já embutida no script/scripts `.bat`.
+
+## 1. Porta de debug do Chrome não sobe
+
+**Sintoma:** `curl http://127.0.0.1:9222/json/version` não responde (conexão recusada), mesmo com o Chrome aberto e `--remote-debugging-port=9222` na linha de comando do processo.
+
+**Causa:** Chrome moderno (a partir de ~v136) **ignora silenciosamente** `--remote-debugging-port` quando o `--user-data-dir` resolvido é o diretório "de verdade" (o `User Data` default da instalação) — proteção contra apps maliciosos anexarem debugger no navegador real do usuário. Só funciona se o `--user-data-dir` apontar pra um diretório **diferente** do default.
+
+**Solução:** os scripts `setup_perfil_automacao.bat`/`abrir_chrome_automacao.bat` sempre usam `--user-data-dir=...\ChromeAutomationProfile_<Cliente>` (nunca o default), então isso já vem resolvido — só usar os scripts, não abrir o Chrome manualmente sem essa flag.
+
+## 2. Perfil de automação abre sem login (mesmo tendo copiado o perfil real)
+
+**Sintoma:** copiou a pasta do perfil real pro perfil de automação, mas a sessão do Facebook/Instagram não veio junto — cai na tela de login.
+
+**Causa:** o Chrome criptografa cookies de um jeito vinculado ao caminho/instalação específica ("app-bound encryption"). Uma cópia crua da pasta de perfil não decripta certo no caminho novo.
+
+**Solução:** não tem workaround de cópia — **é preciso logar manualmente, uma vez só**, dentro do próprio perfil de automação (depois que ele já existe, com a porta de debug ativa). Depois disso a sessão fica salva ali normalmente, como qualquer perfil comum do Chrome, sem precisar mexer em cookies de novo.
+
+## 3. PowerShell corta o comando de abrir o Chrome em pedaços errados
+
+**Sintoma:** ao montar o comando de `Start-Process -ArgumentList` manualmente (fora dos `.bat` prontos), argumentos com espaço (`"User Data"`, `"Profile 10"`) ficam truncados, e o Chrome abre um perfil em branco.
+
+**Causa:** `Start-Process -ArgumentList` não coloca aspas automaticamente em cada elemento da lista — se o valor tem espaço e você não escapou as aspas manualmente dentro da string, o PowerShell quebra no espaço.
+
+**Solução:** usar os `.bat` prontos (que já lidam com isso via `cmd.exe`/`start`), em vez de montar o comando via PowerShell na mão.
+
+## 4. Upload de vídeo grande trava ou dá erro "Cannot transfer files larger than 50Mb"
+
+**Sintoma:** `file_chooser.set_files(caminho)` ou `locator.set_input_files(caminho)` falha com esse erro exato pra vídeos grandes (a maioria passa de 50MB facilmente).
+
+**Causa:** Playwright, quando conectado via `connect_over_cdp` (em vez de ter lançado o navegador ele mesmo), trata a conexão como "não colocalizada" e tenta transferir o conteúdo do arquivo inteiro em base64 pelo protocolo — o que tem um teto de 50MB.
+
+**Solução:** o script usa CDP puro pra contornar isso (`upload_media_raw_cdp()`): registra um listener no evento `Page.fileChooserOpened` (que devolve um `backendNodeId` direto, sem precisar ler o arquivo), e chama `DOM.setFileInputFiles` com esse id — isso manda o próprio Chrome ler o arquivo do disco local, sem limite de tamanho. Funciona pra qualquer tamanho de arquivo, então o script usa esse caminho sempre (até pra imagens pequenas), evitando dois caminhos de código diferentes.
+
+## 5. Botões "Avançar"/"Programar" clicam no elemento errado (setinha de carrossel)
+
+**Sintoma:** clicar no botão "Avançar" (ou "Programar") não avança o wizard do Reel — em vez disso, só troca as miniaturas sugeridas de capa.
+
+**Causa:** o Meta Business Suite tem **dois elementos com o mesmo texto acessível** na tela ao mesmo tempo: o botão real do rodapé, e a setinha de "próxima página" do carrossel de miniaturas sugeridas (que por acaso também se chama "Avançar"/"Programar" pra leitor de tela). `get_by_role("button", name="Avançar")` encontra os dois.
+
+**Solução:** a função `click_widest()` sempre pega o elemento **mais largo** entre os que casam o texto — o botão real do rodapé é bem maior que a setinha do carrossel.
+
+## 6. Botão "Próximo mês" do calendário não é encontrado por nenhum seletor "normal"
+
+**Sintoma:** `locator("[aria-label='Próximo mês']")` ou `locator("button", has_text=...)` não encontram nada, mesmo com a seta "›" visível na tela ao lado do nome do mês.
+
+**Causa:** o texto "Próximo mês" existe no DOM como texto puro dentro de uma `<div>` sem `role="button"` nem `aria-label` — é um padrão de acessibilidade "screen-reader-only" (texto sem tamanho visual, sobreposto à seta visual de verdade). Um clique por coordenada de tela funciona (a seta está lá visualmente), mas selecionar por atributo não acha o elemento certo.
+
+**Solução:** `composer.get_by_text("Próximo mês", exact=True).click(force=True)` — `force=True` ignora o check de visibilidade do Playwright (que bloquearia o clique num elemento de tamanho zero) e ainda assim dispara o evento de clique real no elemento certo.
+
+## 7. Mapeamento arquivo ↔ post errado (imagem/vídeo publicado não bate com a legenda)
+
+**Sintoma:** o preview no Meta mostra uma imagem/vídeo diferente do que o número do post sugeria.
+
+**Causa:** os nomes dos arquivos de mídia quase nunca batem com a numeração dos posts no doc de copy (ex: `post 15.png` pode ser na verdade o conteúdo do "POST 12" do doc). Isso não é um bug do script — é erro de leitura humana/IA ao montar o `plano.json`.
+
+**Solução:** sempre abrir cada imagem/vídeo e comparar visualmente com o headline/tema de cada POST no doc **antes** de gerar o plano, e sempre rodar o script primeiro **sem `--confirm`** pra conferir o preview antes de publicar de fato.
+
+## 8. Clicar numa célula vazia do calendário do Planner abre um rascunho novo
+
+**Sintoma:** ao tentar conferir visualmente se os posts foram agendados clicando no calendário, abre um "Criar post" em branco, pré-preenchido com a data/hora daquele espaço.
+
+**Causa:** é uma feature de "criação rápida" do próprio Meta Business Suite — clicar em espaço vazio de um dia/hora cria um rascunho novo naquele horário.
+
+**Solução:** não usar cliques no calendário como forma de auditar se os posts foram agendados — a fonte da verdade é o popup de confirmação que o próprio Meta mostra depois de "Programar" ("Seu post foi programado" / "Reel programado"). Se abrir um rascunho em branco sem querer: fechar pelo **X do modal** (não o botão "Cancelar" de trás, que fica coberto/bloqueado pelo modal), depois "Cancelar" no composer.
+
+## 9. Acentos saem corrompidos no terminal do Windows
+
+**Sintoma:** `print()` com texto acentuado (ex: "não", "mês") solta `UnicodeEncodeError` ou imprime `?`/`�` no console.
+
+**Causa:** o console do Windows por padrão usa a codepage `cp1252`, que não cobre todos os caracteres UTF-8.
+
+**Solução:** rodar o script com `PYTHONIOENCODING=utf-8` na frente do comando quando for inspecionar saída de texto acentuado, ou simplesmente confiar nos screenshots (`preview_post<N>.png`) em vez do texto impresso no terminal pra conferir conteúdo.

--- a/.agents/skills/geral-postar-conteudo-meta/references/plano-exemplo.json
+++ b/.agents/skills/geral-postar-conteudo-meta/references/plano-exemplo.json
@@ -1,0 +1,38 @@
+{
+  "cliente": "Cliente Exemplo",
+  "lote": "conteudo-social-exemplo",
+  "pasta_origem": "C:\\Users\\usuario\\Downloads\\lote-conteudo-exemplo",
+  "gerado_em": "2026-01-10",
+  "status": "aguardando publicação",
+  "regras_aplicadas": {
+    "cadencia": "um dia sim, um dia não, pulando sábado e domingo",
+    "horarios": "alternando 10:00 e 15:00",
+    "inicio": "próximo dia útil a partir de 2026-01-10"
+  },
+  "posts": [
+    {
+      "post": 1,
+      "tema": "Exemplo de tema do post estático",
+      "tipo": "ESTATICO",
+      "acao_meta_business": "Criar post",
+      "arquivo": "imagem-exemplo.png",
+      "data": "2026-01-12",
+      "dia_semana": "segunda",
+      "hora": "10:00",
+      "legenda": "Texto de exemplo da legenda, já limpo (sem 'CTA:' e sem travessão).\n\nCall to action final como frase normal.",
+      "hashtags": "#ExemploHashtag1 #ExemploHashtag2 #ExemploHashtag3"
+    },
+    {
+      "post": 2,
+      "tema": "Exemplo de tema do reel",
+      "tipo": "VIDEO",
+      "acao_meta_business": "Criar Reel",
+      "arquivo": "video-exemplo.mp4",
+      "data": "2026-01-14",
+      "dia_semana": "quarta",
+      "hora": "15:00",
+      "legenda": "Texto de exemplo da legenda do reel.",
+      "hashtags": "#ExemploHashtag1 #ExemploHashtag4"
+    }
+  ]
+}

--- a/.agents/skills/geral-postar-conteudo-meta/scripts/abrir_chrome_automacao.bat
+++ b/.agents/skills/geral-postar-conteudo-meta/scripts/abrir_chrome_automacao.bat
@@ -1,0 +1,39 @@
+@echo off
+setlocal
+
+if "%~1"=="" (
+    echo Uso: abrir_chrome_automacao.bat NOME_CLIENTE
+    echo.
+    echo   NOME_CLIENTE   o mesmo nome usado no setup_perfil_automacao.bat pra esse cliente
+    echo.
+    echo Exemplo: abrir_chrome_automacao.bat ClienteExemplo
+    echo.
+    echo Se ainda nao existe perfil de automacao pra esse cliente, rode primeiro:
+    echo   setup_perfil_automacao.bat NOME_CLIENTE "NOME_DO_PERFIL_CHROME_JA_LOGADO"
+    exit /b 1
+)
+
+set CLIENTE=%~1
+set DEST=C:\Users\%USERNAME%\AppData\Local\ChromeAutomationProfile_%CLIENTE%
+
+if not exist "%DEST%" (
+    echo Nao existe perfil de automacao para "%CLIENTE%" ainda.
+    echo Rode primeiro: setup_perfil_automacao.bat %CLIENTE% "NOME_DO_PERFIL_CHROME_JA_LOGADO"
+    exit /b 1
+)
+
+echo Fechando Chrome existente...
+taskkill /F /IM chrome.exe >nul 2>&1
+timeout /t 2 /nobreak >nul
+
+REM NAO ressincroniza do perfil real aqui: esse perfil de automacao ja tem login
+REM proprio (feito uma vez via setup_perfil_automacao.bat). Ressincronizar
+REM sobrescreveria a sessao logada. Pra recriar do zero, rode setup de novo.
+
+echo Abrindo Chrome com debug remoto (porta 9222) no perfil de automacao de %CLIENTE%...
+start "" "C:\Program Files\Google\Chrome\Application\chrome.exe" --remote-debugging-port=9222 --user-data-dir="%DEST%" --profile-directory="Default" --no-first-run "https://business.facebook.com/latest/content_calendar"
+
+echo.
+echo Chrome abrindo no perfil de automacao de %CLIENTE%. Confira se a pagina/conta certa
+echo do Meta Business Suite esta selecionada antes de rodar postar_conteudo.py.
+pause

--- a/.agents/skills/geral-postar-conteudo-meta/scripts/postar_conteudo.py
+++ b/.agents/skills/geral-postar-conteudo-meta/scripts/postar_conteudo.py
@@ -1,0 +1,289 @@
+# -*- coding: utf-8 -*-
+"""
+Automacao de postagem no Meta Business Suite (Planner) via Playwright + CDP.
+
+Pre-requisito: Chrome aberto com --remote-debugging-port=9222 (ou a porta passada
+em --cdp) no perfil de automacao do cliente certo, ja logado no Meta Business
+Suite na pagina certa. Use abrir_chrome_automacao.bat / setup_perfil_automacao.bat
+pra isso.
+
+Uso:
+    python postar_conteudo.py --plan <plano.json> --post <numero> --media-dir <pasta> [--confirm] [--cdp http://127.0.0.1:9222]
+
+Sem --confirm: faz tudo (upload, legenda, data/hora) e para ANTES do clique final
+de Programar, tirando um screenshot pra revisao em preview_post<N>.png.
+Com --confirm: roda tudo de novo do zero (nao continua de um dry-run anterior) e
+clica em Programar/Compartilhar de verdade, fechando os popups de upsell.
+
+Rode duas vezes: primeiro sem --confirm pra revisar a previa, depois com --confirm
+pra publicar.
+"""
+import argparse
+import json
+import os
+import time
+from playwright.sync_api import sync_playwright
+
+SCRATCH = os.path.dirname(os.path.abspath(__file__))
+
+MESES_PT = ["janeiro", "fevereiro", "março", "abril", "maio", "junho",
+            "julho", "agosto", "setembro", "outubro", "novembro", "dezembro"]
+
+
+def get_composer_frame(page, timeout=20):
+    start = time.time()
+    while time.time() - start < timeout:
+        for f in page.frames:
+            if "composer" in f.url:
+                return f
+        page.wait_for_timeout(300)
+    raise RuntimeError("Frame do composer nao encontrado a tempo. O Chrome esta "
+                        "na pagina do Planner do Meta Business Suite, na conta certa?")
+
+
+def click_widest(locator_set, label=""):
+    """Entre varios elementos com o mesmo texto/role, clica no de maior largura
+    (evita setinhas de carrossel/paginacao que tem o mesmo texto acessivel)."""
+    best, best_w = None, 0
+    for i in range(locator_set.count()):
+        box = locator_set.nth(i).bounding_box()
+        if box and box["width"] > best_w:
+            best_w, best = box["width"], i
+    if best is None:
+        raise RuntimeError(f"Nenhum elemento visivel encontrado para {label}")
+    locator_set.nth(best).click()
+
+
+def upload_media_raw_cdp(ctx, page, composer, button_text, media_path):
+    """Upload via CDP puro (DOM.setFileInputFiles), sem limite de tamanho de
+    arquivo -- necessario pois arquivos >50MB nao passam pelo set_files normal
+    quando conectado via connect_over_cdp."""
+    if not os.path.exists(media_path):
+        raise FileNotFoundError(f"Arquivo de midia nao encontrado: {media_path}")
+
+    cdp = ctx.new_cdp_session(page)
+    captured = {}
+
+    def handler(params):
+        captured.update(params)
+    cdp.on("Page.fileChooserOpened", handler)
+    cdp.send("Page.enable")
+    cdp.send("Page.setInterceptFileChooserDialog", {"enabled": True})
+
+    composer.get_by_text(button_text).first.click()
+    page.wait_for_timeout(1500)
+
+    if "backendNodeId" not in captured:
+        raise RuntimeError("Nao capturou o evento de selecao de arquivo.")
+
+    cdp.send("DOM.setFileInputFiles", {
+        "backendNodeId": captured["backendNodeId"],
+        "files": [media_path],
+    })
+
+
+def wait_upload_complete(composer, page, max_wait=180):
+    """Espera a barra de progresso do upload de video chegar a 100%."""
+    start = time.time()
+    while time.time() - start < max_wait:
+        txt = composer.locator("body").inner_text()
+        if "100%" in txt:
+            return
+        page.wait_for_timeout(2000)
+
+
+def fill_caption(page, composer, text):
+    target = composer.locator("[contenteditable='true']").first
+    target.click()
+    page.keyboard.press("Control+A")
+    page.keyboard.press("Delete")
+    page.wait_for_timeout(200)
+    page.keyboard.insert_text(text)
+    page.wait_for_timeout(400)
+    page.keyboard.press("Escape")
+    page.wait_for_timeout(300)
+
+
+def find_calendar_header(composer):
+    """Acha o texto do cabecalho do calendario ('julho de 2026') procurando
+    por qual nome de mes esta visivel no momento."""
+    for idx, nome in enumerate(MESES_PT, start=1):
+        loc = composer.get_by_text(f"{nome} de", exact=False)
+        cnt = loc.count()
+        for i in range(cnt):
+            el = loc.nth(i)
+            if el.is_visible():
+                return idx, el
+    return None, None
+
+
+def navigate_calendar_to_month(composer, page, target_month_idx, target_year):
+    """Depois de abrir o calendario, avanca de mes ate bater com o alvo."""
+    for _ in range(14):
+        current_idx, header_el = find_calendar_header(composer)
+        if current_idx is None:
+            return
+        text = header_el.inner_text().strip()
+        if str(target_year) in text and MESES_PT[target_month_idx - 1] in text:
+            return
+        # o botao "Proximo mes" e um texto de leitor de tela sem tamanho visual
+        # (sem aria-label, sem role=button visivel) -- so funciona com force click
+        next_btn = composer.get_by_text("Próximo mês", exact=True).first
+        next_btn.click(force=True)
+        page.wait_for_timeout(400)
+
+
+def set_date_field(page, composer, input_locator, day, month_idx, year):
+    input_locator.click()
+    page.wait_for_timeout(500)
+    navigate_calendar_to_month(composer, page, month_idx, year)
+    composer.get_by_text(str(day), exact=True).first.click()
+    page.wait_for_timeout(400)
+
+
+def set_time_field(page, hora_input, min_input, hour, minute):
+    hora_input.click()
+    page.keyboard.press("Control+A")
+    page.keyboard.type(f"{hour:02d}")
+    min_input.click()
+    page.keyboard.press("Control+A")
+    page.keyboard.type(f"{minute:02d}")
+
+
+def post_estatico(ctx, page, post, media_path, confirm):
+    page.get_by_role("button", name="Criar post").first.click()
+    composer = get_composer_frame(page)
+    page.wait_for_timeout(1500)
+
+    upload_media_raw_cdp(ctx, page, composer, "Adicionar foto/vídeo", media_path)
+    page.wait_for_timeout(4000)
+
+    fill_caption(page, composer, post["legenda"] + "\n\n" + post["hashtags"])
+    composer.get_by_text("Detalhes do post", exact=True).click()
+
+    switch = composer.locator("input[aria-label='Definir data e hora']")
+    switch.click()
+    page.wait_for_timeout(1000)
+
+    year, month, day = post["data"].split("-")
+    hour, minute = post["hora"].split(":")
+    date_inputs = composer.locator("input")
+
+    set_date_field(page, composer, date_inputs.nth(2), int(day), int(month), int(year))
+    set_date_field(page, composer, date_inputs.nth(5), int(day), int(month), int(year))
+
+    horas = composer.locator("input[aria-label='horas']")
+    minutos = composer.locator("input[aria-label='minutos']")
+    set_time_field(page, horas.nth(0), minutos.nth(0), int(hour), int(minute))
+    set_time_field(page, horas.nth(1), minutos.nth(1), int(hour), int(minute))
+
+    page.wait_for_timeout(1000)
+    shot = os.path.join(SCRATCH, f"preview_post{post['post']}.png")
+    page.screenshot(path=shot)
+    print("Preview salvo em:", shot)
+
+    if not confirm:
+        print("Rode de novo com --confirm para publicar de fato.")
+        return
+
+    click_widest(composer.get_by_role("button", name="Programar"), "Programar")
+    page.wait_for_timeout(4000)
+    try:
+        page.get_by_text("Talvez mais tarde", exact=True).click(timeout=5000)
+    except Exception:
+        pass
+    print(f"POST {post['post']} programado.")
+
+
+def post_video(ctx, page, post, media_path, confirm):
+    caret = page.get_by_role("button").nth(2)
+    caret.click()
+    page.wait_for_timeout(800)
+    page.get_by_text("Criar reel", exact=True).click()
+    composer = get_composer_frame(page)
+    page.wait_for_timeout(2000)
+
+    upload_media_raw_cdp(ctx, page, composer, "Adicionar vídeo", media_path)
+    wait_upload_complete(composer, page)
+    page.wait_for_timeout(2000)
+
+    fill_caption(page, composer, post["legenda"] + "\n\n" + post["hashtags"])
+    composer.get_by_text("Detalhes do reel", exact=True).click()
+    page.wait_for_timeout(500)
+
+    # Criar -> Editar
+    click_widest(composer.get_by_role("button", name="Avançar"), "Avancar1")
+    page.wait_for_timeout(3000)
+    # Editar -> Compartilhar
+    click_widest(composer.get_by_role("button", name="Avançar"), "Avancar2")
+    page.wait_for_timeout(3000)
+
+    composer.get_by_text("Programar", exact=True).click()
+    page.wait_for_timeout(1500)
+
+    year, month, day = post["data"].split("-")
+    hour, minute = post["hora"].split(":")
+    inputs = composer.locator("input")
+
+    set_date_field(page, composer, inputs.nth(0), int(day), int(month), int(year))
+    set_date_field(page, composer, inputs.nth(3), int(day), int(month), int(year))
+    set_time_field(page, inputs.nth(1), inputs.nth(2), int(hour), int(minute))
+    set_time_field(page, inputs.nth(4), inputs.nth(5), int(hour), int(minute))
+
+    page.wait_for_timeout(1000)
+    shot = os.path.join(SCRATCH, f"preview_post{post['post']}.png")
+    page.screenshot(path=shot)
+    print("Preview salvo em:", shot)
+
+    if not confirm:
+        print("Rode de novo com --confirm para publicar de fato.")
+        return
+
+    click_widest(composer.get_by_role("button", name="Programar"), "ProgramarFinal")
+    page.wait_for_timeout(4000)
+    try:
+        page.get_by_text("Concluir", exact=True).click(timeout=5000)
+    except Exception:
+        pass
+    print(f"POST {post['post']} (reel) programado.")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--plan", required=True, help="Caminho pro plano.json do lote")
+    ap.add_argument("--post", required=True, type=int, help="Numero do post dentro do plano")
+    ap.add_argument("--media-dir", required=True, help="Pasta onde estao os arquivos de midia")
+    ap.add_argument("--confirm", action="store_true", help="Clica em Programar de verdade (sem isso, so gera preview)")
+    ap.add_argument("--cdp", default="http://127.0.0.1:9222", help="Endereco do endpoint CDP do Chrome")
+    args = ap.parse_args()
+
+    with open(args.plan, encoding="utf-8") as f:
+        plan = json.load(f)
+    try:
+        post = next(p for p in plan["posts"] if p["post"] == args.post)
+    except StopIteration:
+        nums = [p["post"] for p in plan["posts"]]
+        raise SystemExit(f"Post {args.post} nao existe no plano. Numeros disponiveis: {nums}")
+    media_path = os.path.join(args.media_dir, post["arquivo"])
+
+    with sync_playwright() as p:
+        browser = p.chromium.connect_over_cdp(args.cdp)
+        ctx = browser.contexts[0]
+        page = ctx.pages[0]
+        page.bring_to_front()
+
+        if "content_calendar" not in page.url:
+            page.goto("https://business.facebook.com/latest/content_calendar",
+                      wait_until="domcontentloaded")
+            page.wait_for_timeout(2500)
+
+        if post["tipo"] == "VIDEO":
+            post_video(ctx, page, post, media_path, args.confirm)
+        else:
+            post_estatico(ctx, page, post, media_path, args.confirm)
+
+        browser.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/geral-postar-conteudo-meta/scripts/setup_perfil_automacao.bat
+++ b/.agents/skills/geral-postar-conteudo-meta/scripts/setup_perfil_automacao.bat
@@ -1,0 +1,47 @@
+@echo off
+setlocal
+
+if "%~1"=="" (
+    echo Uso: setup_perfil_automacao.bat NOME_CLIENTE PERFIL_CHROME_ORIGEM
+    echo.
+    echo   NOME_CLIENTE         nome livre pra identificar esse cliente ^(ex: ClienteExemplo^)
+    echo   PERFIL_CHROME_ORIGEM nome da pasta do perfil do Chrome ja logado nesse cliente
+    echo                        ^(ver em chrome://version, campo "Profile Path" - pegue so a
+    echo                        ultima pasta do caminho, ex: "Profile 10" ou "Default"^)
+    echo.
+    echo Exemplo: setup_perfil_automacao.bat ClienteExemplo "Profile 10"
+    exit /b 1
+)
+if "%~2"=="" (
+    echo Falta o segundo parametro: nome do perfil Chrome de origem. Veja o uso acima.
+    exit /b 1
+)
+
+set CLIENTE=%~1
+set PERFIL_ORIGEM=%~2
+set DEST=C:\Users\%USERNAME%\AppData\Local\ChromeAutomationProfile_%CLIENTE%
+set ORIGEM=C:\Users\%USERNAME%\AppData\Local\Google\Chrome\User Data\%PERFIL_ORIGEM%
+
+echo Cliente: %CLIENTE%
+echo Perfil de origem: %ORIGEM%
+echo Perfil de automacao (destino): %DEST%\Default
+echo.
+echo ATENCAO: isso cria (ou recria do zero) o perfil de automacao deste cliente.
+echo Se ja existir e tiver login funcionando, isso vai te obrigar a logar de novo.
+pause
+
+taskkill /F /IM chrome.exe >nul 2>&1
+timeout /t 2 /nobreak >nul
+
+echo Copiando dados essenciais do perfil de origem (sem cache)...
+robocopy "%ORIGEM%" "%DEST%\Default" /E /R:1 /W:1 /NFL /NDL /NJH /XD "Cache" "Code Cache" "GPUCache" "DawnWebGPUCache" "Service Worker" "Shared Dictionary" "Extensions" "Local Extension Settings" "Extension State" "DNR Extension Rules" "shared_proto_db"
+copy /Y "C:\Users\%USERNAME%\AppData\Local\Google\Chrome\User Data\Local State" "%DEST%\Local State"
+
+echo Abrindo Chrome com debug remoto (porta 9222) no perfil de automacao de %CLIENTE%...
+start "" "C:\Program Files\Google\Chrome\Application\chrome.exe" --remote-debugging-port=9222 --user-data-dir="%DEST%" --profile-directory="Default" --no-first-run "https://business.facebook.com/latest/content_calendar"
+
+echo.
+echo Se pedir login (normal ao recriar o perfil), faca uma vez so.
+echo Confirme tambem que a pagina/conta do Meta Business Suite certa (%CLIENTE%) esta selecionada.
+echo Das proximas vezes, use: abrir_chrome_automacao.bat %CLIENTE%
+pause

--- a/.claude/skills/geral-postar-conteudo-meta/SKILL.md
+++ b/.claude/skills/geral-postar-conteudo-meta/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: geral-postar-conteudo-meta
+description: Agenda posts estáticos e Reels de um lote de conteúdo social direto no Meta Business Suite (Facebook + Instagram), de verdade, via automação de browser real conectado à sessão logada do cliente. Use sempre que o usuário tiver uma pasta de vídeos/imagens + um documento de copy pra agendar/publicar no Facebook ou Instagram, mencionar "agendar posts", "postar no Meta Business Suite", "programar reels", "automatizar publicação de calendário de conteúdo", ou pedir pra você "postar" um lote de criativos aprovados. Não é a skill certa pra gerenciar campanhas de anúncios pagos (use notfair:meta-ads ou adkit pra isso) — é especificamente sobre conteúdo orgânico agendado no Planner.
+area: geral
+author: juan
+version: 1.0.0
+---
+
+# Postar conteúdo social no Meta Business Suite
+
+Pega um lote de conteúdo (vídeos + estáticos + doc de copy) e agenda os posts de verdade no Meta Business Suite, via Playwright conectado por CDP num Chrome real já aberto (não headless) — assim a sessão logada do cliente é reaproveitada, sem precisar automatizar login.
+
+## Antes de começar — pergunte, não assuma
+
+Esta skill é usada por pessoas diferentes, em máquinas diferentes, com clientes diferentes. **Nunca assuma nenhum destes pontos** — pergunte diretamente (pode usar uma pergunta de múltipla escolha ou texto livre, o importante é não adivinhar):
+
+1. **Nome do cliente.** Curto, sem espaço/acento (ex: `ClienteExemplo`, `ClinicaXYZ`) — vai isolar o perfil de automação desse cliente dos outros, pra não misturar logins.
+2. **Onde estão os arquivos de mídia** no computador da pessoa (pasta com os vídeos/imagens do lote).
+3. **Qual perfil do Chrome já está logado** na conta do Meta Business Suite desse cliente. Oriente a pessoa a: abrir o Chrome normal dela (o que já usa pra entrar nesse cliente), digitar `chrome://version` na barra de endereço, e te passar o valor de **"Profile Path"** — só a última pasta do caminho (ex: `Profile 3`, `Default`).
+4. **Se já existe um perfil de automação pra esse cliente** (pergunte se essa pessoa já rodou essa skill antes pra esse cliente nessa máquina). Se não existe, ela vai precisar **logar manualmente uma vez** — você nunca deve tentar logar por ela nem pedir senha/2FA. Só oriente e espere ela confirmar que logou.
+5. **Regras de cronograma**: cadência (todo dia? um dia sim um dia não? datas fixas?), horário(s), se pula fim de semana, e a partir de quando começa. Depois de definidas, **valide contra o calendário real** (rode algo como `date -d <data> +%A` — nunca assuma que "amanhã" cai num dia útil sem checar).
+
+Só depois de ter essas respostas, siga pro passo a passo.
+
+## Passo a passo
+
+### 1. Mapear arquivo ↔ post
+
+Os nomes de arquivo quase nunca batem com o número/nome do post no doc de copy. **Abra cada imagem/vídeo e compare visualmente** com o headline/tema de cada post antes de montar o plano — não assuma pela ordem alfabética ou numérica do nome do arquivo. Erro aqui é o mais comum e o mais fácil de não perceber até tarde (ver item 7 de `references/gotchas-tecnicos.md`).
+
+### 2. Limpar a legenda (se aplicável)
+
+Se o doc de copy do usuário tiver convenções específicas (ex: label "CTA:" antes do call-to-action, travessões `–`/`—` no meio das frases), pergunte se ele quer que você limpe isso antes de postar — não aplique regras de limpeza que não foram pedidas. Um padrão comum que já apareceu: remover a label "CTA:" (o texto vira só mais uma frase no fim da legenda) e trocar travessões por vírgula/ponto/dois-pontos.
+
+### 3. Calcular o cronograma
+
+Com as regras confirmadas no passo "antes de começar", gere as datas concretas e valide cada uma contra o dia da semana real. Se cair em dia que deveria ser pulado (fim de semana, por exemplo), ajuste e avise o usuário do ajuste.
+
+### 4. Gerar o plano.json
+
+Ver `references/plano-exemplo.json` pro formato exato. Por post: número, tema, tipo (`ESTATICO`/`VIDEO`), ação no Meta Business Suite (`Criar post`/`Criar Reel`), nome do arquivo, data (`YYYY-MM-DD`), dia da semana, hora (`HH:MM`), legenda já limpa, hashtags. Salvar num arquivo acessível (ex: pasta do cliente/campanha do usuário).
+
+### 5. Preparar o Chrome com debug remoto
+
+**Primeira vez com esse cliente nessa máquina** (depois de já ter o nome do perfil Chrome via `chrome://version`):
+```
+scripts\setup_perfil_automacao.bat NOME_CLIENTE "NOME_DO_PERFIL_CHROME_JA_LOGADO"
+```
+Isso cria um perfil de automação isolado pra esse cliente, copiando os dados essenciais (sem cache) do perfil real, e abre o Chrome nele. **A sessão não vem logada automaticamente** (cookies não sobrevivem à cópia — ver item 2 de `references/gotchas-tecnicos.md`) — a pessoa precisa logar manualmente ali, uma vez só, e confirmar que a página/conta certa do Meta Business Suite está selecionada.
+
+**Já configurado antes:**
+```
+scripts\abrir_chrome_automacao.bat NOME_CLIENTE
+```
+Fecha qualquer Chrome aberto e reabre o perfil de automação desse cliente, já logado, com a porta de debug ativa.
+
+Confirmar que funcionou: `curl -s http://127.0.0.1:9222/json/version` deve devolver um JSON com a versão do Chrome. Se não responder, ver item 1 de `references/gotchas-tecnicos.md`.
+
+### 6. Rodar o script, post por post
+
+```
+python scripts\postar_conteudo.py --plan <plano.json> --media-dir <pasta> --post <numero>
+```
+Sem `--confirm`: monta tudo (upload, legenda, agendamento) e **para antes de publicar**, salvando uma prévia em `preview_post<N>.png`. **Sempre mostrar essa prévia pro usuário e confirmar antes de publicar de fato** — publicar em conta real de cliente é uma ação visível externamente e difícil de desfazer, então essa confirmação não é opcional.
+
+Depois de aprovado, rodar de novo com `--confirm` (não continua de onde parou — refaz o fluxo inteiro e desta vez clica em Programar de verdade):
+```
+python scripts\postar_conteudo.py --plan <plano.json> --media-dir <pasta> --post <numero> --confirm
+```
+
+Repetir pra cada post do lote. O próprio Meta mostra um popup de confirmação ("Seu post foi programado" / "Reel programado") depois de cada `--confirm` bem-sucedido — essa é a fonte da verdade, não precisa reabrir o calendário pra conferir (ver item 8 de `references/gotchas-tecnicos.md` sobre por que isso é arriscado).
+
+## Quando algo quebrar
+
+Ler `references/gotchas-tecnicos.md` — cobre os 9 problemas reais já encontrados (porta de debug não sobe, login não sobrevive a cópia de perfil, upload de arquivo grande, botões duplicados no Meta, etc.), cada um com sintoma, causa e a solução que já está embutida nos scripts.
+
+## Limites conhecidos
+
+- Não automatiza login (nunca deve pedir senha/2FA ao usuário nem tentar preencher esses campos).
+- Assume Windows + Google Chrome instalado no caminho padrão (`C:\Program Files\Google\Chrome\Application\chrome.exe`).
+- Um perfil de automação por cliente evita conflito de sessão entre clientes diferentes, mas ainda depende da pessoa ter, ela mesma, acesso de login à conta do Meta Business Suite daquele cliente.

--- a/.claude/skills/geral-postar-conteudo-meta/references/gotchas-tecnicos.md
+++ b/.claude/skills/geral-postar-conteudo-meta/references/gotchas-tecnicos.md
@@ -1,0 +1,75 @@
+# Gotchas técnicos (por que o script é do jeito que é)
+
+Ler isto quando algo der errado no meio da automação — cada item explica o sintoma, a causa real e a solução já embutida no script/scripts `.bat`.
+
+## 1. Porta de debug do Chrome não sobe
+
+**Sintoma:** `curl http://127.0.0.1:9222/json/version` não responde (conexão recusada), mesmo com o Chrome aberto e `--remote-debugging-port=9222` na linha de comando do processo.
+
+**Causa:** Chrome moderno (a partir de ~v136) **ignora silenciosamente** `--remote-debugging-port` quando o `--user-data-dir` resolvido é o diretório "de verdade" (o `User Data` default da instalação) — proteção contra apps maliciosos anexarem debugger no navegador real do usuário. Só funciona se o `--user-data-dir` apontar pra um diretório **diferente** do default.
+
+**Solução:** os scripts `setup_perfil_automacao.bat`/`abrir_chrome_automacao.bat` sempre usam `--user-data-dir=...\ChromeAutomationProfile_<Cliente>` (nunca o default), então isso já vem resolvido — só usar os scripts, não abrir o Chrome manualmente sem essa flag.
+
+## 2. Perfil de automação abre sem login (mesmo tendo copiado o perfil real)
+
+**Sintoma:** copiou a pasta do perfil real pro perfil de automação, mas a sessão do Facebook/Instagram não veio junto — cai na tela de login.
+
+**Causa:** o Chrome criptografa cookies de um jeito vinculado ao caminho/instalação específica ("app-bound encryption"). Uma cópia crua da pasta de perfil não decripta certo no caminho novo.
+
+**Solução:** não tem workaround de cópia — **é preciso logar manualmente, uma vez só**, dentro do próprio perfil de automação (depois que ele já existe, com a porta de debug ativa). Depois disso a sessão fica salva ali normalmente, como qualquer perfil comum do Chrome, sem precisar mexer em cookies de novo.
+
+## 3. PowerShell corta o comando de abrir o Chrome em pedaços errados
+
+**Sintoma:** ao montar o comando de `Start-Process -ArgumentList` manualmente (fora dos `.bat` prontos), argumentos com espaço (`"User Data"`, `"Profile 10"`) ficam truncados, e o Chrome abre um perfil em branco.
+
+**Causa:** `Start-Process -ArgumentList` não coloca aspas automaticamente em cada elemento da lista — se o valor tem espaço e você não escapou as aspas manualmente dentro da string, o PowerShell quebra no espaço.
+
+**Solução:** usar os `.bat` prontos (que já lidam com isso via `cmd.exe`/`start`), em vez de montar o comando via PowerShell na mão.
+
+## 4. Upload de vídeo grande trava ou dá erro "Cannot transfer files larger than 50Mb"
+
+**Sintoma:** `file_chooser.set_files(caminho)` ou `locator.set_input_files(caminho)` falha com esse erro exato pra vídeos grandes (a maioria passa de 50MB facilmente).
+
+**Causa:** Playwright, quando conectado via `connect_over_cdp` (em vez de ter lançado o navegador ele mesmo), trata a conexão como "não colocalizada" e tenta transferir o conteúdo do arquivo inteiro em base64 pelo protocolo — o que tem um teto de 50MB.
+
+**Solução:** o script usa CDP puro pra contornar isso (`upload_media_raw_cdp()`): registra um listener no evento `Page.fileChooserOpened` (que devolve um `backendNodeId` direto, sem precisar ler o arquivo), e chama `DOM.setFileInputFiles` com esse id — isso manda o próprio Chrome ler o arquivo do disco local, sem limite de tamanho. Funciona pra qualquer tamanho de arquivo, então o script usa esse caminho sempre (até pra imagens pequenas), evitando dois caminhos de código diferentes.
+
+## 5. Botões "Avançar"/"Programar" clicam no elemento errado (setinha de carrossel)
+
+**Sintoma:** clicar no botão "Avançar" (ou "Programar") não avança o wizard do Reel — em vez disso, só troca as miniaturas sugeridas de capa.
+
+**Causa:** o Meta Business Suite tem **dois elementos com o mesmo texto acessível** na tela ao mesmo tempo: o botão real do rodapé, e a setinha de "próxima página" do carrossel de miniaturas sugeridas (que por acaso também se chama "Avançar"/"Programar" pra leitor de tela). `get_by_role("button", name="Avançar")` encontra os dois.
+
+**Solução:** a função `click_widest()` sempre pega o elemento **mais largo** entre os que casam o texto — o botão real do rodapé é bem maior que a setinha do carrossel.
+
+## 6. Botão "Próximo mês" do calendário não é encontrado por nenhum seletor "normal"
+
+**Sintoma:** `locator("[aria-label='Próximo mês']")` ou `locator("button", has_text=...)` não encontram nada, mesmo com a seta "›" visível na tela ao lado do nome do mês.
+
+**Causa:** o texto "Próximo mês" existe no DOM como texto puro dentro de uma `<div>` sem `role="button"` nem `aria-label` — é um padrão de acessibilidade "screen-reader-only" (texto sem tamanho visual, sobreposto à seta visual de verdade). Um clique por coordenada de tela funciona (a seta está lá visualmente), mas selecionar por atributo não acha o elemento certo.
+
+**Solução:** `composer.get_by_text("Próximo mês", exact=True).click(force=True)` — `force=True` ignora o check de visibilidade do Playwright (que bloquearia o clique num elemento de tamanho zero) e ainda assim dispara o evento de clique real no elemento certo.
+
+## 7. Mapeamento arquivo ↔ post errado (imagem/vídeo publicado não bate com a legenda)
+
+**Sintoma:** o preview no Meta mostra uma imagem/vídeo diferente do que o número do post sugeria.
+
+**Causa:** os nomes dos arquivos de mídia quase nunca batem com a numeração dos posts no doc de copy (ex: `post 15.png` pode ser na verdade o conteúdo do "POST 12" do doc). Isso não é um bug do script — é erro de leitura humana/IA ao montar o `plano.json`.
+
+**Solução:** sempre abrir cada imagem/vídeo e comparar visualmente com o headline/tema de cada POST no doc **antes** de gerar o plano, e sempre rodar o script primeiro **sem `--confirm`** pra conferir o preview antes de publicar de fato.
+
+## 8. Clicar numa célula vazia do calendário do Planner abre um rascunho novo
+
+**Sintoma:** ao tentar conferir visualmente se os posts foram agendados clicando no calendário, abre um "Criar post" em branco, pré-preenchido com a data/hora daquele espaço.
+
+**Causa:** é uma feature de "criação rápida" do próprio Meta Business Suite — clicar em espaço vazio de um dia/hora cria um rascunho novo naquele horário.
+
+**Solução:** não usar cliques no calendário como forma de auditar se os posts foram agendados — a fonte da verdade é o popup de confirmação que o próprio Meta mostra depois de "Programar" ("Seu post foi programado" / "Reel programado"). Se abrir um rascunho em branco sem querer: fechar pelo **X do modal** (não o botão "Cancelar" de trás, que fica coberto/bloqueado pelo modal), depois "Cancelar" no composer.
+
+## 9. Acentos saem corrompidos no terminal do Windows
+
+**Sintoma:** `print()` com texto acentuado (ex: "não", "mês") solta `UnicodeEncodeError` ou imprime `?`/`�` no console.
+
+**Causa:** o console do Windows por padrão usa a codepage `cp1252`, que não cobre todos os caracteres UTF-8.
+
+**Solução:** rodar o script com `PYTHONIOENCODING=utf-8` na frente do comando quando for inspecionar saída de texto acentuado, ou simplesmente confiar nos screenshots (`preview_post<N>.png`) em vez do texto impresso no terminal pra conferir conteúdo.

--- a/.claude/skills/geral-postar-conteudo-meta/references/plano-exemplo.json
+++ b/.claude/skills/geral-postar-conteudo-meta/references/plano-exemplo.json
@@ -1,0 +1,38 @@
+{
+  "cliente": "Cliente Exemplo",
+  "lote": "conteudo-social-exemplo",
+  "pasta_origem": "C:\\Users\\usuario\\Downloads\\lote-conteudo-exemplo",
+  "gerado_em": "2026-01-10",
+  "status": "aguardando publicação",
+  "regras_aplicadas": {
+    "cadencia": "um dia sim, um dia não, pulando sábado e domingo",
+    "horarios": "alternando 10:00 e 15:00",
+    "inicio": "próximo dia útil a partir de 2026-01-10"
+  },
+  "posts": [
+    {
+      "post": 1,
+      "tema": "Exemplo de tema do post estático",
+      "tipo": "ESTATICO",
+      "acao_meta_business": "Criar post",
+      "arquivo": "imagem-exemplo.png",
+      "data": "2026-01-12",
+      "dia_semana": "segunda",
+      "hora": "10:00",
+      "legenda": "Texto de exemplo da legenda, já limpo (sem 'CTA:' e sem travessão).\n\nCall to action final como frase normal.",
+      "hashtags": "#ExemploHashtag1 #ExemploHashtag2 #ExemploHashtag3"
+    },
+    {
+      "post": 2,
+      "tema": "Exemplo de tema do reel",
+      "tipo": "VIDEO",
+      "acao_meta_business": "Criar Reel",
+      "arquivo": "video-exemplo.mp4",
+      "data": "2026-01-14",
+      "dia_semana": "quarta",
+      "hora": "15:00",
+      "legenda": "Texto de exemplo da legenda do reel.",
+      "hashtags": "#ExemploHashtag1 #ExemploHashtag4"
+    }
+  ]
+}

--- a/.claude/skills/geral-postar-conteudo-meta/scripts/abrir_chrome_automacao.bat
+++ b/.claude/skills/geral-postar-conteudo-meta/scripts/abrir_chrome_automacao.bat
@@ -1,0 +1,39 @@
+@echo off
+setlocal
+
+if "%~1"=="" (
+    echo Uso: abrir_chrome_automacao.bat NOME_CLIENTE
+    echo.
+    echo   NOME_CLIENTE   o mesmo nome usado no setup_perfil_automacao.bat pra esse cliente
+    echo.
+    echo Exemplo: abrir_chrome_automacao.bat ClienteExemplo
+    echo.
+    echo Se ainda nao existe perfil de automacao pra esse cliente, rode primeiro:
+    echo   setup_perfil_automacao.bat NOME_CLIENTE "NOME_DO_PERFIL_CHROME_JA_LOGADO"
+    exit /b 1
+)
+
+set CLIENTE=%~1
+set DEST=C:\Users\%USERNAME%\AppData\Local\ChromeAutomationProfile_%CLIENTE%
+
+if not exist "%DEST%" (
+    echo Nao existe perfil de automacao para "%CLIENTE%" ainda.
+    echo Rode primeiro: setup_perfil_automacao.bat %CLIENTE% "NOME_DO_PERFIL_CHROME_JA_LOGADO"
+    exit /b 1
+)
+
+echo Fechando Chrome existente...
+taskkill /F /IM chrome.exe >nul 2>&1
+timeout /t 2 /nobreak >nul
+
+REM NAO ressincroniza do perfil real aqui: esse perfil de automacao ja tem login
+REM proprio (feito uma vez via setup_perfil_automacao.bat). Ressincronizar
+REM sobrescreveria a sessao logada. Pra recriar do zero, rode setup de novo.
+
+echo Abrindo Chrome com debug remoto (porta 9222) no perfil de automacao de %CLIENTE%...
+start "" "C:\Program Files\Google\Chrome\Application\chrome.exe" --remote-debugging-port=9222 --user-data-dir="%DEST%" --profile-directory="Default" --no-first-run "https://business.facebook.com/latest/content_calendar"
+
+echo.
+echo Chrome abrindo no perfil de automacao de %CLIENTE%. Confira se a pagina/conta certa
+echo do Meta Business Suite esta selecionada antes de rodar postar_conteudo.py.
+pause

--- a/.claude/skills/geral-postar-conteudo-meta/scripts/postar_conteudo.py
+++ b/.claude/skills/geral-postar-conteudo-meta/scripts/postar_conteudo.py
@@ -1,0 +1,289 @@
+# -*- coding: utf-8 -*-
+"""
+Automacao de postagem no Meta Business Suite (Planner) via Playwright + CDP.
+
+Pre-requisito: Chrome aberto com --remote-debugging-port=9222 (ou a porta passada
+em --cdp) no perfil de automacao do cliente certo, ja logado no Meta Business
+Suite na pagina certa. Use abrir_chrome_automacao.bat / setup_perfil_automacao.bat
+pra isso.
+
+Uso:
+    python postar_conteudo.py --plan <plano.json> --post <numero> --media-dir <pasta> [--confirm] [--cdp http://127.0.0.1:9222]
+
+Sem --confirm: faz tudo (upload, legenda, data/hora) e para ANTES do clique final
+de Programar, tirando um screenshot pra revisao em preview_post<N>.png.
+Com --confirm: roda tudo de novo do zero (nao continua de um dry-run anterior) e
+clica em Programar/Compartilhar de verdade, fechando os popups de upsell.
+
+Rode duas vezes: primeiro sem --confirm pra revisar a previa, depois com --confirm
+pra publicar.
+"""
+import argparse
+import json
+import os
+import time
+from playwright.sync_api import sync_playwright
+
+SCRATCH = os.path.dirname(os.path.abspath(__file__))
+
+MESES_PT = ["janeiro", "fevereiro", "março", "abril", "maio", "junho",
+            "julho", "agosto", "setembro", "outubro", "novembro", "dezembro"]
+
+
+def get_composer_frame(page, timeout=20):
+    start = time.time()
+    while time.time() - start < timeout:
+        for f in page.frames:
+            if "composer" in f.url:
+                return f
+        page.wait_for_timeout(300)
+    raise RuntimeError("Frame do composer nao encontrado a tempo. O Chrome esta "
+                        "na pagina do Planner do Meta Business Suite, na conta certa?")
+
+
+def click_widest(locator_set, label=""):
+    """Entre varios elementos com o mesmo texto/role, clica no de maior largura
+    (evita setinhas de carrossel/paginacao que tem o mesmo texto acessivel)."""
+    best, best_w = None, 0
+    for i in range(locator_set.count()):
+        box = locator_set.nth(i).bounding_box()
+        if box and box["width"] > best_w:
+            best_w, best = box["width"], i
+    if best is None:
+        raise RuntimeError(f"Nenhum elemento visivel encontrado para {label}")
+    locator_set.nth(best).click()
+
+
+def upload_media_raw_cdp(ctx, page, composer, button_text, media_path):
+    """Upload via CDP puro (DOM.setFileInputFiles), sem limite de tamanho de
+    arquivo -- necessario pois arquivos >50MB nao passam pelo set_files normal
+    quando conectado via connect_over_cdp."""
+    if not os.path.exists(media_path):
+        raise FileNotFoundError(f"Arquivo de midia nao encontrado: {media_path}")
+
+    cdp = ctx.new_cdp_session(page)
+    captured = {}
+
+    def handler(params):
+        captured.update(params)
+    cdp.on("Page.fileChooserOpened", handler)
+    cdp.send("Page.enable")
+    cdp.send("Page.setInterceptFileChooserDialog", {"enabled": True})
+
+    composer.get_by_text(button_text).first.click()
+    page.wait_for_timeout(1500)
+
+    if "backendNodeId" not in captured:
+        raise RuntimeError("Nao capturou o evento de selecao de arquivo.")
+
+    cdp.send("DOM.setFileInputFiles", {
+        "backendNodeId": captured["backendNodeId"],
+        "files": [media_path],
+    })
+
+
+def wait_upload_complete(composer, page, max_wait=180):
+    """Espera a barra de progresso do upload de video chegar a 100%."""
+    start = time.time()
+    while time.time() - start < max_wait:
+        txt = composer.locator("body").inner_text()
+        if "100%" in txt:
+            return
+        page.wait_for_timeout(2000)
+
+
+def fill_caption(page, composer, text):
+    target = composer.locator("[contenteditable='true']").first
+    target.click()
+    page.keyboard.press("Control+A")
+    page.keyboard.press("Delete")
+    page.wait_for_timeout(200)
+    page.keyboard.insert_text(text)
+    page.wait_for_timeout(400)
+    page.keyboard.press("Escape")
+    page.wait_for_timeout(300)
+
+
+def find_calendar_header(composer):
+    """Acha o texto do cabecalho do calendario ('julho de 2026') procurando
+    por qual nome de mes esta visivel no momento."""
+    for idx, nome in enumerate(MESES_PT, start=1):
+        loc = composer.get_by_text(f"{nome} de", exact=False)
+        cnt = loc.count()
+        for i in range(cnt):
+            el = loc.nth(i)
+            if el.is_visible():
+                return idx, el
+    return None, None
+
+
+def navigate_calendar_to_month(composer, page, target_month_idx, target_year):
+    """Depois de abrir o calendario, avanca de mes ate bater com o alvo."""
+    for _ in range(14):
+        current_idx, header_el = find_calendar_header(composer)
+        if current_idx is None:
+            return
+        text = header_el.inner_text().strip()
+        if str(target_year) in text and MESES_PT[target_month_idx - 1] in text:
+            return
+        # o botao "Proximo mes" e um texto de leitor de tela sem tamanho visual
+        # (sem aria-label, sem role=button visivel) -- so funciona com force click
+        next_btn = composer.get_by_text("Próximo mês", exact=True).first
+        next_btn.click(force=True)
+        page.wait_for_timeout(400)
+
+
+def set_date_field(page, composer, input_locator, day, month_idx, year):
+    input_locator.click()
+    page.wait_for_timeout(500)
+    navigate_calendar_to_month(composer, page, month_idx, year)
+    composer.get_by_text(str(day), exact=True).first.click()
+    page.wait_for_timeout(400)
+
+
+def set_time_field(page, hora_input, min_input, hour, minute):
+    hora_input.click()
+    page.keyboard.press("Control+A")
+    page.keyboard.type(f"{hour:02d}")
+    min_input.click()
+    page.keyboard.press("Control+A")
+    page.keyboard.type(f"{minute:02d}")
+
+
+def post_estatico(ctx, page, post, media_path, confirm):
+    page.get_by_role("button", name="Criar post").first.click()
+    composer = get_composer_frame(page)
+    page.wait_for_timeout(1500)
+
+    upload_media_raw_cdp(ctx, page, composer, "Adicionar foto/vídeo", media_path)
+    page.wait_for_timeout(4000)
+
+    fill_caption(page, composer, post["legenda"] + "\n\n" + post["hashtags"])
+    composer.get_by_text("Detalhes do post", exact=True).click()
+
+    switch = composer.locator("input[aria-label='Definir data e hora']")
+    switch.click()
+    page.wait_for_timeout(1000)
+
+    year, month, day = post["data"].split("-")
+    hour, minute = post["hora"].split(":")
+    date_inputs = composer.locator("input")
+
+    set_date_field(page, composer, date_inputs.nth(2), int(day), int(month), int(year))
+    set_date_field(page, composer, date_inputs.nth(5), int(day), int(month), int(year))
+
+    horas = composer.locator("input[aria-label='horas']")
+    minutos = composer.locator("input[aria-label='minutos']")
+    set_time_field(page, horas.nth(0), minutos.nth(0), int(hour), int(minute))
+    set_time_field(page, horas.nth(1), minutos.nth(1), int(hour), int(minute))
+
+    page.wait_for_timeout(1000)
+    shot = os.path.join(SCRATCH, f"preview_post{post['post']}.png")
+    page.screenshot(path=shot)
+    print("Preview salvo em:", shot)
+
+    if not confirm:
+        print("Rode de novo com --confirm para publicar de fato.")
+        return
+
+    click_widest(composer.get_by_role("button", name="Programar"), "Programar")
+    page.wait_for_timeout(4000)
+    try:
+        page.get_by_text("Talvez mais tarde", exact=True).click(timeout=5000)
+    except Exception:
+        pass
+    print(f"POST {post['post']} programado.")
+
+
+def post_video(ctx, page, post, media_path, confirm):
+    caret = page.get_by_role("button").nth(2)
+    caret.click()
+    page.wait_for_timeout(800)
+    page.get_by_text("Criar reel", exact=True).click()
+    composer = get_composer_frame(page)
+    page.wait_for_timeout(2000)
+
+    upload_media_raw_cdp(ctx, page, composer, "Adicionar vídeo", media_path)
+    wait_upload_complete(composer, page)
+    page.wait_for_timeout(2000)
+
+    fill_caption(page, composer, post["legenda"] + "\n\n" + post["hashtags"])
+    composer.get_by_text("Detalhes do reel", exact=True).click()
+    page.wait_for_timeout(500)
+
+    # Criar -> Editar
+    click_widest(composer.get_by_role("button", name="Avançar"), "Avancar1")
+    page.wait_for_timeout(3000)
+    # Editar -> Compartilhar
+    click_widest(composer.get_by_role("button", name="Avançar"), "Avancar2")
+    page.wait_for_timeout(3000)
+
+    composer.get_by_text("Programar", exact=True).click()
+    page.wait_for_timeout(1500)
+
+    year, month, day = post["data"].split("-")
+    hour, minute = post["hora"].split(":")
+    inputs = composer.locator("input")
+
+    set_date_field(page, composer, inputs.nth(0), int(day), int(month), int(year))
+    set_date_field(page, composer, inputs.nth(3), int(day), int(month), int(year))
+    set_time_field(page, inputs.nth(1), inputs.nth(2), int(hour), int(minute))
+    set_time_field(page, inputs.nth(4), inputs.nth(5), int(hour), int(minute))
+
+    page.wait_for_timeout(1000)
+    shot = os.path.join(SCRATCH, f"preview_post{post['post']}.png")
+    page.screenshot(path=shot)
+    print("Preview salvo em:", shot)
+
+    if not confirm:
+        print("Rode de novo com --confirm para publicar de fato.")
+        return
+
+    click_widest(composer.get_by_role("button", name="Programar"), "ProgramarFinal")
+    page.wait_for_timeout(4000)
+    try:
+        page.get_by_text("Concluir", exact=True).click(timeout=5000)
+    except Exception:
+        pass
+    print(f"POST {post['post']} (reel) programado.")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--plan", required=True, help="Caminho pro plano.json do lote")
+    ap.add_argument("--post", required=True, type=int, help="Numero do post dentro do plano")
+    ap.add_argument("--media-dir", required=True, help="Pasta onde estao os arquivos de midia")
+    ap.add_argument("--confirm", action="store_true", help="Clica em Programar de verdade (sem isso, so gera preview)")
+    ap.add_argument("--cdp", default="http://127.0.0.1:9222", help="Endereco do endpoint CDP do Chrome")
+    args = ap.parse_args()
+
+    with open(args.plan, encoding="utf-8") as f:
+        plan = json.load(f)
+    try:
+        post = next(p for p in plan["posts"] if p["post"] == args.post)
+    except StopIteration:
+        nums = [p["post"] for p in plan["posts"]]
+        raise SystemExit(f"Post {args.post} nao existe no plano. Numeros disponiveis: {nums}")
+    media_path = os.path.join(args.media_dir, post["arquivo"])
+
+    with sync_playwright() as p:
+        browser = p.chromium.connect_over_cdp(args.cdp)
+        ctx = browser.contexts[0]
+        page = ctx.pages[0]
+        page.bring_to_front()
+
+        if "content_calendar" not in page.url:
+            page.goto("https://business.facebook.com/latest/content_calendar",
+                      wait_until="domcontentloaded")
+            page.wait_for_timeout(2500)
+
+        if post["tipo"] == "VIDEO":
+            post_video(ctx, page, post, media_path, args.confirm)
+        else:
+            post_estatico(ctx, page, post, media_path, args.confirm)
+
+        browser.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/geral-postar-conteudo-meta/scripts/setup_perfil_automacao.bat
+++ b/.claude/skills/geral-postar-conteudo-meta/scripts/setup_perfil_automacao.bat
@@ -1,0 +1,47 @@
+@echo off
+setlocal
+
+if "%~1"=="" (
+    echo Uso: setup_perfil_automacao.bat NOME_CLIENTE PERFIL_CHROME_ORIGEM
+    echo.
+    echo   NOME_CLIENTE         nome livre pra identificar esse cliente ^(ex: ClienteExemplo^)
+    echo   PERFIL_CHROME_ORIGEM nome da pasta do perfil do Chrome ja logado nesse cliente
+    echo                        ^(ver em chrome://version, campo "Profile Path" - pegue so a
+    echo                        ultima pasta do caminho, ex: "Profile 10" ou "Default"^)
+    echo.
+    echo Exemplo: setup_perfil_automacao.bat ClienteExemplo "Profile 10"
+    exit /b 1
+)
+if "%~2"=="" (
+    echo Falta o segundo parametro: nome do perfil Chrome de origem. Veja o uso acima.
+    exit /b 1
+)
+
+set CLIENTE=%~1
+set PERFIL_ORIGEM=%~2
+set DEST=C:\Users\%USERNAME%\AppData\Local\ChromeAutomationProfile_%CLIENTE%
+set ORIGEM=C:\Users\%USERNAME%\AppData\Local\Google\Chrome\User Data\%PERFIL_ORIGEM%
+
+echo Cliente: %CLIENTE%
+echo Perfil de origem: %ORIGEM%
+echo Perfil de automacao (destino): %DEST%\Default
+echo.
+echo ATENCAO: isso cria (ou recria do zero) o perfil de automacao deste cliente.
+echo Se ja existir e tiver login funcionando, isso vai te obrigar a logar de novo.
+pause
+
+taskkill /F /IM chrome.exe >nul 2>&1
+timeout /t 2 /nobreak >nul
+
+echo Copiando dados essenciais do perfil de origem (sem cache)...
+robocopy "%ORIGEM%" "%DEST%\Default" /E /R:1 /W:1 /NFL /NDL /NJH /XD "Cache" "Code Cache" "GPUCache" "DawnWebGPUCache" "Service Worker" "Shared Dictionary" "Extensions" "Local Extension Settings" "Extension State" "DNR Extension Rules" "shared_proto_db"
+copy /Y "C:\Users\%USERNAME%\AppData\Local\Google\Chrome\User Data\Local State" "%DEST%\Local State"
+
+echo Abrindo Chrome com debug remoto (porta 9222) no perfil de automacao de %CLIENTE%...
+start "" "C:\Program Files\Google\Chrome\Application\chrome.exe" --remote-debugging-port=9222 --user-data-dir="%DEST%" --profile-directory="Default" --no-first-run "https://business.facebook.com/latest/content_calendar"
+
+echo.
+echo Se pedir login (normal ao recriar o perfil), faca uma vez so.
+echo Confirme tambem que a pagina/conta do Meta Business Suite certa (%CLIENTE%) esta selecionada.
+echo Das proximas vezes, use: abrir_chrome_automacao.bat %CLIENTE%
+pause


### PR DESCRIPTION
## Skill sendo compartilhada

**Nome:** `geral-postar-conteudo-meta`
**Area:** geral
**Autor:** @JuanMarques-Colli
**Versao:** 1.0.0

## O que ela faz

Agenda posts estaticos e Reels de um lote de conteudo social direto no Meta Business Suite (Facebook + Instagram), de verdade, via automacao de browser real (Playwright conectado por CDP num Chrome ja aberto, nao headless, pra manter a sessao logada do cliente). Pergunta cliente, pasta de midia, perfil do Chrome e regras de cronograma antes de comecar a automacao.

## Como testar

1. Rode `/sync-hub` pra puxar a branch localmente
2. Peca pra Claude "agendar esses posts no Meta Business Suite" com uma pasta de midia + doc de copy
3. Valide que a skill pergunta cliente/pasta/perfil do Chrome antes de tentar automatizar qualquer coisa, e que gera uma previa (`preview_post<N>.png`) antes de publicar de fato

## Checklist do contribuidor

- [x] Nome segue `geral-slug` em kebab-case
- [x] Frontmatter completo (name, description, area, author, version)
- [x] Duplo-write em .claude/ e .agents/ (conteudo identico)
- [x] Testada com sucesso (5 posts reais agendados numa conta de cliente durante o desenvolvimento)
- [x] Sem credenciais, tokens, clientes reais, dados pessoais
- [x] Portugues brasileiro

---

_Gerado via `/compartilhar-skill`._