### PR TITLE
feat(skills): pipeline designer-lp-* para producao de landing page

### DIFF
--- a/.agents/skills/designer-landing-page/SKILL.md
+++ b/.agents/skills/designer-landing-page/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: designer-landing-page
+description: "Cria a landing page de conversão: copy completa seção por seção, geração de código React+Tailwind, e deploy na Vercel. Mix auto + manual. Use quando disser /designer-landing-page ou 'criar LP' ou 'landing page' ou 'página de conversão'."
+area: designer
+author: luizfreitasv4
+version: 1.0.0
+dependencies:
+  - geral-posicionamento-estrategico
+  - designer-manual-marca
+inputs:
+  - client.json (briefing)
+  - geral-posicionamento-estrategico.json
+  - designer-manual-marca.json
+  - gt-diagnostico-cro.json (opcional — só no modelo inside-sales)
+output: designer-landing-page.json
+week: 4
+type: mixed
+estimated_time: "6h"
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta versao foi portada do sistema de Estruturacao Estrategica. As regras abaixo tem precedencia sobre caminhos e persistencia citados no fluxo original:
+
+- Trabalhe somente em `squads/{squad}/clientes/{cliente}/`, nunca em um diretorio `clientes/` solto na raiz.
+- Leia primeiro o `CLAUDE.md` ou `AGENTS.md` da KB, `mission-control/`, `calls/`, `docs/` e `campanhas/`.
+- Se `client.json` existir, use-o como fonte complementar. Se nao existir, derive o contexto da KB e do Mission Control; nao exija nem invente esse arquivo.
+- Salve entregaveis em `squads/{squad}/clientes/{cliente}/outputs/`, em JSON e Markdown quando o fluxo pedir ambos.
+- Registre decisoes e progresso no `mission-control/historico-checkins.md` ou no arquivo de historico equivalente encontrado na KB.
+- Resolva recursos empacotados a partir do proprio diretorio desta skill. Se uma integracao externa nao estiver configurada, declare o gap e continue apenas com os dados reais disponiveis.
+
+
+# Landing Page — Copy + Código + Deploy (POP 3.8)
+
+> **Posição no fluxo:** Semana 4 — Identidade de Comunicação e Plano de Mídia (**comum** a todos os modelos) (e-commerce / inside-sales / pdv). Mobile-first, formulário curto (3-5 campos) integrado ao CRM, tracking testado **antes** do deploy. No modelo inside-sales, consome o diagnóstico de CRO (3.1) se disponível; nos demais, baseia-se em posicionamento + manual de marca.
+
+Você é um copywriter especializado em landing pages de conversão para PMEs brasileiras, com conhecimento em desenvolvimento React/Tailwind. Vai criar a LP completa: copy persuasiva, código funcional e deploy na Vercel.
+
+## Dados necessários
+
+1. `client.json` (seção `briefing`) — nome, segmento, produto/serviço, WhatsApp, site atual
+2. `outputs/geral-posicionamento-estrategico.json` — PUV, posicionamento, diferenciais
+3. `outputs/designer-manual-marca.json` — tom de voz, paleta, tipografia, vocabulário, headlines, CTAs
+4. `outputs/gt-diagnostico-cro.json` — **opcional** (só no modelo inside-sales): análise de conversão, problemas, wireframe sugerido
+5. `client.json` (seção `history`) — decisões anteriores
+
+> Identidade visual (paleta/tipografia) vem do `designer-manual-marca` (item 2) — os antigos brandbook/identidade-visual foram unificados nele.
+
+Se brandbook ou posicionamento não existirem, avise e sugira rodar antes.
+
+---
+
+## Geração
+
+Gere o output COMPLETO de uma vez: copy da LP + código + instruções de deploy. Use os dados de `client.json` (briefing) e outputs de skills dependentes em `outputs/`.
+
+Consulte `references/copy-patterns-lp.md` para padrões de copy de alta conversão.
+
+### Copy completa (seção por seção)
+
+Toda seção pode ter `eyebrow` opcional (texto pequeno acima do headline, estilo "· A profissional" ou sticker rounded — ajuda hierarquia tipográfica).
+
+**HERO:** Headline (máx. 8 palavras), subheadline (1-2 frases), CTA primário, CTA secundário, opcional `stats[]` (3-4 números) e `credential_card` (nome + CRMV/credencial flutuante sobre a foto)
+**PROBLEMA:** 3 cards de dor (título curto + 1 frase de empatia cada). Recomendo formato "Sem X / Sem Y / Sem Z" ou similar, em vez de listar dores genéricas.
+**PROFISSIONAL/AUTORIDADE (opcional `authority`):** Seção dedicada de autoridade quando há um profissional de marca. Inclui `credentials[]` (timeline ano + título de formação) e CTA. Recomendado para clínicas, consultórios e prestadores de serviço pessoa-física.
+**SOLUÇÃO:** 3-4 benefícios com ícone sugerido (Lucide/Heroicons), conectados ao PUV
+**COMO FUNCIONA:** 3-4 passos simples (título + 1 frase)
+**ENTREGÁVEIS:** Lista principal com benefício de cada
+**PROVA SOCIAL:** Depoimentos no formato simples (`name`/`role`/`text`) ou rico (`photo`, `photo_caption`, `source` ex 'Google Reviews', `when` ex '6 meses atrás', `rating` 1-5, `neighborhood`, `pet`). Quando há fotos reais, prefira o formato rico — converte mais. Stats podem ficar no `social_proof.stats[]` OU inline no hero (`sections[0].stats`); evite duplicar.
+**SECONDARY_AUDIENCE / SECUNDÁRIO (opcional):** Callout para audiência secundária quando o foco é nicho (ex: especialista em um segmento que também atende um público adjacente).
+**FAQ:** 5+ objeções mais comuns do ICP com respostas que vendem
+**LOCATION (opcional):** Embed Google Maps + card de contato. Recomendado para negócios físicos.
+**FINAL CTA:** Headline emocional + WhatsApp button. Pode ter eyebrow.
+**CTA FINAL:** Headline de urgência + subtítulo de reassurance + botão
+
+**META / SEO:** Title tag (máx. 60 chars), meta description (máx. 155 chars), OG tags
+
+### Código React + Tailwind
+
+Gere o código completo da LP:
+- Next.js ou React SPA com Tailwind CSS
+- Mobile-first, totalmente responsivo
+- CTA com link para WhatsApp: `https://wa.me/{WHATSAPP}?text={MENSAGEM_ENCODED}`
+- SEO básico, Google Fonts, cores da paleta como variáveis Tailwind
+- Componentes por seção (Hero, Problem, Solution, HowItWorks, SocialProof, FAQ, FinalCTA)
+- FAQ com accordion, scroll suave, sem imagens pesadas, PageSpeed-friendly
+
+### Deploy na Vercel
+
+> **Precedência:** se o pipeline `designer-lp-*` estiver em uso nesta conta, o deploy **não** acontece aqui. Esta skill entrega estratégia, copy e código; baseline, adaptação, assets, quality gate e release passam por `designer-lp-orchestrator`, que exige autorização explícita para Preview e proíbe Production. Nesse caso pare no teste local e chame `designer-lp-source-audit`.
+
+Teste local (sempre):
+```bash
+cd landing-{slug}
+npm install && npm run dev
+```
+
+Deploy direto, só quando o pipeline `designer-lp-*` não estiver em uso e o usuário autorizar na hora:
+```bash
+vercel --yes            # Preview, revisar antes de promover
+```
+
+Não rode `vercel --prod` sem autorização explícita do usuário para aquela publicação específica.
+
+## Auto-validação
+
+Antes de mostrar ao operador, verifique:
+
+- [ ] Mencionou o cliente pelo nome?
+- [ ] Usou dados reais do client.json (não inventou)?
+- [ ] Nenhum item genérico (ex: "quer crescer", "qualidade e compromisso")?
+- [ ] Schema da skill validou?
+- [ ] Todos os campos do schema preenchidos (ou com `null` + `unavailable_reason` no pai)?
+- [ ] Nenhuma string vazia (`""`) — substituí por `null` + reason quando o dado não existe?
+- [ ] Estimativas marcadas com `estimated: true` ou `[E]`?
+- [ ] Consistente com outputs anteriores (posicionamento, brandbook)?
+- [ ] Headline do hero é baseada na PUV (não genérica)?
+- [ ] FAQ responde as 5 objeções reais do ICP?
+- [ ] Código é mobile-first e PageSpeed-friendly?
+
+Se falhou → regenere silenciosamente. Não avise o operador.
+
+## Apresentação e decisões
+
+Apresente o output COMPLETO ao operador — copy seção por seção em formato de preview.
+
+**DECISÃO 1:** Copy da LP — aprovar ou ajustar?
+
+Apresente preview visual da estrutura:
+```
+━━ HERO ━━ → ━━ PROBLEMA ━━ → ━━ SOLUÇÃO ━━ → ━━ COMO FUNCIONA ━━
+━━ PROVA SOCIAL ━━ → ━━ FAQ ━━ → ━━ CTA FINAL ━━
+```
+
+Valide:
+- Headline do hero é específica e orientada ao benefício?
+- As 3 dores são as que o ICP realmente sente?
+- Os 3 passos do "como funciona" são verdadeiros?
+- O cliente tem depoimentos reais? Se sim, cole aqui.
+- As respostas do FAQ respondem as objeções reais de venda?
+- O CTA aponta para WhatsApp ou formulário?
+- O WhatsApp está correto?
+
+Após aprovação da copy, gere o código e instrua o operador a testar localmente. Depois, execute o deploy.
+
+**Checklist pós-deploy:**
+- Abriu corretamente no desktop e mobile?
+- PageSpeed > 90?
+- WhatsApp CTA funciona?
+- Meta tags corretas?
+
+## Finalização
+
+Operador aprova (com ou sem ajustes).
+1. Salve em `squads/{squad}/clientes/{cliente}/outputs/designer-landing-page.json` (com campo `summary` no topo, incluindo URL de deploy)
+2. Atualize `client.json`: progress.skills → completed, version++, append em history[]
+3. Salve também uma versão Markdown do entregável na mesma pasta de outputs.
+4. Sugira próxima skill do dependency_graph
+
+## Formato do output (designer-landing-page.json)
+
+```json
+{
+  "sections": [
+    { "name": "hero", "headline": "string", "subheadline": "string", "cta_primary": "string", "cta_secondary": "string" },
+    { "name": "problem", "headline": "string", "cards": [{ "title": "string", "body": "string" }] },
+    { "name": "solution", "headline": "string", "benefits": [{ "icon": "string", "title": "string", "body": "string" }] },
+    { "name": "how_it_works", "headline": "string", "steps": [{ "number": 1, "title": "string", "body": "string" }] },
+    { "name": "deliverables", "headline": "string", "items": [{ "title": "string", "benefit": "string" }] },
+    { "name": "final_cta", "headline": "string", "subheadline": "string", "cta": "string" }
+  ],
+  "faq": [{ "question": "string", "answer": "string" }],
+  "social_proof": {
+    "testimonials": [{ "name": "string", "role": "string", "text": "string" }],
+    "stats": [{ "number": "string", "label": "string" }]
+  },
+  "meta": { "title": "string", "description": "string", "og_title": "string", "og_description": "string", "og_type": "website" },
+  "deploy_url": "string",
+  "whatsapp_link": "string"
+}
+```
+
+
+## Campo obrigatório: summary
+
+Sempre inclua no JSON de saída:
+```json
+"summary": "Resumo de 1-2 frases do landing page: proposta central da página e número de seções criadas. Seja específico — mencione o cliente, números reais e a conclusão principal."
+```
+
+Este campo alimenta o Resumo Executivo do portal de entregas. Deve ser objetivo, com dados reais, sem genéricos.

--- a/.agents/skills/designer-landing-page/references/copy-patterns-lp.md
+++ b/.agents/skills/designer-landing-page/references/copy-patterns-lp.md
@@ -1,0 +1,226 @@
+# Padrões de Copy para Landing Pages de Alta Conversão (Brasil)
+
+Referência para gerar copy de LP orientada a conversão para PMEs brasileiras. Padrões testados e validados em mercados de serviços, infoprodutos e e-commerce local.
+
+---
+
+## 1. Hero — A Primeira Tela
+
+O hero decide se o visitante fica ou sai. Média de decisão: 3-5 segundos.
+
+### Padrões de headline que convertem
+
+**Padrão 1: Resultado + Prazo**
+> "[Resultado desejado] em [prazo realista]"
+> Ex: "Sua clínica lotada em 90 dias"
+> Ex: "Delivery direto pelo WhatsApp em 7 dias"
+
+**Padrão 2: Pergunta de Dor**
+> "[Pergunta que espelha a frustração do ICP]?"
+> Ex: "Cansou de pagar comissão pro iFood?"
+> Ex: "Quantos leads você perdeu esse mês por falta de follow-up?"
+
+**Padrão 3: Antes → Depois**
+> "De [situação atual] para [situação desejada]"
+> Ex: "De 5 clientes no boca a boca para 30 leads qualificados por mês"
+> Ex: "De planilha no Excel para gestão financeira de verdade"
+
+**Padrão 4: Benefício Único**
+> "[Verbo de ação] + [benefício principal] + [sem objeção principal]"
+> Ex: "Atraia clientes do seu bairro sem gastar com agência"
+> Ex: "Automatize seu atendimento sem perder o toque humano"
+
+### Regras do hero
+
+- Headline: máximo 8 palavras (quanto mais curta, mais impacto)
+- Subheadline: 1-2 frases que expandem e contextualizam
+- CTA primário: verbo de ação + benefício ("Quero meus leads" > "Saiba mais")
+- CTA secundário (opcional): baixa barreira ("Ver como funciona" / "Sem compromisso")
+- Sem imagens genéricas de banco — gradiente ou ilustração é melhor que foto artificial
+
+---
+
+## 2. Seção de Problema — Empatia Antes de Solução
+
+**Princípio:** O visitante precisa se sentir compreendido antes de ouvir a solução.
+
+### Padrão: 3 Cards de Dor
+
+Cada card:
+- Título curto (3-5 palavras) que nomeia a dor
+- 1 frase de empatia (mostre que entende, não julgue)
+
+**Exemplo para contabilidade:**
+```
+Card 1: "Medo do fiscal bater na porta"
+"Você emite nota, mas não sabe se está fazendo certo. A multa pode ser maior que o faturamento."
+
+Card 2: "Contador que nunca responde"
+"Você manda mensagem segunda e recebe resposta quinta. Enquanto isso, a decisão urgente fica parada."
+
+Card 3: "Imposto alto demais"
+"Você sente que paga mais do que deveria, mas não sabe quanto — porque ninguém nunca mostrou as opções."
+```
+
+### Regras da seção de problema
+
+- Máximo 3 dores (mais dilui o impacto)
+- Use a linguagem do ICP (as palavras que ele usaria, não termos técnicos)
+- Nunca culpe o visitante ("Você não faz X" → "Quando X acontece...")
+- A dor deve ser reconhecível em 3 segundos de leitura
+
+---
+
+## 3. Seção de Solução — Benefícios, Não Features
+
+**Princípio:** Feature é o que o produto faz. Benefício é o que muda na vida do cliente.
+
+### Padrão: 3-4 Benefícios com Ícone
+
+Cada benefício:
+- Ícone visual (sugestão de Lucide/Heroicons)
+- Título orientado a resultado (não a feature)
+- 1 frase que conecta ao PUV
+
+**RUIM (features):**
+- "Dashboard de métricas em tempo real"
+- "Integração com 50+ plataformas"
+- "Relatórios automatizados"
+
+**BOM (benefícios):**
+- "Saiba em 10 segundos se sua campanha está dando lucro"
+- "Tudo conectado — não precisa copiar dados entre ferramentas"
+- "Relatório pronto toda segunda. Sem pedir. Sem esperar."
+
+### Regras da seção de solução
+
+- Cada benefício deve responder: "E daí?" (e daí que tem dashboard? → mostra se dá lucro)
+- Conecte ao PUV do geral-posicionamento-estrategico
+- Máximo 4 benefícios (5+ fica visual pesado)
+
+---
+
+## 4. Como Funciona — Simplicidade Gera Confiança
+
+**Princípio:** Se parece complicado, o visitante desiste. Simplifique até parecer inevitável.
+
+### Padrão: 3 Passos Numerados
+
+```
+1. [Verbo simples] → [O que acontece]
+   "Preencha o formulário" → "Em 30 segundos, já sabemos o que você precisa"
+
+2. [Verbo simples] → [O que acontece]
+   "Receba seu plano" → "Em 24h, montamos a estratégia personalizada"
+
+3. [Verbo simples] → [O que acontece]
+   "Comece a vender" → "Seus anúncios vão ao ar e os leads chegam no WhatsApp"
+```
+
+### Regras
+
+- SEMPRE 3 passos (4 é demais, 2 parece incompleto)
+- O passo 1 deve ter barreira zero (formulário, WhatsApp, ligação)
+- O passo 3 deve ser o resultado desejado
+- Use setas ou numeração grande para guiar o olho
+
+---
+
+## 5. Prova Social — Números e Rostos
+
+### Padrão de Depoimentos
+
+**Estrutura ideal:**
+> "[Resultado específico]. [Situação antes]. [O que mudou]. Recomendo!"
+> — Nome, Cargo/Empresa
+
+**BOM:**
+> "Em 60 dias, saí de 3 para 18 leads por semana. Antes eu dependia de indicação. Agora tenho previsibilidade."
+> — Ana Silva, dona da Clínica Bella
+
+**RUIM:**
+> "Ótimo serviço, super recomendo!"
+> — Cliente satisfeito
+
+### Padrão de Números de Impacto
+
+Escolha 3-4 métricas que impressionam:
+- Quantidade de clientes/projetos
+- Anos de mercado
+- Resultado principal (em R$ ou %)
+- Volume processado
+
+```
+500+         12           R$ 2M+          98%
+clientes     anos de      em vendas       de satisfação
+atendidos    mercado      geradas         dos clientes
+```
+
+### Regras
+
+- Números reais > números inflados. Se não tem, use o que tem honestamente
+- Depoimentos com nome + foto + empresa convertem 30% mais que anônimos
+- Se não tem depoimentos, substitua por resultados documentados ou estudos de caso resumidos
+
+---
+
+## 6. FAQ — Vendas Disfarçadas de Suporte
+
+**Princípio:** Cada pergunta é uma objeção. Cada resposta é um argumento de venda.
+
+### 5 Objeções Universais (adapte ao segmento)
+
+1. **Preço/Investimento:** "Quanto custa?" → Reframe para valor, não preço
+2. **Confiança:** "Como sei que funciona?" → Prova social, garantia, case
+3. **Tempo:** "Quanto tempo demora?" → Prazo realista + marcos intermediários
+4. **Complexidade:** "Preciso saber de tecnologia/marketing?" → Nós fazemos por você
+5. **Risco:** "E se não funcionar?" → Garantia, teste, sem contrato longo
+
+### Exemplo
+
+**P: Quanto custa o serviço?**
+R: "O investimento começa em R$ X/mês. Mas a pergunta mais importante é: quanto está custando NÃO ter isso? Se você perde 10 leads por mês por falta de follow-up, e cada lead vale R$ 500, são R$ 5.000 que você deixa na mesa. Nosso serviço se paga no primeiro mês."
+
+**P: E se eu não gostar do resultado?**
+R: "Nos primeiros 30 dias, se você não perceber melhoria mensurável, devolvemos 100% do investimento. Sem perguntas. Podemos fazer isso porque 94% dos clientes continuam após o primeiro mês."
+
+### Regras
+
+- Máximo 5 perguntas (mais vira manual de suporte)
+- Sempre redirecione para benefício ou CTA no final da resposta
+- Perguntas devem vir das objeções reais do ICP, não de perguntas técnicas que ninguém faz
+
+---
+
+## 7. CTA Final — Última Chance
+
+### Padrão
+
+```
+[Headline de urgência real]     → "Vagas limitadas para este mês"
+[Subtítulo de reassurance]      → "Sem contrato. Cancele quando quiser."
+[Botão CTA grande]              → "Quero Começar Agora"
+[Micro-copy sob o botão]        → "Resposta em até 2h pelo WhatsApp"
+```
+
+### Regras
+
+- Urgência real (vagas limitadas, preço de lançamento, agenda) — NUNCA fake countdown
+- Reassurance: reduza o risco percebido (sem contrato, devolução, teste grátis)
+- O CTA deve ser o mesmo do hero (consistência)
+- Adicione micro-copy que resolve a última objeção
+
+---
+
+## Regras Gerais de Copy para LP Brasileira
+
+1. **Trate por "você"** — formalidade mata conversão em PME
+2. **Frases curtas** — máx. 20 palavras por frase, máx. 3 frases por parágrafo
+3. **Números específicos > promessas vagas** — "47 clientes em BH" > "vários clientes"
+4. **Benefício > Feature** — sempre
+5. **CTA com verbo de ação** — "Quero meus leads" > "Enviar" > "Submit"
+6. **Sem jargão não traduzido** — se usar ROI, explique
+7. **Escaneabilidade** — negritos, bullets, espaço em branco. Ninguém lê parágrafo longo
+8. **WhatsApp como CTA principal** — no Brasil, WhatsApp converte mais que formulário
+9. **Mobile-first** — 70%+ do tráfego brasileiro é mobile. Teste no celular primeiro
+10. **Velocidade** — LP lenta = lead perdido. Máximo 3s de carregamento

--- a/.agents/skills/designer-landing-page/schema.json
+++ b/.agents/skills/designer-landing-page/schema.json
@@ -1,0 +1,431 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Landing Page",
+  "description": "Output estruturado da landing page: copy por seção, FAQ, prova social, meta tags e URL de deploy.",
+  "type": "object",
+  "required": [
+    "summary",
+    "sections",
+    "faq",
+    "social_proof",
+    "meta",
+    "client_name",
+    "summary_headline",
+    "summary_highlights",
+    "summary_key_findings"
+  ],
+  "properties": {
+    "client_name": {
+      "type": "string",
+      "description": "Nome do cliente — sempre presente em todo output."
+    },
+    "summary": {
+      "type": "string",
+      "description": "Resumo de 1-2 frases da landing page. Inclui proposta central da página e número de seções criadas."
+    },
+    "summary_headline": {
+      "type": "string",
+      "description": "Manchete em 1 linha (~120 caracteres) com o veredito da skill."
+    },
+    "summary_highlights": {
+      "type": "array",
+      "description": "KPIs em destaque (4-6 itens). Categorias: posicao | competicao | janela | maturidade | oportunidade | risco.",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "label",
+          "value",
+          "tone"
+        ],
+        "properties": {
+          "category": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "subtext": {
+            "type": "string"
+          },
+          "tone": {
+            "type": "string",
+            "enum": [
+              "green",
+              "yellow",
+              "red",
+              "blue",
+              "gray"
+            ]
+          }
+        }
+      }
+    },
+    "summary_key_findings": {
+      "type": "array",
+      "description": "3-5 achados categorizados (vantagem | contexto | ameaca | acao).",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "text"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "vantagem",
+              "contexto",
+              "ameaca",
+              "acao"
+            ]
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "sections": {
+      "type": "array",
+      "description": "Seções da LP em ordem de exibição.",
+      "minItems": 6,
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "enum": [
+              "hero",
+              "problem",
+              "authority",
+              "solution",
+              "how_it_works",
+              "deliverables",
+              "social_proof",
+              "secondary_audience",
+              "faq",
+              "final_cta",
+              "location"
+            ],
+            "description": "Identificador da seção. Aceita seções extras além do core (authority, secondary_audience, location/map) para LPs mais ricas."
+          },
+          "eyebrow": {
+            "type": "string",
+            "description": "Texto pequeno acima do headline (estilo eyebrow/sticker — ex: '· A profissional')."
+          },
+          "stats": {
+            "type": "array",
+            "description": "Stats inline da seção (ex: hero stats — alternativa a social_proof.stats).",
+            "items": {
+              "type": "object",
+              "required": [
+                "number",
+                "label"
+              ],
+              "properties": {
+                "number": {
+                  "type": "string"
+                },
+                "label": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "credential_card": {
+            "type": "object",
+            "description": "Card flutuante com credencial (ex: nome do profissional + CRMV).",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "role": {
+                "type": "string"
+              }
+            }
+          },
+          "credentials": {
+            "type": "array",
+            "description": "Timeline de credenciais (formato 'year' + 'title' — usado em seções de autoridade).",
+            "items": {
+              "type": "object",
+              "required": [
+                "year",
+                "title"
+              ],
+              "properties": {
+                "year": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "headline": {
+            "type": "string",
+            "description": "Título principal da seção"
+          },
+          "subheadline": {
+            "type": "string",
+            "description": "Subtítulo (quando aplicável)"
+          },
+          "body": {
+            "type": "string",
+            "description": "Texto do corpo (quando aplicável)"
+          },
+          "cta_primary": {
+            "type": "string",
+            "description": "Texto do CTA primário (hero e final_cta)"
+          },
+          "cta_secondary": {
+            "type": "string",
+            "description": "Texto do CTA secundário (hero)"
+          },
+          "cards": {
+            "type": "array",
+            "description": "Cards de dor (seção problem)",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "body"
+              ],
+              "properties": {
+                "title": {
+                  "type": "string"
+                },
+                "body": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "benefits": {
+            "type": "array",
+            "description": "Benefícios com ícone (seção solution)",
+            "items": {
+              "type": "object",
+              "required": [
+                "icon",
+                "title",
+                "body"
+              ],
+              "properties": {
+                "icon": {
+                  "type": "string",
+                  "description": "Nome do ícone sugerido (Lucide/Heroicons)"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "body": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "steps": {
+            "type": "array",
+            "description": "Passos do como funciona",
+            "items": {
+              "type": "object",
+              "required": [
+                "number",
+                "title",
+                "body"
+              ],
+              "properties": {
+                "number": {
+                  "type": "integer"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "body": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "items": {
+            "type": "array",
+            "description": "Itens de entregáveis",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "benefit"
+              ],
+              "properties": {
+                "title": {
+                  "type": "string"
+                },
+                "benefit": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "faq": {
+      "type": "array",
+      "description": "5 perguntas frequentes que respondem às objeções do ICP.",
+      "minItems": 5,
+      "items": {
+        "type": "object",
+        "required": [
+          "question",
+          "answer"
+        ],
+        "properties": {
+          "question": {
+            "type": "string"
+          },
+          "answer": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "social_proof": {
+      "type": "object",
+      "required": [
+        "testimonials"
+      ],
+      "properties": {
+        "testimonials": {
+          "type": "array",
+          "description": "Depoimentos de clientes (reais ou placeholders). Aceita formato simples (name/role/text) ou rico (com photo, source, when, rating, neighborhood, pet, photo_caption).",
+          "items": {
+            "type": "object",
+            "required": [
+              "name",
+              "text"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "role": {
+                "type": "string",
+                "description": "Cargo ou contexto da pessoa (opcional — pode ser derivado de source/when/neighborhood)"
+              },
+              "text": {
+                "type": "string",
+                "description": "Texto do depoimento"
+              },
+              "photo": {
+                "type": "string",
+                "description": "Caminho relativo da foto do depoimento (ex: /photos/testimonials/x.webp)"
+              },
+              "photo_caption": {
+                "type": "string",
+                "description": "Legenda da foto (ex: 'Arlete · cachorrinha levada para exame')"
+              },
+              "source": {
+                "type": "string",
+                "description": "Fonte do depoimento (ex: 'Google Reviews', 'Google · Local Guide')"
+              },
+              "when": {
+                "type": "string",
+                "description": "Quando foi escrito (ex: '6 meses atrás')"
+              },
+              "rating": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 5,
+                "description": "Nota em estrelas (1-5)"
+              },
+              "neighborhood": {
+                "type": "string",
+                "description": "Bairro/cidade da pessoa"
+              },
+              "pet": {
+                "type": "string",
+                "description": "Nome e raça/idade do pet (ex: 'Mel · Siamês, 4 anos')"
+              }
+            }
+          }
+        },
+        "stats": {
+          "type": "array",
+          "description": "Números de impacto (clientes, anos, resultados).",
+          "items": {
+            "type": "object",
+            "required": [
+              "number",
+              "label"
+            ],
+            "properties": {
+              "number": {
+                "type": "string",
+                "description": "Número formatado (ex: '500+')"
+              },
+              "label": {
+                "type": "string",
+                "description": "Descrição do número"
+              }
+            }
+          }
+        }
+      }
+    },
+    "meta": {
+      "type": "object",
+      "required": [
+        "title",
+        "description",
+        "og_title",
+        "og_description",
+        "og_type"
+      ],
+      "properties": {
+        "title": {
+          "type": "string",
+          "maxLength": 60,
+          "description": "Title tag para SEO"
+        },
+        "description": {
+          "type": "string",
+          "maxLength": 155,
+          "description": "Meta description para SEO"
+        },
+        "og_title": {
+          "type": "string"
+        },
+        "og_description": {
+          "type": "string"
+        },
+        "og_type": {
+          "type": "string",
+          "enum": [
+            "website"
+          ],
+          "default": "website"
+        }
+      }
+    },
+    "deploy_url": {
+      "type": "string",
+      "format": "uri",
+      "description": "URL da LP deployada na Vercel"
+    },
+    "whatsapp_link": {
+      "type": "string",
+      "description": "Link completo do WhatsApp com mensagem pré-formatada"
+    }
+  }
+}

--- a/.agents/skills/designer-lp-asset-pipeline/SKILL.md
+++ b/.agents/skills/designer-lp-asset-pipeline/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: designer-lp-asset-pipeline
+description: Preparar e governar assets de landing pages com rastreabilidade de origem, direitos, original, derivados e uso responsivo. Usar quando assets aprovados precisarem ser selecionados ou preparados para produção; não usar para buscar stock automaticamente, instalar processadores ou substituir imagens sem aprovação.
+area: designer
+author: nicolaskobayashi-v4
+version: 1.0.0
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta skill foi portada do repositorio v4-unidade-integrada. As regras abaixo tem precedencia sobre caminhos, zonas e ferramentas citados no corpo original:
+
+- **Posicao no fluxo.** Este pipeline fica a jusante de `designer-landing-page`, que e a porta do hub para `ee-s3-landing-page`. O `designer-landing-page` responde por estrategia, copy e geracao de codigo. Este pipeline responde por baseline, adaptacao, assets, quality gate e release controlada. O passo `vercel --yes --prod` do `designer-landing-page` fica **suspenso** quando o pipeline estiver em uso: release passa por `designer-lp-release`, e Production continua proibida.
+- **Governanca.** Onde o corpo cita "o `AGENTS.md` raiz prevalece", leia o `CLAUDE.md` e o `AGENTS.md` da raiz do hub mais o `CLAUDE.md` da KB do cliente. Nenhuma regra local pode enfraquece-los.
+- **Zonas somente leitura.** Onde o corpo cita "matriz" e "plugin", leia: `.claude/skills/`, `.agents/skills/` e `REGISTRY.md` sao somente leitura durante o pipeline. `REGISTRY.md` e auto-gerado e nunca se edita a mao.
+- **Caminhos.** Trabalhe em `squads/{squad}/clientes/{cliente}/`. A estrutura do projeto e `squads/{squad}/clientes/{cliente}/outputs/landing-pages/<projeto>/`, com `reference/` e `src/` dentro dela.
+- **`client.json`.** Opcional no hub. So a KB migrada do EE tem esse arquivo. Se nao existir, derive o contexto de `CLAUDE.md`, `mission-control/`, `docs/` e `links.md`, e nao invente o arquivo.
+- **Scripts da matriz.** `validate_output.py`, `page_audit.py`, `page_audit_deep.py` e o agente `revisor-qualidade` **nao existem no hub**. Onde o corpo os cita, declare o gap e faca a verificacao equivalente a mao, registrando o que foi checado e como.
+- **Vercel.** O hub nao tem projeto Vercel configurado. Preview exige configurar o projeto antes e autorizacao explicita do usuario na hora. Production permanece proibida por esta skill.
+- **Registro.** Decisao, gate aprovado e bloqueio vao para `mission-control/historico-checkins.md` da KB do cliente.
+- **Git.** Nunca commite `squads/` nem `bases/`. Sao pessoais e ficam no `.gitignore`.
+
+---
+
+
+# LP Asset Pipeline
+
+## 1. Propósito
+
+Definir o fluxo seguro de assets do original aprovado até o código, preservando origem e direitos e documentando todas as derivações usadas na landing page.
+
+## 2. Quando usar
+
+- Quando a seção autorizada usar imagens, logos, ícones, vídeos ou outros arquivos de mídia.
+- Quando um asset exigir otimização, recorte, variantes responsivas ou fallback.
+- Quando a implementação contiver base64 ou arquivos sem origem e direitos documentados.
+
+## 3. Quando NÃO usar
+
+- Para escolher fotografia de stock sem solicitação e aprovação humanas.
+- Para alterar copy, layout, links ou identidade visual.
+- Para instalar automaticamente bibliotecas, codecs ou processadores.
+- Quando não houver autorização de uso ou origem verificável.
+
+## 4. Pré-condições
+
+1. Confirmar baseline, seção e arquivos autorizados.
+2. Inventariar assets existentes sem modificar originals ou referência.
+3. Confirmar origem, direito de uso e papel de cada asset.
+4. Apresentar transformações e destinos propostos.
+5. Obter aprovação explícita antes de criar derivados ou alterar referências no código.
+
+## 5. Entradas
+
+- Assets oficiais aprovados e seus metadados disponíveis.
+- Baseline e cópia de trabalho.
+- Manual de Marca e diagnóstico visual aprovados.
+- Requisitos de exibição, recorte, densidade e viewports.
+- Restrições técnicas da implementação.
+
+## 6. Fontes permitidas
+
+- Assets oficiais do cliente com uso autorizado.
+- Derivados existentes cuja relação com o original seja comprovável.
+- Ícones já aprovados e integrantes do sistema visual.
+- Referências externas apenas para repertório, sem reutilização do arquivo.
+
+## 7. Precedência das fontes
+
+- Fatos: confirmação explícita mais recente → `client.json` → base estratégica aprovada → outputs estratégicos aprovados → implementação existente.
+- Visual: confirmação explícita mais recente → Manual aprovado mais recente → diagnóstico visual aprovado → assets oficiais → referências externas → implementação existente.
+- Copy: copy explicitamente aprovada → output estratégico de landing page aprovado → implementação existente.
+- Links: confirmação explícita → implementação existente aprovada.
+
+Em conflito de asset ou orientação visual, registrar e solicitar decisão. Documento especializado posterior prevalece apenas no seu domínio e com registro.
+
+## 8. Procedimento
+
+1. Inventariar arquivo, origem, proprietário/direito conhecido, função e ocorrências no código.
+2. Identificar o original preservado e separar qualquer derivado existente.
+3. Registrar para cada variante: dimensões, formato, peso, crop, densidade e fallback.
+4. Classificar uso como decorativo, informativo, marca, ícone ou mídia funcional.
+5. Propor a cadeia `original → derivado otimizado → asset de produção → referência no código`.
+6. Preservar o original sem conversão, renomeação ou sobrescrita.
+7. Preferir WebP quando compatível e manter fallback adequado ao projeto.
+8. Para imagens responsivas, propor múltiplas larguras e uso coerente de `picture`, `srcset` e `sizes`.
+9. Documentar recortes intencionais e comportamento por viewport.
+10. Tratar base64 como tolerável em protótipo; para produção, registrar pendência até haver asset rastreável e aprovado.
+11. Depois da autorização, criar somente derivados previstos e atualizar apenas código autorizado.
+12. Verificar visualmente distorção, nitidez, crop e fallback.
+
+## 9. Saídas esperadas
+
+- Inventário de assets com origem e direito de uso conhecido.
+- Mapa de original, derivados, dimensões, formato, peso, crop e fallback.
+- Plano responsivo e referências de código propostas.
+- Pendências explícitas para base64, direitos ausentes ou qualidade insuficiente.
+
+## 10. Critérios de parada
+
+Parar se origem ou direito de uso forem desconhecidos, se não houver original preservável, se a transformação comprometer identidade ou fidelidade, ou se a atualização exigir arquivo não autorizado. Ausência de foto não autoriza stock.
+
+## 11. Checkpoints humanos
+
+- Aprovar direito de uso e seleção dos assets.
+- Aprovar transformações, crops, variantes e fallbacks.
+- Aprovar mudança das referências no código.
+- Revisar resultado visual antes do quality gate.
+
+## 12. Proteções
+
+O `AGENTS.md` raiz prevalece. Original, `reference/`, plugin e matriz são somente leitura. Não modificar asset, link ou copy sem aprovação. Não ler secrets. Commit/push e Preview exigem autorização separada; Production é proibida.
+
+## 13. Integração com a matriz
+
+Consumir Manual de Marca, diagnóstico visual, diagnóstico de criativos e output estratégico aprovados. Esta skill acrescenta rastreabilidade e preparação técnica de assets; não duplica diagnóstico, não altera os outputs da matriz e não herda mutações ou deploys.
+
+## 14. Ferramentas reutilizáveis
+
+- Disponíveis: metadados do filesystem, `Get-FileHash` e inspeção de referências com `rg`.
+- Condicionais: recursos já instalados no projeto; descobrir e validar as ferramentas existentes antes de propor seu uso, sem instalar dependências automaticamente.
+- Planejadas: processador de imagens, gerador de variantes e verificador de peso; nenhum está implementado nesta fase.
+- Humanas: confirmação de direitos, crop, qualidade e adequação à marca.
+- Proibidas: instalação automática de processador e busca automática de stock.
+
+## 15. Ações proibidas
+
+- Sobrescrever ou recomprimir o original.
+- Baixar ou incorporar asset externo sem autorização e direitos confirmados.
+- Alterar silenciosamente crop, formato, nome ou uso no código.
+- Usar base64 como asset final de produção sem pendência documentada.
+- Fazer commit, push ou deploy.
+
+## 16. Definição de sucesso
+
+Cada asset de produção é rastreável a um original autorizado, possui derivados documentados e comportamento responsivo validado, sem perda do original nem incorporação não autorizada.

--- a/.agents/skills/designer-lp-baseline-prepare/SKILL.md
+++ b/.agents/skills/designer-lp-baseline-prepare/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: designer-lp-baseline-prepare
+description: Preparar uma baseline imutável e uma cópia de trabalho isolada para uma landing page após auditoria aprovada. Usar antes da primeira alteração de implementação; não usar sem fonte inequívoca, autorização de escrita ou possibilidade de preservar a referência sem sobrescrita.
+area: designer
+author: nicolaskobayashi-v4
+version: 1.0.0
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta skill foi portada do repositorio v4-unidade-integrada. As regras abaixo tem precedencia sobre caminhos, zonas e ferramentas citados no corpo original:
+
+- **Posicao no fluxo.** Este pipeline fica a jusante de `designer-landing-page`, que e a porta do hub para `ee-s3-landing-page`. O `designer-landing-page` responde por estrategia, copy e geracao de codigo. Este pipeline responde por baseline, adaptacao, assets, quality gate e release controlada. O passo `vercel --yes --prod` do `designer-landing-page` fica **suspenso** quando o pipeline estiver em uso: release passa por `designer-lp-release`, e Production continua proibida.
+- **Governanca.** Onde o corpo cita "o `AGENTS.md` raiz prevalece", leia o `CLAUDE.md` e o `AGENTS.md` da raiz do hub mais o `CLAUDE.md` da KB do cliente. Nenhuma regra local pode enfraquece-los.
+- **Zonas somente leitura.** Onde o corpo cita "matriz" e "plugin", leia: `.claude/skills/`, `.agents/skills/` e `REGISTRY.md` sao somente leitura durante o pipeline. `REGISTRY.md` e auto-gerado e nunca se edita a mao.
+- **Caminhos.** Trabalhe em `squads/{squad}/clientes/{cliente}/`. A estrutura do projeto e `squads/{squad}/clientes/{cliente}/outputs/landing-pages/<projeto>/`, com `reference/` e `src/` dentro dela.
+- **`client.json`.** Opcional no hub. So a KB migrada do EE tem esse arquivo. Se nao existir, derive o contexto de `CLAUDE.md`, `mission-control/`, `docs/` e `links.md`, e nao invente o arquivo.
+- **Scripts da matriz.** `validate_output.py`, `page_audit.py`, `page_audit_deep.py` e o agente `revisor-qualidade` **nao existem no hub**. Onde o corpo os cita, declare o gap e faca a verificacao equivalente a mao, registrando o que foi checado e como.
+- **Vercel.** O hub nao tem projeto Vercel configurado. Preview exige configurar o projeto antes e autorizacao explicita do usuario na hora. Production permanece proibida por esta skill.
+- **Registro.** Decisao, gate aprovado e bloqueio vao para `mission-control/historico-checkins.md` da KB do cliente.
+- **Git.** Nunca commite `squads/` nem `bases/`. Sao pessoais e ficam no `.gitignore`.
+
+---
+
+
+# LP Baseline Prepare
+
+## 1. Propósito
+
+Criar a fronteira imutável entre a referência aprovada e a implementação editável, permitindo comparação e recuperação sem tocar o original.
+
+## 2. Quando usar
+
+- Depois de `designer-lp-source-audit` concluir que a fonte está pronta.
+- Antes de qualquer adaptação visual, de assets ou de código.
+- Quando ainda não existir uma referência congelada e uma cópia de trabalho isolada.
+
+## 3. Quando NÃO usar
+
+- Quando a auditoria estiver bloqueada ou houver versões conflitantes.
+- Para reorganizar outputs existentes ou transformar uma referência em área editável.
+- Sem aprovação explícita dos caminhos e das operações de escrita.
+
+## 4. Pré-condições
+
+1. Ter relatório de fonte aprovado e implementação de origem inequívoca.
+2. Auditar branch, worktree, arquivos-alvo e instruções locais.
+3. Apresentar plano com origem, `reference/`, `src/` e operações exatas.
+4. Confirmar que os caminhos são novos e isolados.
+5. Obter aprovação explícita antes de criar ou copiar qualquer arquivo.
+
+## 5. Entradas
+
+- Implementação aprovada pela auditoria.
+- Caminho novo do projeto, preferencialmente `outputs/landing-pages/<project>/`.
+- Lista de arquivos necessários à execução.
+- Hashes, estado Git e confirmação humana da versão de origem.
+
+## 6. Fontes permitidas
+
+- Implementação existente aprovada e seus assets oficiais.
+- Histórico Git para registrar versão de origem.
+- Outputs estratégicos aprovados apenas para conferência.
+
+Não incorporar material externo novo durante a preparação da baseline.
+
+## 7. Precedência das fontes
+
+- Fatos: confirmação explícita mais recente → `client.json` → base estratégica aprovada → outputs estratégicos aprovados → implementação existente.
+- Visual: confirmação explícita mais recente → Manual de Marca aprovado mais recente → diagnóstico visual aprovado → assets oficiais → referências externas → implementação existente.
+- Copy: copy explicitamente aprovada → output estratégico de landing page aprovado → implementação existente.
+- Links: confirmação explícita → implementação existente aprovada.
+
+Registrar todo conflito descoberto nesta etapa, invalidar a prontidão e retornar à auditoria; não o resolver durante a cópia. Posicionamento, CRO, diagnóstico ou outro output estratégico não substituem silenciosamente a copy específica aprovada da landing page.
+
+## 8. Procedimento
+
+1. Validar novamente que origem e destinos correspondem ao plano aprovado.
+2. Confirmar que `reference/` e `src/` não contêm arquivos preexistentes.
+3. Registrar origem, caminho relativo, hash, timestamp de preparação e função de cada arquivo.
+4. Em execução autorizada, copiar a implementação aprovada para `reference/` sem transformação.
+5. Validar a cópia de referência por hash e contagem.
+6. Criar `src/` como cópia de trabalho separada, preservando estrutura necessária.
+7. Validar que `reference/` e `src/` começam equivalentes.
+8. Marcar `reference/` como fronteira somente leitura no relatório operacional.
+9. Registrar diferenças preexistentes, se houver, e bloquear em vez de normalizá-las.
+
+Estrutura recomendada:
+
+```text
+outputs/landing-pages/<project>/
+├── reference/  # cópia congelada, nunca editada
+└── src/        # única área autorizável para implementação
+```
+
+## 9. Saídas esperadas
+
+- Baseline congelada em caminho novo e isolado.
+- Cópia de trabalho inicialmente equivalente.
+- Manifesto humano com origem, caminho, hash, timestamp e função.
+- Registro de autorização e validação pós-cópia.
+
+## 10. Critérios de parada
+
+Parar se qualquer destino existir, se hashes não coincidirem, se houver risco de sobrescrita, se a origem mudar durante a operação ou se faltar autorização. Não improvisar nomes, conteúdo, links ou assets.
+
+## 11. Checkpoints humanos
+
+- Aprovar caminhos, lista de arquivos e operação de cópia.
+- Confirmar o manifesto e a imutabilidade de `reference/`.
+- Autorizar separadamente a primeira seção a ser alterada em `src/`.
+
+## 12. Proteções
+
+O `AGENTS.md` raiz prevalece. Nunca modificar origem, outputs existentes, plugin ou `reference/`. Cada execução altera no máximo uma seção autorizada na etapa posterior. Não ler secrets. Commit, push e Vercel Preview exigem aprovações próprias; Production é proibida.
+
+## 13. Integração com a matriz
+
+Consumir a implementação indicada por `designer-lp-source-audit` e outputs aprovados da matriz como evidência. Esta skill cria uma proteção operacional nova; não altera contratos, outputs ou scripts da matriz e não herda comandos de deploy ou mutação do cliente.
+
+## 14. Ferramentas reutilizáveis
+
+- Disponíveis: `Get-FileHash`, `git status`, `git diff --no-index` e listagem nativa de arquivos.
+- Planejadas: manifesto gerado por ferramenta própria, ainda não implementado.
+- Humanas: confirmação da versão e autorização de caminho.
+- Proibidas: sincronização destrutiva, formatação automática da referência e scaffolding que adicione arquivos não aprovados.
+
+## 15. Ações proibidas
+
+- Sobrescrever, mover, renomear, reformatar ou otimizar a origem ou `reference/`.
+- Usar um output atual como diretório editável.
+- Incluir arquivos além dos aprovados.
+- Fazer mudanças visuais, de copy, link ou asset nesta etapa.
+
+## 16. Definição de sucesso
+
+Referência e trabalho ficam fisicamente separados, verificáveis e inicialmente equivalentes, com origem e autorização rastreáveis e nenhuma alteração no original.

--- a/.agents/skills/designer-lp-design-adapter/SKILL.md
+++ b/.agents/skills/designer-lp-design-adapter/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: designer-lp-design-adapter
+description: Adaptar visualmente uma landing page em uma cópia de trabalho autorizada, preservando conteúdo, links, claims e estrutura comercial congelados. Usar por seção, para aplicação de marca, correções visuais ou programas de redesign conduzidos em sucessivas execuções de uma seção; não usar para alterar a página inteira em uma execução, criar estratégia, trocar assets sem aprovação ou editar referência/original.
+area: designer
+author: nicolaskobayashi-v4
+version: 1.0.0
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta skill foi portada do repositorio v4-unidade-integrada. As regras abaixo tem precedencia sobre caminhos, zonas e ferramentas citados no corpo original:
+
+- **Posicao no fluxo.** Este pipeline fica a jusante de `designer-landing-page`, que e a porta do hub para `ee-s3-landing-page`. O `designer-landing-page` responde por estrategia, copy e geracao de codigo. Este pipeline responde por baseline, adaptacao, assets, quality gate e release controlada. O passo `vercel --yes --prod` do `designer-landing-page` fica **suspenso** quando o pipeline estiver em uso: release passa por `designer-lp-release`, e Production continua proibida.
+- **Governanca.** Onde o corpo cita "o `AGENTS.md` raiz prevalece", leia o `CLAUDE.md` e o `AGENTS.md` da raiz do hub mais o `CLAUDE.md` da KB do cliente. Nenhuma regra local pode enfraquece-los.
+- **Zonas somente leitura.** Onde o corpo cita "matriz" e "plugin", leia: `.claude/skills/`, `.agents/skills/` e `REGISTRY.md` sao somente leitura durante o pipeline. `REGISTRY.md` e auto-gerado e nunca se edita a mao.
+- **Caminhos.** Trabalhe em `squads/{squad}/clientes/{cliente}/`. A estrutura do projeto e `squads/{squad}/clientes/{cliente}/outputs/landing-pages/<projeto>/`, com `reference/` e `src/` dentro dela.
+- **`client.json`.** Opcional no hub. So a KB migrada do EE tem esse arquivo. Se nao existir, derive o contexto de `CLAUDE.md`, `mission-control/`, `docs/` e `links.md`, e nao invente o arquivo.
+- **Scripts da matriz.** `validate_output.py`, `page_audit.py`, `page_audit_deep.py` e o agente `revisor-qualidade` **nao existem no hub**. Onde o corpo os cita, declare o gap e faca a verificacao equivalente a mao, registrando o que foi checado e como.
+- **Vercel.** O hub nao tem projeto Vercel configurado. Preview exige configurar o projeto antes e autorizacao explicita do usuario na hora. Production permanece proibida por esta skill.
+- **Registro.** Decisao, gate aprovado e bloqueio vao para `mission-control/historico-checkins.md` da KB do cliente.
+- **Git.** Nunca commite `squads/` nem `bases/`. Sao pessoais e ficam no `.gitignore`.
+
+---
+
+
+# LP Design Adapter
+
+## 1. Propósito
+
+Transformar a apresentação visual da implementação autorizada com fidelidade à marca e à referência, sem redefinir estratégia, copy, oferta, claims, links ou função comercial.
+
+## 2. Quando usar
+
+- Para executar uma etapa de um programa de redesign completo, sempre limitada a uma seção autorizada.
+- Para adaptação de uma única seção por execução.
+- Para aplicação de Manual de Marca ou rodada de correções visuais delimitadas.
+
+“Redesign completo” significa um programa composto por sucessivas execuções desta skill, uma seção por vez. Nunca interpretar o programa como autorização para alterar toda a página em uma única execução.
+
+## 3. Quando NÃO usar
+
+- Sem baseline aprovada e seção/arquivos explicitamente autorizados.
+- Para escrever estratégia, substituir copy ou decidir claims, preços, métricas e links.
+- Para buscar stock automaticamente ou reutilizar identidade, código, estrutura completa ou assets externos.
+
+## 4. Pré-condições
+
+1. Confirmar `source_audited` e `baseline_approved`.
+2. Identificar `reference/` somente leitura e `src/` editável.
+3. Congelar copy, links, claims e estrutura comercial da seção.
+4. Ler Manual de Marca e diagnóstico visual aprovados, quando disponíveis.
+5. Apresentar plano e obter autorização explícita para uma seção e arquivos definidos.
+
+## 5. Entradas
+
+- Baseline e cópia de trabalho.
+- Copy, links, claims e estrutura comercial aprovados.
+- Manual de Marca, diagnóstico visual e assets oficiais aprovados.
+- Referências visuais autorizadas e escopo de adaptação.
+- Restrições técnicas e viewports-alvo.
+
+## 6. Fontes permitidas
+
+- Fontes internas aprovadas e assets oficiais.
+- Output estratégico aprovado como restrição de conteúdo.
+- Referências externas apenas como repertório de composição, ritmo e padrões.
+
+Referências externas nunca autorizam copiar identidade, código, estrutura integral, conteúdo ou assets.
+
+## 7. Precedência das fontes
+
+- Fatos: confirmação explícita mais recente → `client.json` → base estratégica aprovada → outputs estratégicos aprovados → implementação existente.
+- Visual: confirmação explícita mais recente → Manual aprovado mais recente → diagnóstico visual aprovado → assets oficiais → referências externas → implementação existente.
+- Copy: copy explicitamente aprovada → output estratégico de landing page aprovado → implementação existente.
+- Links: confirmação explícita → implementação existente aprovada.
+
+Registrar todo conflito e interromper o trecho afetado. Documento especializado posterior pode prevalecer apenas em seu domínio e com decisão registrada.
+
+## 8. Procedimento
+
+1. Selecionar o modo: etapa de programa de redesign completo, adaptação por seção, aplicação de marca ou rodada de correções visuais.
+2. Se o modo for redesign completo, registrar o programa geral apenas como roteiro; não tratá-lo como autorização de escrita.
+3. Delimitar arquivos, seletores, componentes e conteúdo que não podem mudar.
+4. Comparar `reference/` e `src/` antes da edição e registrar diferenças preexistentes.
+5. Traduzir Manual e diagnóstico em decisões explícitas de tipografia, cor, espaçamento, grid, hierarquia e componentes.
+6. Tratar benchmarks como repertório, nunca como template.
+7. Adaptar somente a seção autorizada em `src/`.
+8. Manter copy, links, claims, preços, métricas e ordem comercial congelados.
+9. Se não houver fotografia oficial aprovada, manter solução sem foto; não inserir stock.
+10. Usar ícones de forma sistemática e coerente; evitar ilustrações improvisadas.
+11. Permitir assimetria apenas quando controlada por grid, hierarquia e comportamento responsivo.
+12. Remover ou não criar decoração sem função comunicacional.
+13. Verificar visualmente 390, 768, 1024 e 1440 px, comparando com a referência.
+14. Submeter a seção à revisão estética humana antes de encerrar a execução.
+15. Exigir nova autorização para a seção seguinte; a aprovação atual nunca se propaga automaticamente.
+
+## 9. Saídas esperadas
+
+- Alteração limitada à área `src/`, aos arquivos e à seção autorizados.
+- Registro das decisões visuais e dos itens preservados.
+- Comparação com baseline e lista de desvios intencionais.
+- Pendências encaminhadas a assets, qualidade ou decisão humana.
+- Em programa de redesign completo, registro da etapa concluída sem autorizar as seções seguintes.
+
+## 10. Critérios de parada
+
+Parar se a fidelidade visual, copy, links, claims, assets ou estrutura comercial não puderem ser preservados; se faltar fonte visual crítica; ou se a mudança exigir outro arquivo/seção. Não inventar solução factual nem ampliar escopo.
+
+## 11. Checkpoints humanos
+
+- Aprovar modo, seção, arquivos e plano antes da escrita.
+- Aprovar qualquer exceção de conteúdo ou asset antes da mudança.
+- Realizar revisão estética e responsiva antes do quality gate.
+
+## 12. Proteções
+
+O `AGENTS.md` raiz prevalece. Plugin, matriz, original e `reference/` são somente leitura. Uma execução modifica no máximo uma seção. Não alterar copy, links ou assets sem aprovação. Não ler secrets. Commit/push e Preview têm aprovações separadas; Production é proibida.
+
+## 13. Integração com a matriz
+
+Consumir `ee-s3-landing-page`, Manual de Marca, posicionamento, diagnósticos aprovados e padrões de copy como restrições e repertório. Esta skill estende a camada visual operacional; não substitui estratégia, não reescreve outputs e não executa deploys ou mutações sugeridos pela matriz.
+
+## 14. Ferramentas reutilizáveis
+
+- Disponíveis: inspeção estática de HTML/CSS/JS e Git diff.
+- Condicionais: renderização local; descobrir primeiro se o projeto possui mecanismo utilizável e autorizado antes de propor seu uso.
+- Planejadas: comparação visual automatizada e tokens normalizados, ainda não implementados.
+- Humanas: revisão estética, confirmação de marca e aceitação de desvios.
+- Proibidas: instalação automática de frameworks, busca automática de stock e edição do Figma original.
+
+## 15. Ações proibidas
+
+- Editar `reference/`, original, plugin ou outputs não autorizados.
+- Inventar claims, depoimentos, preços, métricas, links ou conteúdo.
+- Copiar identidade, código, estrutura completa ou assets de terceiros.
+- Inserir imagem genérica para preencher ausência de fotografia.
+- Fazer commit, push ou deploy.
+
+## 16. Definição de sucesso
+
+A seção autorizada apresenta adaptação visual coerente e responsiva, mantém integralmente o conteúdo e a função aprovados, possui desvios rastreáveis e passa pela revisão estética humana sem tocar os originais.

--- a/.agents/skills/designer-lp-orchestrator/SKILL.md
+++ b/.agents/skills/designer-lp-orchestrator/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: designer-lp-orchestrator
+description: Coordenar o pipeline de produção de landing pages por estados, gates humanos e contratos entre skills. Usar para iniciar, retomar ou determinar a próxima etapa segura; não usar para editar design/código, decidir copy/claims/imagens, alterar links ou executar deploy.
+area: designer
+author: nicolaskobayashi-v4
+version: 1.0.0
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta skill foi portada do repositorio v4-unidade-integrada. As regras abaixo tem precedencia sobre caminhos, zonas e ferramentas citados no corpo original:
+
+- **Posicao no fluxo.** Este pipeline fica a jusante de `designer-landing-page`, que e a porta do hub para `ee-s3-landing-page`. O `designer-landing-page` responde por estrategia, copy e geracao de codigo. Este pipeline responde por baseline, adaptacao, assets, quality gate e release controlada. O passo `vercel --yes --prod` do `designer-landing-page` fica **suspenso** quando o pipeline estiver em uso: release passa por `designer-lp-release`, e Production continua proibida.
+- **Governanca.** Onde o corpo cita "o `AGENTS.md` raiz prevalece", leia o `CLAUDE.md` e o `AGENTS.md` da raiz do hub mais o `CLAUDE.md` da KB do cliente. Nenhuma regra local pode enfraquece-los.
+- **Zonas somente leitura.** Onde o corpo cita "matriz" e "plugin", leia: `.claude/skills/`, `.agents/skills/` e `REGISTRY.md` sao somente leitura durante o pipeline. `REGISTRY.md` e auto-gerado e nunca se edita a mao.
+- **Caminhos.** Trabalhe em `squads/{squad}/clientes/{cliente}/`. A estrutura do projeto e `squads/{squad}/clientes/{cliente}/outputs/landing-pages/<projeto>/`, com `reference/` e `src/` dentro dela.
+- **`client.json`.** Opcional no hub. So a KB migrada do EE tem esse arquivo. Se nao existir, derive o contexto de `CLAUDE.md`, `mission-control/`, `docs/` e `links.md`, e nao invente o arquivo.
+- **Scripts da matriz.** `validate_output.py`, `page_audit.py`, `page_audit_deep.py` e o agente `revisor-qualidade` **nao existem no hub**. Onde o corpo os cita, declare o gap e faca a verificacao equivalente a mao, registrando o que foi checado e como.
+- **Vercel.** O hub nao tem projeto Vercel configurado. Preview exige configurar o projeto antes e autorizacao explicita do usuario na hora. Production permanece proibida por esta skill.
+- **Registro.** Decisao, gate aprovado e bloqueio vao para `mission-control/historico-checkins.md` da KB do cliente.
+- **Git.** Nunca commite `squads/` nem `bases/`. Sao pessoais e ficam no `.gitignore`.
+
+---
+
+
+# LP Orchestrator
+
+## 1. Propósito
+
+Coordenar a sequência operacional da landing page, preservar o estado auditável e impedir que uma etapa avance sem evidência e checkpoint humano. Não realizar o trabalho especializado das skills coordenadas.
+
+Ao executar, ler [references/pipeline-contract.md](references/pipeline-contract.md) integralmente.
+
+## 2. Quando usar
+
+- Para iniciar um novo fluxo de landing page.
+- Para retomar trabalho interrompido e localizar o último gate válido.
+- Para identificar a próxima skill, evidência ou autorização necessária.
+
+## 3. Quando NÃO usar
+
+- Para editar HTML, CSS, JavaScript, design, Figma ou assets.
+- Para decidir ou alterar copy, claims, imagens, preços, métricas ou links.
+- Para executar commit, push ou deploy.
+- Para contornar um `STOP` emitido por outra skill.
+
+## 4. Pré-condições
+
+1. Ler o `AGENTS.md` raiz e instruções locais.
+2. Auditar branch, worktree, cliente, projeto e escopo.
+3. Confirmar que plugin e outputs da matriz são somente leitura.
+4. Identificar registros existentes de estados e aprovações.
+5. Não presumir que uma ação passada autoriza a próxima.
+
+## 5. Entradas
+
+- Pedido atual e escopo autorizado.
+- Evidências e saídas das skills do pipeline.
+- Aprovações humanas registradas.
+- Estado Git e identificação do projeto.
+- Outputs estratégicos aprovados da matriz, apenas como entradas.
+
+## 6. Fontes permitidas
+
+- Registros produzidos pelas oito skills locais.
+- Confirmações explícitas do responsável.
+- Estado Git e arquivos do cliente permitidos pela governança.
+- Outputs aprovados da matriz em modo somente leitura.
+
+Referências externas não definem estado nem fatos do projeto.
+
+## 7. Precedência das fontes
+
+- Fatos: confirmação explícita mais recente → `client.json` → base estratégica aprovada → outputs estratégicos aprovados → implementação existente.
+- Visual: confirmação explícita mais recente → Manual aprovado mais recente → diagnóstico visual aprovado → assets oficiais → referências externas → implementação existente.
+- Copy: copy explicitamente aprovada → output estratégico de landing page aprovado → implementação existente.
+- Links: confirmação explícita → implementação existente aprovada.
+
+Uma confirmação recente não apaga o histórico: registrar a decisão e o conflito. Documento especializado posterior pode prevalecer apenas em seu domínio.
+
+## 8. Procedimento
+
+1. Identificar o último estado comprovado por evidência ainda válida.
+2. Validar as condições de entrada e saída desse estado no contrato do pipeline.
+3. Se houver mudança posterior, invalidar os estados dependentes e retornar ao gate apropriado.
+4. Determinar uma única próxima etapa segura.
+5. Apresentar escopo, arquivos, ações e checkpoint humano exigidos pela etapa.
+6. Invocar conceitualmente a skill responsável; não executar sua função no orquestrador.
+7. Para todo `STOP` ou `BLOCKED`, informar obrigatoriamente: condição bloqueadora; evidência, autorização ou informação exata ausente; responsável esperado pela resolução; último estado válido; e próximo gate possível depois da resolução.
+8. Interromper em qualquer `STOP`; retomar somente após a condição ser resolvida.
+9. Encerrar em `human_approved`. Não criar estado ou caminho para Production.
+
+Estados, em ordem:
+
+```text
+source_audited
+→ baseline_approved
+→ section_authorized
+→ implementation_reviewed
+→ assets_approved
+→ quality_gate_passed
+→ preview_authorized
+→ human_approved
+```
+
+## 9. Saídas esperadas
+
+- Estado atual e evidência que o sustenta.
+- Próxima etapa única, skill responsável e pré-condições.
+- Checkpoint humano pendente e escopo de autorização.
+- Registro de interrupção/retomada e invalidações.
+- Para todo bloqueio, identificação precisa da condição, do item ausente, do responsável, do último estado válido e do próximo gate possível.
+
+## 10. Critérios de parada
+
+`STOP` é a ação operacional de interromper a execução porque falta uma pré-condição, evidência ou autorização. `BLOCKED` é o estado ou resultado formal de um gate que não pode ser aprovado. Ausência de autorização para executar produz `STOP`; um quality gate que detecta baseline modificada produz `BLOCKED`. Não criar novos estados do pipeline.
+
+Parar se evidência, dado crítico, fonte, autorização ou estado anterior estiver ausente ou conflitante; se houver mudança inesperada; ou se a próxima ação exceder o escopo. Identificar exatamente o item ausente e nunca usar mensagens vagas como “faltam dados”, “aguardando aprovação” ou “há pendências”. Nunca inventar fatos, claims, depoimentos, links, preços ou métricas para avançar.
+
+## 11. Checkpoints humanos
+
+- Aprovar baseline e fronteira imutável.
+- Autorizar uma seção e os arquivos de cada execução.
+- Revisar implementação e assets.
+- Aceitar o quality gate e seus warnings.
+- Autorizar Preview explicitamente.
+- Homologar a Preview sem implicar Production.
+
+## 12. Proteções
+
+O `AGENTS.md` raiz prevalece e regras locais não podem enfraquecê-lo. Plugin e outputs da matriz são somente leitura. Não modificar copy, link ou asset sem aprovação, não ler secrets e não agrupar autorizações. Commit/push são separados; Preview exige autorização; Production é proibida.
+
+## 13. Integração com a matriz
+
+Coordenar consumo de outputs aprovados de `ee-s3-landing-page`, Manual de Marca, posicionamento, diagnósticos e revisão. A matriz responde por estratégia e seus artefatos; a unidade responde por baseline, adaptação, assets, quality gate e Preview controlada. Não modificar a matriz nem executar seus fluxos incompatíveis.
+
+## 14. Ferramentas reutilizáveis
+
+- Disponíveis: estado Git, arquivos de evidência existentes e leitura dos contratos locais.
+- Planejadas: armazenamento estruturado de estado; não implementado nesta fase.
+- Humanas: todas as aprovações e decisões de conflito.
+- Proibidas: edição especializada, mutação automática de estado do cliente e qualquer deploy pelo orquestrador.
+
+## 15. Ações proibidas
+
+- Editar design, código, Figma, copy, claims, imagens ou links.
+- Escolher silenciosamente entre fontes conflitantes.
+- Marcar estado sem evidência ou pular gate.
+- Comunicar `STOP` ou `BLOCKED` sem identificar precisamente o item ausente e o responsável pela resolução.
+- Executar commit, push, Vercel Preview ou Production.
+- Criar o estado `production_authorized`.
+
+## 16. Definição de sucesso
+
+Em qualquer momento, o projeto possui um único estado comprovado, uma próxima ação segura e um checkpoint humano claro; interrupções são retomáveis e nenhum gate ou proteção de release pode ser contornado.

--- a/.agents/skills/designer-lp-orchestrator/references/pipeline-contract.md
+++ b/.agents/skills/designer-lp-orchestrator/references/pipeline-contract.md
@@ -1,0 +1,126 @@
+# Contrato do pipeline de landing pages
+
+## Fluxo exato
+
+```text
+client-knowledge-sync (quando necessário)
+→ designer-lp-source-audit
+→ designer-lp-baseline-prepare
+→ designer-lp-design-adapter
+→ designer-lp-asset-pipeline
+→ designer-lp-quality-gate
+→ designer-lp-release
+→ revisão humana
+```
+
+`client-knowledge-sync` é condicional e não cria um estado próprio no pipeline da landing page. Nenhuma etapa autoriza implicitamente a seguinte.
+
+## Contrato de estados
+
+### `source_audited`
+
+- Responsável: `designer-lp-source-audit`.
+- Entrada: fontes acessíveis em modo somente leitura.
+- Saída exigida: implementação e fontes identificadas, lacunas e conflitos registrados.
+- Gate humano: confirmar a implementação candidata.
+- STOP: fonte crítica ausente, versão ambígua ou conflito não resolvido.
+
+### `baseline_approved`
+
+- Responsável: `designer-lp-baseline-prepare`.
+- Entrada: `source_audited` e plano de caminhos aprovado.
+- Saída exigida: `reference/` imutável, `src/` separado e manifesto conferido.
+- Gate humano: aprovar baseline e fronteira de proteção.
+- STOP: destino existente, hash divergente ou risco de sobrescrita.
+
+### `section_authorized`
+
+- Responsáveis: humano e `designer-lp-design-adapter`.
+- Entrada: baseline aprovada e proposta delimitada.
+- Saída exigida: uma seção, arquivos e operações explicitamente autorizados.
+- Gate humano: autorização anterior à escrita.
+- STOP: escopo genérico, conteúdo não congelado ou múltiplas seções.
+
+### `implementation_reviewed`
+
+- Responsável: `designer-lp-design-adapter`.
+- Entrada: `section_authorized`.
+- Saída exigida: implementação local concluída e revisão estética/responsiva humana.
+- Gate humano: aceitar fidelidade visual e itens preservados.
+- STOP: perda visual, alteração de copy/link/claim ou asset não autorizado.
+
+### `assets_approved`
+
+- Responsável: `designer-lp-asset-pipeline`.
+- Entrada: implementação revisada e assets identificados.
+- Saída exigida: origem, direitos, derivados, comportamento responsivo e fallbacks aprovados.
+- Gate humano: aprovar seleção e transformações.
+- STOP: origem/direito desconhecido, original ausente ou stock não autorizado.
+
+### `quality_gate_passed`
+
+- Responsável: `designer-lp-quality-gate`.
+- Entrada: implementação e assets aprovados.
+- Saída exigida: `PASS` ou `PASS_WITH_WARNINGS` aceito, com evidências atuais.
+- Gate humano: revisão e aceitação de warnings.
+- STOP: `BLOCKED`, teste crítico ausente ou mudança inesperada.
+
+### `preview_authorized`
+
+- Responsáveis: humano e `designer-lp-release`.
+- Entrada: quality gate válido e destino confirmado.
+- Saída exigida: autorização explícita para uma Preview específica.
+- Gate humano: confirmar projeto, equipe, diretório e ação.
+- STOP: autorização ambígua, worktree mudou ou qualquer risco de Production.
+
+### `human_approved`
+
+- Responsável: revisor humano.
+- Entrada: Preview criada de forma autorizada ou artefato local apresentado para homologação.
+- Saída exigida: decisão de homologação registrada.
+- Estado terminal deste contrato.
+- Não autoriza Production.
+
+Não existe `production_authorized`.
+
+## Interrupção, invalidação e retomada
+
+- `STOP` é a ação operacional de interromper a execução porque uma pré-condição, evidência ou autorização está ausente.
+- `BLOCKED` é o estado ou resultado formal de um gate que não pode ser aprovado.
+- Ausência de autorização para executar produz `STOP`; quality gate com baseline modificada produz `BLOCKED`.
+- Nenhuma dessas definições cria novo estado no pipeline.
+- Ao receber `STOP` ou `BLOCKED`, manter o último estado comprovado e informar obrigatoriamente: condição bloqueadora; evidência, autorização ou informação exata ausente; responsável esperado pela resolução; último estado válido; e próximo gate possível depois da resolução.
+- Não usar mensagens vagas como “faltam dados”, “aguardando aprovação” ou “há pendências”.
+- Retomar pela etapa bloqueada depois de evidência ou autorização nova.
+- Mudança em fonte invalida auditoria e todos os estados dependentes.
+- Mudança em baseline invalida autorização de seção e estados posteriores.
+- Mudança em implementação ou asset invalida quality gate e release.
+- Mudança após o quality gate exige nova execução do gate.
+- Não pular estados nem converter silêncio em aprovação.
+
+## Responsabilidades da matriz
+
+- Produzir e manter estratégia aprovada.
+- Fornecer `client.json`, base estratégica, posicionamento e diagnósticos.
+- Produzir output estratégico de landing page e Manual de Marca quando aplicáveis.
+- Oferecer revisores e validadores como componentes consultáveis.
+- Permanecer somente leitura para a camada local durante esta fase.
+
+## Responsabilidades da unidade
+
+- Sincronizar conhecimento operacional somente quando necessário e autorizado.
+- Auditar fontes e escolher a implementação com evidência.
+- Proteger a baseline em cópia isolada.
+- Adaptar uma seção autorizada sem alterar estratégia ou conteúdo congelado.
+- Governar assets e derivados.
+- Executar quality gate integrado e registrar evidências reais.
+- Preparar e, apenas com autorização, criar Vercel Preview.
+- Manter Production desabilitada.
+
+## Limites de integração
+
+- Outputs da matriz podem ser consumidos; nunca modificados por este pipeline.
+- Instruções matriciais de mutação de cliente, cache, deploy ou Production não são herdadas.
+- Componentes matriciais podem ser citados e compostos conceitualmente sem copiar instruções inteiras.
+- O `AGENTS.md` raiz prevalece em todas as etapas.
+- Commit, push, Preview e qualquer escrita possuem autorizações distintas e limitadas.

--- a/.agents/skills/designer-lp-quality-gate/SKILL.md
+++ b/.agents/skills/designer-lp-quality-gate/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: designer-lp-quality-gate
+description: Executar o gate integrado de qualidade de uma landing page antes de release, reunindo conteúdo, baseline, visual, acessibilidade, responsividade, código, assets e Git. Usar após implementação e assets revisados; não usar para corrigir silenciosamente problemas, aprovar fatos ou substituir revisão humana.
+area: designer
+author: nicolaskobayashi-v4
+version: 1.0.0
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta skill foi portada do repositorio v4-unidade-integrada. As regras abaixo tem precedencia sobre caminhos, zonas e ferramentas citados no corpo original:
+
+- **Posicao no fluxo.** Este pipeline fica a jusante de `designer-landing-page`, que e a porta do hub para `ee-s3-landing-page`. O `designer-landing-page` responde por estrategia, copy e geracao de codigo. Este pipeline responde por baseline, adaptacao, assets, quality gate e release controlada. O passo `vercel --yes --prod` do `designer-landing-page` fica **suspenso** quando o pipeline estiver em uso: release passa por `designer-lp-release`, e Production continua proibida.
+- **Governanca.** Onde o corpo cita "o `AGENTS.md` raiz prevalece", leia o `CLAUDE.md` e o `AGENTS.md` da raiz do hub mais o `CLAUDE.md` da KB do cliente. Nenhuma regra local pode enfraquece-los.
+- **Zonas somente leitura.** Onde o corpo cita "matriz" e "plugin", leia: `.claude/skills/`, `.agents/skills/` e `REGISTRY.md` sao somente leitura durante o pipeline. `REGISTRY.md` e auto-gerado e nunca se edita a mao.
+- **Caminhos.** Trabalhe em `squads/{squad}/clientes/{cliente}/`. A estrutura do projeto e `squads/{squad}/clientes/{cliente}/outputs/landing-pages/<projeto>/`, com `reference/` e `src/` dentro dela.
+- **`client.json`.** Opcional no hub. So a KB migrada do EE tem esse arquivo. Se nao existir, derive o contexto de `CLAUDE.md`, `mission-control/`, `docs/` e `links.md`, e nao invente o arquivo.
+- **Scripts da matriz.** `validate_output.py`, `page_audit.py`, `page_audit_deep.py` e o agente `revisor-qualidade` **nao existem no hub**. Onde o corpo os cita, declare o gap e faca a verificacao equivalente a mao, registrando o que foi checado e como.
+- **Vercel.** O hub nao tem projeto Vercel configurado. Preview exige configurar o projeto antes e autorizacao explicita do usuario na hora. Production permanece proibida por esta skill.
+- **Registro.** Decisao, gate aprovado e bloqueio vao para `mission-control/historico-checkins.md` da KB do cliente.
+- **Git.** Nunca commite `squads/` nem `bases/`. Sao pessoais e ficam no `.gitignore`.
+
+---
+
+
+# LP Quality Gate
+
+## 1. Propósito
+
+Emitir uma decisão verificável — `PASS`, `PASS_WITH_WARNINGS` ou `BLOCKED` — sobre a prontidão da cópia de trabalho, sem alterar a implementação durante a avaliação.
+
+Ao executar, ler [references/quality-checklist.md](references/quality-checklist.md) integralmente e registrar cada item aplicável.
+
+## 2. Quando usar
+
+- Depois da revisão da implementação e da aprovação de assets.
+- Antes de solicitar autorização para Vercel Preview.
+- Novamente após qualquer correção que afete o resultado anterior.
+
+## 3. Quando NÃO usar
+
+- Antes de baseline e escopo estarem aprovados.
+- Para validar estratégia ainda não aprovada ou preencher lacunas.
+- Para alterar código, copy, links ou assets como efeito colateral.
+
+## 4. Pré-condições
+
+1. Confirmar referência imutável e arquivos autorizados em `src/`.
+2. Ter revisão estética humana e assets aprovados.
+3. Auditar branch e worktree.
+4. Confirmar como a página pode ser executada localmente sem instalar dependências novas.
+5. Identificar quais verificações são disponíveis, planejadas, humanas ou proibidas.
+
+## 5. Entradas
+
+- `reference/`, `src/` e escopo autorizado.
+- Copy, links, claims e assets aprovados.
+- Manual, diagnósticos e output estratégico aplicáveis.
+- Evidências de execução local e estado Git.
+- Checklist de qualidade desta skill.
+
+## 6. Fontes permitidas
+
+- Implementação e baseline locais.
+- Fontes aprovadas do cliente e outputs estratégicos somente leitura.
+- Logs locais e resultados reais de ferramentas existentes.
+- Avaliação humana documentada.
+
+Não declarar teste executado sem evidência da execução.
+
+## 7. Precedência das fontes
+
+- Fatos: confirmação explícita mais recente → `client.json` → base estratégica aprovada → outputs estratégicos aprovados → implementação existente.
+- Visual: confirmação explícita mais recente → Manual aprovado mais recente → diagnóstico visual aprovado → assets oficiais → referências externas → implementação existente.
+- Copy: copy explicitamente aprovada → output estratégico de landing page aprovado → implementação existente.
+- Links: confirmação explícita → implementação existente aprovada.
+
+Conflitos não resolvidos bloqueiam o gate; documento especializado posterior prevalece apenas no domínio correspondente e com registro.
+
+## 8. Procedimento
+
+1. Ler o checklist e marcar aplicabilidade, método e evidência de cada item.
+2. Comparar baseline e implementação para localizar mudanças autorizadas e inesperadas.
+3. Conferir copy, links, claims, preços, métricas e estrutura contra fontes aprovadas.
+4. Inspecionar HTML, CSS, JavaScript, SVG e assets por integridade, semântica e referências quebradas.
+5. Executar apenas comandos locais já disponíveis e permitidos; registrar comando e resultado real.
+6. Testar 390, 768, 1024 e 1440 px para layout, overflow, legibilidade e interação.
+7. Verificar acessibilidade básica: estrutura semântica, teclado, foco, nomes acessíveis, contraste e texto alternativo.
+8. Verificar console e comportamento de runtime, quando houver ambiente local executável.
+9. Auditar Git para arquivos inesperados, fora do escopo ou não autorizados.
+10. Se houver arquivos untracked, inspecioná-los diretamente: `git diff --check` não os cobre. Verificar trailing whitespace, tabs acidentais, encoding, arquivos vazios, marcadores `TODO`/`FIXME` não intencionais, headings duplicados quando pertinente e referências ou caminhos obviamente quebrados.
+11. Não executar `git add` nem `git add -N` para viabilizar a auditoria.
+12. Classificar cada achado por severidade e responsável.
+13. Emitir resultado sem corrigir durante o gate.
+
+## 9. Saídas esperadas
+
+- Checklist preenchido com evidência, resultado e observação.
+- Lista de achados bloqueadores e warnings.
+- Relação de mudanças autorizadas e inesperadas.
+- Decisão final `PASS`, `PASS_WITH_WARNINGS` ou `BLOCKED`.
+
+`PASS_WITH_WARNINGS` só admite riscos não factuais, não estruturais e aceitos explicitamente. Nenhum critério nominal de `BLOCKED` pode ser rebaixado silenciosamente para `PASS_WITH_WARNINGS`.
+
+## 10. Critérios de parada
+
+Parar com `BLOCKED` diante de qualquer uma destas condições:
+
+- baseline alterada ou violada;
+- arquivo criado ou modificado fora do escopo autorizado;
+- alteração factual inesperada;
+- copy não autorizada;
+- link não autorizado;
+- claim não validado;
+- asset sem autorização quando exigível;
+- erro crítico de responsividade;
+- erro crítico de acessibilidade;
+- erro de runtime que impeça ou prejudique o uso essencial;
+- fonte crítica ausente ou impossibilidade de comprovar teste necessário.
+
+## 11. Checkpoints humanos
+
+- Validar fidelidade visual e experiência nos quatro viewports.
+- Resolver ou aceitar warnings não bloqueadores.
+- Aprovar correções em execução separada e reexecutar o gate.
+- Aceitar o resultado antes de encaminhar ao release.
+
+## 12. Proteções
+
+O `AGENTS.md` raiz prevalece. O gate é somente leitura e não modifica plugin, matriz, baseline ou código. Não inventar evidência nem ler secrets. Não autoriza commit, push ou Preview. Production é proibida.
+
+## 13. Integração com a matriz
+
+Compor, sem duplicar, conceitos de `revisor-qualidade`, `validate_output.py`, `page_audit.py` e `page_audit_deep.py`. Esses componentes podem ser consultados e, em execução futura, usados apenas se forem compatíveis e não escreverem dados não autorizados. O gate local adiciona baseline, escopo, Git, runtime e release readiness.
+
+## 14. Ferramentas reutilizáveis
+
+- Disponíveis: Git, `rg` e inspeção estática.
+- Disponíveis na matriz: revisores e scripts citados, sem garantia de execução segura neste fluxo.
+- Condicionais: executor local e ferramentas nativas do navegador; descobrir e confirmar sua disponibilidade e adequação antes do uso.
+- Dependências futuras: Playwright, axe ou equivalentes quando não estiverem presentes e autorizados; não instalar automaticamente.
+- Planejadas: screenshot/diff visual, auditor automatizado de links e suíte multi-viewport integrada.
+- Humanas: estética, contexto de marca, claims e aceitação de warnings.
+- Proibidas: correção automática, instalação de dependências e diagnóstico que escreva em cliente/cache sem aprovação.
+
+## 15. Ações proibidas
+
+- Corrigir código durante o gate ou reclassificar falha para avançar o fluxo.
+- Marcar como testado o que foi apenas inspecionado ou planejado.
+- Ignorar arquivo inesperado, mudança factual ou estrutural.
+- Executar `git add` ou `git add -N` apenas para tornar arquivos untracked visíveis à auditoria.
+- Fazer commit, push, Preview ou Production.
+
+## 16. Definição de sucesso
+
+O resultado é reproduzível, cobre todo o checklist aplicável, distingue evidência automática de avaliação humana e impede release diante de qualquer desvio crítico ou não autorizado.

--- a/.agents/skills/designer-lp-quality-gate/references/quality-checklist.md
+++ b/.agents/skills/designer-lp-quality-gate/references/quality-checklist.md
@@ -1,0 +1,91 @@
+# Checklist do quality gate
+
+Usar este checklist como contrato humano legível. Para cada item, registrar `PASS`, `WARNING`, `BLOCKED` ou `N/A`, o método (`disponível`, `planejado` ou `humano`) e a evidência. Um controle planejado não pode ser marcado como executado.
+
+## Conteúdo
+
+- Copy idêntica à versão explicitamente aprovada ou alteração autorizada registrada.
+- Links idênticos aos confirmados e destinos essenciais verificados.
+- Claims, preços, métricas, depoimentos e condições comerciais possuem fonte aprovada.
+- Nenhum placeholder plausível, fato inventado ou conteúdo externo incorporado.
+- Estrutura e sequência comercial preservadas, salvo autorização explícita.
+- Conflitos de precedência resolvidos e registrados.
+
+## Design
+
+- Implementação comparada com a baseline imutável.
+- Mudanças limitadas à seção e aos arquivos autorizados.
+- Tipografia, cores, espaçamento, grid e componentes coerentes com o Manual aprovado.
+- Hierarquia visual e ações principais são claras.
+- Assimetria, ícones e elementos decorativos possuem função e sistema coerente.
+- Revisão estética humana concluída.
+
+## Acessibilidade
+
+- Estrutura de headings é lógica e existe landmark principal.
+- Controles são acessíveis por teclado e possuem foco visível.
+- Botões, links, formulários e ícones interativos têm nomes acessíveis.
+- Imagens informativas têm texto alternativo; decorativas são corretamente ignoradas.
+- Contraste e legibilidade foram avaliados.
+- Não há dependência exclusiva de cor, hover ou movimento.
+- Preferência de movimento reduzido é respeitada quando aplicável.
+
+## Responsividade
+
+- Viewports 390, 768, 1024 e 1440 px foram verificados.
+- Não há overflow horizontal não intencional.
+- Conteúdo, navegação e CTAs permanecem legíveis e utilizáveis.
+- Imagens mantêm proporção, crop intencional e resolução suficiente.
+- Quebras de texto não ocultam conteúdo nem alteram significado.
+- Estados interativos funcionam com mouse, teclado e toque quando aplicável.
+
+## Código e runtime
+
+- HTML possui semântica válida e referências locais resolvíveis.
+- CSS não introduz regra global inesperada ou dependência implícita.
+- JavaScript não apresenta erro de sintaxe nem falha observada no console.
+- Interações preservam comportamento e progressive enhancement quando aplicável.
+- SVGs não contêm IDs conflitantes, conteúdo indevido ou dimensões quebradas.
+- Dependências são existentes e autorizadas; nenhuma foi instalada pelo gate.
+- Execução local foi comprovada ou a impossibilidade está marcada como bloqueio.
+
+## Assets
+
+- Cada asset usado possui origem e autorização conhecidas.
+- Original permanece preservado e derivados são rastreáveis.
+- Dimensões, formato, peso, crop, fallback e papel estão documentados.
+- `picture`, `srcset` e `sizes` são coerentes quando há variantes responsivas.
+- Nenhum stock foi incluído automaticamente.
+- Base64 de protótipo está substituído ou explicitamente bloqueado para produção.
+- Não há asset quebrado, ausente ou inesperadamente substituído.
+
+## Git e escopo
+
+- Branch corresponde à execução aprovada.
+- Worktree foi auditado antes e depois dos testes.
+- Somente arquivos e seção autorizados foram alterados.
+- Não há arquivo inesperado, secret, cache, temporário ou build gerado.
+- `reference/`, plugin e outputs protegidos permanecem intocados.
+- `git diff --check` não reporta erro.
+- Arquivos untracked foram inspecionados diretamente, pois `git diff --check` não cobre arquivos ainda não adicionados ao índice.
+- A inspeção direta de untracked verificou trailing whitespace, tabs acidentais, encoding, arquivos vazios, marcadores `TODO`/`FIXME` não intencionais, headings duplicados quando pertinente e referências ou caminhos obviamente quebrados.
+- Nenhum `git add` ou `git add -N` foi executado apenas para viabilizar a auditoria.
+- Commit e push não foram realizados sem aprovação separada.
+
+## Release readiness
+
+- Testes locais aplicáveis foram concluídos com evidência.
+- Resultado global é `PASS` ou `PASS_WITH_WARNINGS` aceito por humano.
+- Warnings possuem responsável, impacto e decisão registrada.
+- Branch, commit pretendido e diretório de projeto estão identificados.
+- Projeto/equipe Vercel não são presumidos.
+- Autorização de Preview ainda será solicitada separadamente.
+- Nenhuma ação de Production, domínio ou alias de produção está habilitada.
+
+## Regra de decisão
+
+- `PASS`: todos os itens aplicáveis passaram e não há warnings abertos.
+- `PASS_WITH_WARNINGS`: somente riscos não factuais e não estruturais foram aceitos explicitamente por responsável humano.
+- `BLOCKED`: baseline alterada ou violada; arquivo criado/modificado fora do escopo autorizado; alteração factual inesperada; copy ou link não autorizado; claim não validado; asset sem autorização quando exigível; erro crítico de responsividade ou acessibilidade; erro de runtime que impeça ou prejudique uso essencial; ou qualquer outra falha crítica ou evidência obrigatória ausente.
+
+Essas condições, assim como mudanças factuais, estruturais, de copy, link, claim, preço, métrica ou asset, nunca podem ser rebaixadas silenciosamente a warning ou `PASS_WITH_WARNINGS`. O gate identifica, classifica e bloqueia; não corrige automaticamente.

--- a/.agents/skills/designer-lp-release/SKILL.md
+++ b/.agents/skills/designer-lp-release/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: designer-lp-release
+description: Preparar uma landing page aprovada para release controlado e, somente com autorização explícita, habilitar uma Vercel Preview. Usar após quality gate válido; não usar para Production, domínio, alias de produção, projeto não confirmado ou deploy automático.
+area: designer
+author: nicolaskobayashi-v4
+version: 1.0.0
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta skill foi portada do repositorio v4-unidade-integrada. As regras abaixo tem precedencia sobre caminhos, zonas e ferramentas citados no corpo original:
+
+- **Posicao no fluxo.** Este pipeline fica a jusante de `designer-landing-page`, que e a porta do hub para `ee-s3-landing-page`. O `designer-landing-page` responde por estrategia, copy e geracao de codigo. Este pipeline responde por baseline, adaptacao, assets, quality gate e release controlada. O passo `vercel --yes --prod` do `designer-landing-page` fica **suspenso** quando o pipeline estiver em uso: release passa por `designer-lp-release`, e Production continua proibida.
+- **Governanca.** Onde o corpo cita "o `AGENTS.md` raiz prevalece", leia o `CLAUDE.md` e o `AGENTS.md` da raiz do hub mais o `CLAUDE.md` da KB do cliente. Nenhuma regra local pode enfraquece-los.
+- **Zonas somente leitura.** Onde o corpo cita "matriz" e "plugin", leia: `.claude/skills/`, `.agents/skills/` e `REGISTRY.md` sao somente leitura durante o pipeline. `REGISTRY.md` e auto-gerado e nunca se edita a mao.
+- **Caminhos.** Trabalhe em `squads/{squad}/clientes/{cliente}/`. A estrutura do projeto e `squads/{squad}/clientes/{cliente}/outputs/landing-pages/<projeto>/`, com `reference/` e `src/` dentro dela.
+- **`client.json`.** Opcional no hub. So a KB migrada do EE tem esse arquivo. Se nao existir, derive o contexto de `CLAUDE.md`, `mission-control/`, `docs/` e `links.md`, e nao invente o arquivo.
+- **Scripts da matriz.** `validate_output.py`, `page_audit.py`, `page_audit_deep.py` e o agente `revisor-qualidade` **nao existem no hub**. Onde o corpo os cita, declare o gap e faca a verificacao equivalente a mao, registrando o que foi checado e como.
+- **Vercel.** O hub nao tem projeto Vercel configurado. Preview exige configurar o projeto antes e autorizacao explicita do usuario na hora. Production permanece proibida por esta skill.
+- **Registro.** Decisao, gate aprovado e bloqueio vao para `mission-control/historico-checkins.md` da KB do cliente.
+- **Git.** Nunca commite `squads/` nem `bases/`. Sao pessoais e ficam no `.gitignore`.
+
+---
+
+
+# LP Release
+
+## 1. Propósito
+
+Verificar a identidade exata do artefato e todas as aprovações necessárias antes de uma eventual Vercel Preview, mantendo Production tecnicamente e processualmente fora do fluxo.
+
+Ao executar, ler [references/release-policy.md](references/release-policy.md) integralmente.
+
+## 2. Quando usar
+
+- Depois de `quality_gate_passed`.
+- Para preparar o pacote de evidências de release.
+- Para executar uma Preview somente após autorização humana explícita e específica.
+
+## 3. Quando NÃO usar
+
+- Com quality gate `BLOCKED`, expirado por novas mudanças ou warnings não aceitos.
+- Para Production, alias de produção, domínio ou promoção de Preview.
+- Sem confirmação de projeto, equipe, diretório, branch e commit.
+- Para criar projeto Vercel por inferência ou aceitar configuração desconhecida.
+
+## 4. Pré-condições
+
+1. Ter `PASS` ou `PASS_WITH_WARNINGS` aceito por responsável humano.
+2. Confirmar que testes locais foram concluídos.
+3. Auditar branch, commit pretendido e worktree.
+4. Identificar destino de Preview sem fazer deploy.
+5. Obter autorização explícita separada para commit, push e Preview conforme cada operação necessária.
+
+## 5. Entradas
+
+- Relatório mais recente do quality gate e suas evidências.
+- Diretório exato da implementação.
+- Branch, commit pretendido e estado do worktree.
+- Projeto e equipe Vercel confirmados pelo responsável.
+- Metadados locais `.vercel/project.json`, se existirem, sem secrets.
+- Autorizações humanas com escopo e momento.
+
+## 6. Fontes permitidas
+
+- Estado local do Git e arquivos de configuração não secretos.
+- Quality gate aprovado e registros de autorização.
+- Confirmações explícitas do responsável.
+- Painel ou CLI Vercel somente quando a execução de Preview for autorizada.
+
+Não inferir destino por nome de pasta, histórico de outro cliente ou configuração semelhante.
+
+## 7. Precedência das fontes
+
+- Fatos: confirmação explícita mais recente → `client.json` → base estratégica aprovada → outputs estratégicos aprovados → implementação existente.
+- Visual: confirmação explícita mais recente → Manual de Marca aprovado mais recente → diagnóstico visual aprovado → assets oficiais → referências externas → implementação existente.
+- Copy: copy explicitamente aprovada → output estratégico de landing page aprovado → implementação existente.
+- Links: confirmação explícita → implementação existente aprovada.
+
+Registrar todo conflito de precedência. Para destino de release, vale apenas confirmação explícita do projeto/equipe e configuração local coerente. Qualquer conflito bloqueia; posicionamento, CRO, diagnóstico ou outro output estratégico não substituem silenciosamente a copy específica aprovada da landing page.
+
+## 8. Procedimento
+
+1. Confirmar que o relatório do quality gate corresponde ao estado atual dos arquivos.
+2. Verificar branch, commit pretendido, worktree e diferenças desde o gate.
+3. Confirmar o diretório exato que seria enviado.
+4. Confirmar projeto e equipe Vercel com o responsável.
+5. Se `.vercel/project.json` existir, conferir identidade do projeto sem expor tokens; divergência bloqueia.
+6. Confirmar que não haverá criação automática de projeto, domínio ou alias.
+7. Confirmar que nenhuma opção, script ou configuração aciona Production.
+8. Preparar um resumo com artefato, destino, evidências, warnings aceitos e comando proposto.
+9. Solicitar autorização explícita de Vercel Preview imediatamente antes da ação.
+10. Somente depois da autorização, executar exclusivamente a Preview aprovada.
+11. Registrar URL de Preview e evidência de que nenhum domínio/alias de produção foi alterado.
+12. Encaminhar a URL para revisão humana; não promover o deploy.
+
+## 9. Saídas esperadas
+
+- Checklist de release e identidade do artefato.
+- Destino de Preview confirmado, ou estado `BLOCKED`.
+- Comando/ação de Preview proposto antes da execução.
+- Se autorizado, URL de Preview e registro de revisão pendente.
+
+## 10. Critérios de parada
+
+Parar se houver arquivo alterado após o gate, worktree inesperado, projeto/equipe/diretório não confirmado, configuração divergente, autorização ambígua ou qualquer indício de Production. Falta de dado crítico sempre produz `STOP`.
+
+## 11. Checkpoints humanos
+
+- Aceitar warnings do quality gate, se houver.
+- Autorizar commit e push separadamente, se necessários.
+- Confirmar projeto, equipe e diretório.
+- Autorizar explicitamente a Vercel Preview.
+- Revisar a Preview antes de qualquer decisão posterior.
+
+## 12. Proteções
+
+O `AGENTS.md` raiz prevalece. Plugin, matriz, original e baseline são somente leitura. Preview não equivale a Production. Production, domínio e alias de produção permanecem proibidos. Não ler nem exibir tokens ou secrets.
+
+## 13. Integração com a matriz
+
+Consumir outputs e validações aprovados da matriz, mas rejeitar comandos incompatíveis, inclusive qualquer `vercel --prod` ou mutação de cliente/cache. Esta skill estende a matriz com gates locais de destino, Git e aprovação; não altera os componentes matriciais.
+
+## 14. Ferramentas reutilizáveis
+
+- Disponíveis: Git e inspeção local de configuração não secreta.
+- Condicional: Vercel CLI somente se já disponível, destino confirmado e Preview explicitamente autorizada.
+- Planejadas: verificador dedicado de release; não implementado nesta fase.
+- Humanas: confirmação de destino, autorização e homologação da Preview.
+- Proibidas: `vercel --prod`, promoção, domínio, alias de produção e criação automática de projeto.
+
+## 15. Ações proibidas
+
+- Executar Production direta ou indiretamente.
+- Usar `vercel --prod`, promover Preview ou configurar domínio/alias de produção.
+- Fazer deploy para projeto ou equipe não confirmados.
+- Criar projeto Vercel automaticamente.
+- Tratar autorização de escrita, commit ou push como autorização de Preview.
+
+## 16. Definição de sucesso
+
+O artefato e o destino estão inequivocamente identificados, todos os gates foram respeitados e, quando expressamente autorizada, somente uma Preview isolada é criada para revisão humana, sem efeito em Production.

--- a/.agents/skills/designer-lp-release/references/release-policy.md
+++ b/.agents/skills/designer-lp-release/references/release-policy.md
@@ -1,0 +1,80 @@
+# Política de release de landing pages
+
+## Princípio central
+
+Vercel Preview não é Production. A camada de produção de landing pages encerra sua responsabilidade na preparação e, quando autorizada, na criação de uma Preview isolada para homologação humana.
+
+Production está desabilitada neste fluxo.
+
+## Estados permitidos
+
+- `release_not_ready`: quality gate ausente, inválido ou desatualizado.
+- `release_ready`: artefato e destino conferidos; Preview ainda não autorizada.
+- `preview_authorized`: responsável autorizou explicitamente uma Preview específica.
+- `preview_created`: URL de Preview registrada e aguardando revisão humana.
+- `human_approved`: Preview revisada; não implica autorização de Production.
+- `blocked`: requisito, identidade ou autorização ausente ou conflitante.
+
+Não existe estado `production_authorized` neste contrato.
+
+## Checklist anterior à Preview
+
+Verificar e registrar:
+
+1. Projeto/cliente e diretório exato da implementação.
+2. Branch correta.
+3. Commit pretendido e sua relação com os arquivos avaliados.
+4. Worktree limpo ou diferenças explicitamente compreendidas e aprovadas.
+5. Quality gate atual em `PASS` ou `PASS_WITH_WARNINGS` aceito.
+6. Testes locais concluídos.
+7. Projeto e equipe Vercel confirmados pelo responsável.
+8. `.vercel/project.json`, se existir, coerente com a confirmação e lido sem expor secrets.
+9. Ausência de criação automática de projeto.
+10. Ausência de flags, scripts ou configurações de Production.
+11. Autorização humana explícita para esta Preview, após apresentação do destino e da ação.
+
+Se qualquer item falhar, retornar `blocked` sem deploy.
+
+## Autorizações independentes
+
+- Aprovação de edição não autoriza commit.
+- Aprovação de commit não autoriza push.
+- Aprovação de push não autoriza Preview.
+- Aprovação de Preview não autoriza Production, promoção, domínio ou alias.
+- Homologação humana da Preview não cria autorização implícita para Production.
+
+Cada operação exige consentimento explícito no seu próprio contexto.
+
+## Ações permitidas
+
+- Inspecionar estado Git e configurações locais não secretas.
+- Preparar o resumo de release sem executar deploy.
+- Executar somente a Vercel Preview descrita e autorizada.
+- Registrar a URL de Preview e encaminhá-la para revisão humana.
+
+## Ações proibidas
+
+- Executar `vercel --prod` ou qualquer equivalente.
+- Promover Preview para Production.
+- Criar ou alterar domínio ou alias de produção.
+- Selecionar projeto/equipe por inferência.
+- Criar projeto Vercel automaticamente.
+- Ler, copiar, registrar ou exibir credenciais, tokens ou `.env`.
+- Modificar código, copy, link, asset ou configuração durante o release.
+- Fazer commit ou push sem autorização específica.
+
+## Mudança após o quality gate
+
+Qualquer alteração no artefato, dependência ou configuração depois do gate invalida a decisão anterior. Retornar ao `designer-lp-quality-gate` antes de solicitar nova autorização de Preview.
+
+## Registro mínimo
+
+Registrar sem secrets:
+
+- data e responsável pela autorização;
+- branch, commit e estado do worktree;
+- diretório e projeto/equipe confirmados;
+- resultado do quality gate;
+- ação executada;
+- URL da Preview;
+- confirmação de que Production, domínio e alias permaneceram intocados.

--- a/.agents/skills/designer-lp-source-audit/SKILL.md
+++ b/.agents/skills/designer-lp-source-audit/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: designer-lp-source-audit
+description: Auditar somente em leitura as fontes disponíveis para uma landing page e determinar a implementação correta e seu grau de prontidão. Usar antes de baseline, design ou retomada de projeto; não usar para editar arquivos, produzir estratégia ou corrigir automaticamente lacunas.
+area: designer
+author: nicolaskobayashi-v4
+version: 1.0.0
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta skill foi portada do repositorio v4-unidade-integrada. As regras abaixo tem precedencia sobre caminhos, zonas e ferramentas citados no corpo original:
+
+- **Posicao no fluxo.** Este pipeline fica a jusante de `designer-landing-page`, que e a porta do hub para `ee-s3-landing-page`. O `designer-landing-page` responde por estrategia, copy e geracao de codigo. Este pipeline responde por baseline, adaptacao, assets, quality gate e release controlada. O passo `vercel --yes --prod` do `designer-landing-page` fica **suspenso** quando o pipeline estiver em uso: release passa por `designer-lp-release`, e Production continua proibida.
+- **Governanca.** Onde o corpo cita "o `AGENTS.md` raiz prevalece", leia o `CLAUDE.md` e o `AGENTS.md` da raiz do hub mais o `CLAUDE.md` da KB do cliente. Nenhuma regra local pode enfraquece-los.
+- **Zonas somente leitura.** Onde o corpo cita "matriz" e "plugin", leia: `.claude/skills/`, `.agents/skills/` e `REGISTRY.md` sao somente leitura durante o pipeline. `REGISTRY.md` e auto-gerado e nunca se edita a mao.
+- **Caminhos.** Trabalhe em `squads/{squad}/clientes/{cliente}/`. A estrutura do projeto e `squads/{squad}/clientes/{cliente}/outputs/landing-pages/<projeto>/`, com `reference/` e `src/` dentro dela.
+- **`client.json`.** Opcional no hub. So a KB migrada do EE tem esse arquivo. Se nao existir, derive o contexto de `CLAUDE.md`, `mission-control/`, `docs/` e `links.md`, e nao invente o arquivo.
+- **Scripts da matriz.** `validate_output.py`, `page_audit.py`, `page_audit_deep.py` e o agente `revisor-qualidade` **nao existem no hub**. Onde o corpo os cita, declare o gap e faca a verificacao equivalente a mao, registrando o que foi checado e como.
+- **Vercel.** O hub nao tem projeto Vercel configurado. Preview exige configurar o projeto antes e autorizacao explicita do usuario na hora. Production permanece proibida por esta skill.
+- **Registro.** Decisao, gate aprovado e bloqueio vao para `mission-control/historico-checkins.md` da KB do cliente.
+- **Git.** Nunca commite `squads/` nem `bases/`. Sao pessoais e ficam no `.gitignore`.
+
+---
+
+
+# LP Source Audit
+
+## 1. Propósito
+
+Determinar, com evidência rastreável, qual implementação e quais fontes devem alimentar a landing page, identificando versões duplicadas, conflitos e lacunas antes de qualquer escrita.
+
+## 2. Quando usar
+
+- No início de uma produção ou retomada de landing page.
+- Quando existirem múltiplas versões de HTML, CSS, JavaScript ou assets.
+- Quando não estiver claro se copy, links, claims e referências visuais estão aprovados.
+
+## 3. Quando NÃO usar
+
+- Para editar, normalizar, mover ou excluir arquivos.
+- Para executar diagnósticos que escrevam cache ou dados do cliente.
+- Para inventar conteúdo ausente ou escolher silenciosamente entre fontes conflitantes.
+
+## 4. Pré-condições
+
+1. Ler as instruções de governança aplicáveis.
+2. Confirmar branch, worktree, cliente e escopo da landing page.
+3. Definir diretórios permitidos para leitura e excluir secrets.
+4. Confirmar que plugin, Figma original e outputs existentes são somente leitura.
+
+## 5. Entradas
+
+- `client.json`, base de conhecimento e outputs estratégicos aprovados.
+- Output estratégico de landing page, se existir.
+- Implementações HTML, CSS e JavaScript candidatas.
+- Assets, Manual de Marca, diagnóstico visual, posicionamento, CRO e diagnóstico de criativos.
+- Copy, links, claims, dependências e fontes externas explicitamente indicadas.
+
+## 6. Fontes permitidas
+
+- Fontes internas aprovadas do cliente e histórico Git.
+- Implementações e referências existentes em modo somente leitura.
+- Resultados já aprovados da matriz.
+- Referências externas apenas como repertório visual, nunca como fonte factual.
+
+## 7. Precedência das fontes
+
+- Fatos: confirmação explícita mais recente → `client.json` → base estratégica aprovada → outputs estratégicos aprovados → implementação existente.
+- Visual: confirmação explícita mais recente → Manual de Marca aprovado mais recente → diagnóstico visual aprovado → assets oficiais → referências externas → implementação existente.
+- Copy: copy explicitamente aprovada → output estratégico de landing page aprovado → implementação existente.
+- Links: link explicitamente confirmado → implementação existente aprovada.
+
+Documento especializado aprovado posteriormente pode prevalecer em seu domínio com conflito registrado. Não resolver divergências silenciosamente.
+
+## 8. Procedimento
+
+1. Inventariar todos os candidatos de implementação e registrar caminho, função e estado Git.
+2. Localizar o output estratégico de landing page e verificar se é identificável e aprovado.
+3. Mapear HTML, CSS, JavaScript, frameworks, dependências e instruções de execução.
+4. Inventariar assets, variantes, formatos, dimensões conhecidas, origem e referências no código.
+5. Localizar Manual de Marca, diagnóstico visual, posicionamento, CRO e diagnóstico de criativos.
+6. Extrair, sem alterar, a copy, os links e os claims presentes na estratégia e na implementação.
+7. Comparar as fontes segundo a precedência contextual e registrar cada conflito.
+8. Avaliar estrutura responsiva, breakpoints, conteúdo oculto e diferenças relevantes entre versões.
+9. Identificar duplicatas por caminho, conteúdo e hash; não eleger vencedor sem evidência.
+10. Classificar cada requisito como disponível, ausente, conflitante ou dependente de validação humana.
+11. Indicar a implementação recomendada apenas quando a evidência for suficiente; caso contrário, bloquear.
+
+## 9. Saídas esperadas
+
+- Mapa de fontes com caminho, papel, aprovação e precedência.
+- Implementação candidata recomendada e justificativa, ou estado `BLOCKED`.
+- Lista de lacunas, duplicatas, conflitos e dependências.
+- Avaliação de prontidão para criar a baseline.
+
+## 10. Critérios de parada
+
+Parar se a implementação exata não puder ser determinada, se fontes críticas estiverem ausentes, se houver conflito factual, de copy, links ou claims, ou se a inspeção exigir acesso a secret. Toda lacuna crítica produz `STOP`; não criar placeholders plausíveis.
+
+## 11. Checkpoints humanos
+
+- Confirmar a implementação candidata e a versão estratégica correta.
+- Resolver conflitos de copy, links, claims e assets.
+- Aprovar a passagem para `designer-lp-baseline-prepare`.
+
+## 12. Proteções
+
+O `AGENTS.md` raiz prevalece. Esta auditoria é estritamente somente leitura: não modificar plugin, matriz, cliente, output, Figma ou referência. Não ler `.env` ou credenciais. Não autoriza copy, assets, commit, push, Preview ou Production; Production permanece proibida.
+
+## 13. Integração com a matriz
+
+Consultar conceitualmente `ee-s3-landing-page`, Manual de Marca, posicionamento, diagnóstico CRO, diagnóstico de criativos, `revisor-qualidade`, `validate_output.py`, `page_audit.py` e `page_audit_deep.py`. Consumir apenas resultados aprovados; não executar rotinas incompatíveis que escrevam cache, cliente, deploy ou produção.
+
+## 14. Ferramentas reutilizáveis
+
+- Disponíveis: `rg`, `rg --files`, `Get-FileHash`, Git e inspeção estática de HTML/CSS/JS.
+- Disponíveis para consulta: scripts de auditoria da matriz; sua execução não é pressuposta.
+- Planejadas: inventário normalizado e detector genérico de links/assets, ainda não implementados.
+- Humanas: confirmação de aprovação, leitura estética e validação de claims.
+- Proibidas: crawlers ou diagnósticos que façam escrita não autorizada.
+
+## 15. Ações proibidas
+
+- Corrigir arquivos durante a auditoria.
+- Executar deploy, instalar dependências ou criar outputs auxiliares.
+- Tratar referência externa como fato ou copiar identidade, código, estrutura completa ou assets externos.
+- Fazer commit ou push.
+
+## 16. Definição de sucesso
+
+Existe uma decisão auditável sobre qual implementação e quais fontes são válidas, com prontidão, conflitos e lacunas explícitos, sem qualquer mutação do workspace ou das fontes.

--- a/.claude/skills/designer-landing-page/SKILL.md
+++ b/.claude/skills/designer-landing-page/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: designer-landing-page
+description: "Cria a landing page de conversão: copy completa seção por seção, geração de código React+Tailwind, e deploy na Vercel. Mix auto + manual. Use quando disser /designer-landing-page ou 'criar LP' ou 'landing page' ou 'página de conversão'."
+area: designer
+author: luizfreitasv4
+version: 1.0.0
+dependencies:
+  - geral-posicionamento-estrategico
+  - designer-manual-marca
+inputs:
+  - client.json (briefing)
+  - geral-posicionamento-estrategico.json
+  - designer-manual-marca.json
+  - gt-diagnostico-cro.json (opcional — só no modelo inside-sales)
+output: designer-landing-page.json
+week: 4
+type: mixed
+estimated_time: "6h"
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta versao foi portada do sistema de Estruturacao Estrategica. As regras abaixo tem precedencia sobre caminhos e persistencia citados no fluxo original:
+
+- Trabalhe somente em `squads/{squad}/clientes/{cliente}/`, nunca em um diretorio `clientes/` solto na raiz.
+- Leia primeiro o `CLAUDE.md` ou `AGENTS.md` da KB, `mission-control/`, `calls/`, `docs/` e `campanhas/`.
+- Se `client.json` existir, use-o como fonte complementar. Se nao existir, derive o contexto da KB e do Mission Control; nao exija nem invente esse arquivo.
+- Salve entregaveis em `squads/{squad}/clientes/{cliente}/outputs/`, em JSON e Markdown quando o fluxo pedir ambos.
+- Registre decisoes e progresso no `mission-control/historico-checkins.md` ou no arquivo de historico equivalente encontrado na KB.
+- Resolva recursos empacotados a partir do proprio diretorio desta skill. Se uma integracao externa nao estiver configurada, declare o gap e continue apenas com os dados reais disponiveis.
+
+
+# Landing Page — Copy + Código + Deploy (POP 3.8)
+
+> **Posição no fluxo:** Semana 4 — Identidade de Comunicação e Plano de Mídia (**comum** a todos os modelos) (e-commerce / inside-sales / pdv). Mobile-first, formulário curto (3-5 campos) integrado ao CRM, tracking testado **antes** do deploy. No modelo inside-sales, consome o diagnóstico de CRO (3.1) se disponível; nos demais, baseia-se em posicionamento + manual de marca.
+
+Você é um copywriter especializado em landing pages de conversão para PMEs brasileiras, com conhecimento em desenvolvimento React/Tailwind. Vai criar a LP completa: copy persuasiva, código funcional e deploy na Vercel.
+
+## Dados necessários
+
+1. `client.json` (seção `briefing`) — nome, segmento, produto/serviço, WhatsApp, site atual
+2. `outputs/geral-posicionamento-estrategico.json` — PUV, posicionamento, diferenciais
+3. `outputs/designer-manual-marca.json` — tom de voz, paleta, tipografia, vocabulário, headlines, CTAs
+4. `outputs/gt-diagnostico-cro.json` — **opcional** (só no modelo inside-sales): análise de conversão, problemas, wireframe sugerido
+5. `client.json` (seção `history`) — decisões anteriores
+
+> Identidade visual (paleta/tipografia) vem do `designer-manual-marca` (item 2) — os antigos brandbook/identidade-visual foram unificados nele.
+
+Se brandbook ou posicionamento não existirem, avise e sugira rodar antes.
+
+---
+
+## Geração
+
+Gere o output COMPLETO de uma vez: copy da LP + código + instruções de deploy. Use os dados de `client.json` (briefing) e outputs de skills dependentes em `outputs/`.
+
+Consulte `references/copy-patterns-lp.md` para padrões de copy de alta conversão.
+
+### Copy completa (seção por seção)
+
+Toda seção pode ter `eyebrow` opcional (texto pequeno acima do headline, estilo "· A profissional" ou sticker rounded — ajuda hierarquia tipográfica).
+
+**HERO:** Headline (máx. 8 palavras), subheadline (1-2 frases), CTA primário, CTA secundário, opcional `stats[]` (3-4 números) e `credential_card` (nome + CRMV/credencial flutuante sobre a foto)
+**PROBLEMA:** 3 cards de dor (título curto + 1 frase de empatia cada). Recomendo formato "Sem X / Sem Y / Sem Z" ou similar, em vez de listar dores genéricas.
+**PROFISSIONAL/AUTORIDADE (opcional `authority`):** Seção dedicada de autoridade quando há um profissional de marca. Inclui `credentials[]` (timeline ano + título de formação) e CTA. Recomendado para clínicas, consultórios e prestadores de serviço pessoa-física.
+**SOLUÇÃO:** 3-4 benefícios com ícone sugerido (Lucide/Heroicons), conectados ao PUV
+**COMO FUNCIONA:** 3-4 passos simples (título + 1 frase)
+**ENTREGÁVEIS:** Lista principal com benefício de cada
+**PROVA SOCIAL:** Depoimentos no formato simples (`name`/`role`/`text`) ou rico (`photo`, `photo_caption`, `source` ex 'Google Reviews', `when` ex '6 meses atrás', `rating` 1-5, `neighborhood`, `pet`). Quando há fotos reais, prefira o formato rico — converte mais. Stats podem ficar no `social_proof.stats[]` OU inline no hero (`sections[0].stats`); evite duplicar.
+**SECONDARY_AUDIENCE / SECUNDÁRIO (opcional):** Callout para audiência secundária quando o foco é nicho (ex: especialista em um segmento que também atende um público adjacente).
+**FAQ:** 5+ objeções mais comuns do ICP com respostas que vendem
+**LOCATION (opcional):** Embed Google Maps + card de contato. Recomendado para negócios físicos.
+**FINAL CTA:** Headline emocional + WhatsApp button. Pode ter eyebrow.
+**CTA FINAL:** Headline de urgência + subtítulo de reassurance + botão
+
+**META / SEO:** Title tag (máx. 60 chars), meta description (máx. 155 chars), OG tags
+
+### Código React + Tailwind
+
+Gere o código completo da LP:
+- Next.js ou React SPA com Tailwind CSS
+- Mobile-first, totalmente responsivo
+- CTA com link para WhatsApp: `https://wa.me/{WHATSAPP}?text={MENSAGEM_ENCODED}`
+- SEO básico, Google Fonts, cores da paleta como variáveis Tailwind
+- Componentes por seção (Hero, Problem, Solution, HowItWorks, SocialProof, FAQ, FinalCTA)
+- FAQ com accordion, scroll suave, sem imagens pesadas, PageSpeed-friendly
+
+### Deploy na Vercel
+
+> **Precedência:** se o pipeline `designer-lp-*` estiver em uso nesta conta, o deploy **não** acontece aqui. Esta skill entrega estratégia, copy e código; baseline, adaptação, assets, quality gate e release passam por `designer-lp-orchestrator`, que exige autorização explícita para Preview e proíbe Production. Nesse caso pare no teste local e chame `designer-lp-source-audit`.
+
+Teste local (sempre):
+```bash
+cd landing-{slug}
+npm install && npm run dev
+```
+
+Deploy direto, só quando o pipeline `designer-lp-*` não estiver em uso e o usuário autorizar na hora:
+```bash
+vercel --yes            # Preview, revisar antes de promover
+```
+
+Não rode `vercel --prod` sem autorização explícita do usuário para aquela publicação específica.
+
+## Auto-validação
+
+Antes de mostrar ao operador, verifique:
+
+- [ ] Mencionou o cliente pelo nome?
+- [ ] Usou dados reais do client.json (não inventou)?
+- [ ] Nenhum item genérico (ex: "quer crescer", "qualidade e compromisso")?
+- [ ] Schema da skill validou?
+- [ ] Todos os campos do schema preenchidos (ou com `null` + `unavailable_reason` no pai)?
+- [ ] Nenhuma string vazia (`""`) — substituí por `null` + reason quando o dado não existe?
+- [ ] Estimativas marcadas com `estimated: true` ou `[E]`?
+- [ ] Consistente com outputs anteriores (posicionamento, brandbook)?
+- [ ] Headline do hero é baseada na PUV (não genérica)?
+- [ ] FAQ responde as 5 objeções reais do ICP?
+- [ ] Código é mobile-first e PageSpeed-friendly?
+
+Se falhou → regenere silenciosamente. Não avise o operador.
+
+## Apresentação e decisões
+
+Apresente o output COMPLETO ao operador — copy seção por seção em formato de preview.
+
+**DECISÃO 1:** Copy da LP — aprovar ou ajustar?
+
+Apresente preview visual da estrutura:
+```
+━━ HERO ━━ → ━━ PROBLEMA ━━ → ━━ SOLUÇÃO ━━ → ━━ COMO FUNCIONA ━━
+━━ PROVA SOCIAL ━━ → ━━ FAQ ━━ → ━━ CTA FINAL ━━
+```
+
+Valide:
+- Headline do hero é específica e orientada ao benefício?
+- As 3 dores são as que o ICP realmente sente?
+- Os 3 passos do "como funciona" são verdadeiros?
+- O cliente tem depoimentos reais? Se sim, cole aqui.
+- As respostas do FAQ respondem as objeções reais de venda?
+- O CTA aponta para WhatsApp ou formulário?
+- O WhatsApp está correto?
+
+Após aprovação da copy, gere o código e instrua o operador a testar localmente. Depois, execute o deploy.
+
+**Checklist pós-deploy:**
+- Abriu corretamente no desktop e mobile?
+- PageSpeed > 90?
+- WhatsApp CTA funciona?
+- Meta tags corretas?
+
+## Finalização
+
+Operador aprova (com ou sem ajustes).
+1. Salve em `squads/{squad}/clientes/{cliente}/outputs/designer-landing-page.json` (com campo `summary` no topo, incluindo URL de deploy)
+2. Atualize `client.json`: progress.skills → completed, version++, append em history[]
+3. Salve também uma versão Markdown do entregável na mesma pasta de outputs.
+4. Sugira próxima skill do dependency_graph
+
+## Formato do output (designer-landing-page.json)
+
+```json
+{
+  "sections": [
+    { "name": "hero", "headline": "string", "subheadline": "string", "cta_primary": "string", "cta_secondary": "string" },
+    { "name": "problem", "headline": "string", "cards": [{ "title": "string", "body": "string" }] },
+    { "name": "solution", "headline": "string", "benefits": [{ "icon": "string", "title": "string", "body": "string" }] },
+    { "name": "how_it_works", "headline": "string", "steps": [{ "number": 1, "title": "string", "body": "string" }] },
+    { "name": "deliverables", "headline": "string", "items": [{ "title": "string", "benefit": "string" }] },
+    { "name": "final_cta", "headline": "string", "subheadline": "string", "cta": "string" }
+  ],
+  "faq": [{ "question": "string", "answer": "string" }],
+  "social_proof": {
+    "testimonials": [{ "name": "string", "role": "string", "text": "string" }],
+    "stats": [{ "number": "string", "label": "string" }]
+  },
+  "meta": { "title": "string", "description": "string", "og_title": "string", "og_description": "string", "og_type": "website" },
+  "deploy_url": "string",
+  "whatsapp_link": "string"
+}
+```
+
+
+## Campo obrigatório: summary
+
+Sempre inclua no JSON de saída:
+```json
+"summary": "Resumo de 1-2 frases do landing page: proposta central da página e número de seções criadas. Seja específico — mencione o cliente, números reais e a conclusão principal."
+```
+
+Este campo alimenta o Resumo Executivo do portal de entregas. Deve ser objetivo, com dados reais, sem genéricos.

--- a/.claude/skills/designer-landing-page/references/copy-patterns-lp.md
+++ b/.claude/skills/designer-landing-page/references/copy-patterns-lp.md
@@ -1,0 +1,226 @@
+# Padrões de Copy para Landing Pages de Alta Conversão (Brasil)
+
+Referência para gerar copy de LP orientada a conversão para PMEs brasileiras. Padrões testados e validados em mercados de serviços, infoprodutos e e-commerce local.
+
+---
+
+## 1. Hero — A Primeira Tela
+
+O hero decide se o visitante fica ou sai. Média de decisão: 3-5 segundos.
+
+### Padrões de headline que convertem
+
+**Padrão 1: Resultado + Prazo**
+> "[Resultado desejado] em [prazo realista]"
+> Ex: "Sua clínica lotada em 90 dias"
+> Ex: "Delivery direto pelo WhatsApp em 7 dias"
+
+**Padrão 2: Pergunta de Dor**
+> "[Pergunta que espelha a frustração do ICP]?"
+> Ex: "Cansou de pagar comissão pro iFood?"
+> Ex: "Quantos leads você perdeu esse mês por falta de follow-up?"
+
+**Padrão 3: Antes → Depois**
+> "De [situação atual] para [situação desejada]"
+> Ex: "De 5 clientes no boca a boca para 30 leads qualificados por mês"
+> Ex: "De planilha no Excel para gestão financeira de verdade"
+
+**Padrão 4: Benefício Único**
+> "[Verbo de ação] + [benefício principal] + [sem objeção principal]"
+> Ex: "Atraia clientes do seu bairro sem gastar com agência"
+> Ex: "Automatize seu atendimento sem perder o toque humano"
+
+### Regras do hero
+
+- Headline: máximo 8 palavras (quanto mais curta, mais impacto)
+- Subheadline: 1-2 frases que expandem e contextualizam
+- CTA primário: verbo de ação + benefício ("Quero meus leads" > "Saiba mais")
+- CTA secundário (opcional): baixa barreira ("Ver como funciona" / "Sem compromisso")
+- Sem imagens genéricas de banco — gradiente ou ilustração é melhor que foto artificial
+
+---
+
+## 2. Seção de Problema — Empatia Antes de Solução
+
+**Princípio:** O visitante precisa se sentir compreendido antes de ouvir a solução.
+
+### Padrão: 3 Cards de Dor
+
+Cada card:
+- Título curto (3-5 palavras) que nomeia a dor
+- 1 frase de empatia (mostre que entende, não julgue)
+
+**Exemplo para contabilidade:**
+```
+Card 1: "Medo do fiscal bater na porta"
+"Você emite nota, mas não sabe se está fazendo certo. A multa pode ser maior que o faturamento."
+
+Card 2: "Contador que nunca responde"
+"Você manda mensagem segunda e recebe resposta quinta. Enquanto isso, a decisão urgente fica parada."
+
+Card 3: "Imposto alto demais"
+"Você sente que paga mais do que deveria, mas não sabe quanto — porque ninguém nunca mostrou as opções."
+```
+
+### Regras da seção de problema
+
+- Máximo 3 dores (mais dilui o impacto)
+- Use a linguagem do ICP (as palavras que ele usaria, não termos técnicos)
+- Nunca culpe o visitante ("Você não faz X" → "Quando X acontece...")
+- A dor deve ser reconhecível em 3 segundos de leitura
+
+---
+
+## 3. Seção de Solução — Benefícios, Não Features
+
+**Princípio:** Feature é o que o produto faz. Benefício é o que muda na vida do cliente.
+
+### Padrão: 3-4 Benefícios com Ícone
+
+Cada benefício:
+- Ícone visual (sugestão de Lucide/Heroicons)
+- Título orientado a resultado (não a feature)
+- 1 frase que conecta ao PUV
+
+**RUIM (features):**
+- "Dashboard de métricas em tempo real"
+- "Integração com 50+ plataformas"
+- "Relatórios automatizados"
+
+**BOM (benefícios):**
+- "Saiba em 10 segundos se sua campanha está dando lucro"
+- "Tudo conectado — não precisa copiar dados entre ferramentas"
+- "Relatório pronto toda segunda. Sem pedir. Sem esperar."
+
+### Regras da seção de solução
+
+- Cada benefício deve responder: "E daí?" (e daí que tem dashboard? → mostra se dá lucro)
+- Conecte ao PUV do geral-posicionamento-estrategico
+- Máximo 4 benefícios (5+ fica visual pesado)
+
+---
+
+## 4. Como Funciona — Simplicidade Gera Confiança
+
+**Princípio:** Se parece complicado, o visitante desiste. Simplifique até parecer inevitável.
+
+### Padrão: 3 Passos Numerados
+
+```
+1. [Verbo simples] → [O que acontece]
+   "Preencha o formulário" → "Em 30 segundos, já sabemos o que você precisa"
+
+2. [Verbo simples] → [O que acontece]
+   "Receba seu plano" → "Em 24h, montamos a estratégia personalizada"
+
+3. [Verbo simples] → [O que acontece]
+   "Comece a vender" → "Seus anúncios vão ao ar e os leads chegam no WhatsApp"
+```
+
+### Regras
+
+- SEMPRE 3 passos (4 é demais, 2 parece incompleto)
+- O passo 1 deve ter barreira zero (formulário, WhatsApp, ligação)
+- O passo 3 deve ser o resultado desejado
+- Use setas ou numeração grande para guiar o olho
+
+---
+
+## 5. Prova Social — Números e Rostos
+
+### Padrão de Depoimentos
+
+**Estrutura ideal:**
+> "[Resultado específico]. [Situação antes]. [O que mudou]. Recomendo!"
+> — Nome, Cargo/Empresa
+
+**BOM:**
+> "Em 60 dias, saí de 3 para 18 leads por semana. Antes eu dependia de indicação. Agora tenho previsibilidade."
+> — Ana Silva, dona da Clínica Bella
+
+**RUIM:**
+> "Ótimo serviço, super recomendo!"
+> — Cliente satisfeito
+
+### Padrão de Números de Impacto
+
+Escolha 3-4 métricas que impressionam:
+- Quantidade de clientes/projetos
+- Anos de mercado
+- Resultado principal (em R$ ou %)
+- Volume processado
+
+```
+500+         12           R$ 2M+          98%
+clientes     anos de      em vendas       de satisfação
+atendidos    mercado      geradas         dos clientes
+```
+
+### Regras
+
+- Números reais > números inflados. Se não tem, use o que tem honestamente
+- Depoimentos com nome + foto + empresa convertem 30% mais que anônimos
+- Se não tem depoimentos, substitua por resultados documentados ou estudos de caso resumidos
+
+---
+
+## 6. FAQ — Vendas Disfarçadas de Suporte
+
+**Princípio:** Cada pergunta é uma objeção. Cada resposta é um argumento de venda.
+
+### 5 Objeções Universais (adapte ao segmento)
+
+1. **Preço/Investimento:** "Quanto custa?" → Reframe para valor, não preço
+2. **Confiança:** "Como sei que funciona?" → Prova social, garantia, case
+3. **Tempo:** "Quanto tempo demora?" → Prazo realista + marcos intermediários
+4. **Complexidade:** "Preciso saber de tecnologia/marketing?" → Nós fazemos por você
+5. **Risco:** "E se não funcionar?" → Garantia, teste, sem contrato longo
+
+### Exemplo
+
+**P: Quanto custa o serviço?**
+R: "O investimento começa em R$ X/mês. Mas a pergunta mais importante é: quanto está custando NÃO ter isso? Se você perde 10 leads por mês por falta de follow-up, e cada lead vale R$ 500, são R$ 5.000 que você deixa na mesa. Nosso serviço se paga no primeiro mês."
+
+**P: E se eu não gostar do resultado?**
+R: "Nos primeiros 30 dias, se você não perceber melhoria mensurável, devolvemos 100% do investimento. Sem perguntas. Podemos fazer isso porque 94% dos clientes continuam após o primeiro mês."
+
+### Regras
+
+- Máximo 5 perguntas (mais vira manual de suporte)
+- Sempre redirecione para benefício ou CTA no final da resposta
+- Perguntas devem vir das objeções reais do ICP, não de perguntas técnicas que ninguém faz
+
+---
+
+## 7. CTA Final — Última Chance
+
+### Padrão
+
+```
+[Headline de urgência real]     → "Vagas limitadas para este mês"
+[Subtítulo de reassurance]      → "Sem contrato. Cancele quando quiser."
+[Botão CTA grande]              → "Quero Começar Agora"
+[Micro-copy sob o botão]        → "Resposta em até 2h pelo WhatsApp"
+```
+
+### Regras
+
+- Urgência real (vagas limitadas, preço de lançamento, agenda) — NUNCA fake countdown
+- Reassurance: reduza o risco percebido (sem contrato, devolução, teste grátis)
+- O CTA deve ser o mesmo do hero (consistência)
+- Adicione micro-copy que resolve a última objeção
+
+---
+
+## Regras Gerais de Copy para LP Brasileira
+
+1. **Trate por "você"** — formalidade mata conversão em PME
+2. **Frases curtas** — máx. 20 palavras por frase, máx. 3 frases por parágrafo
+3. **Números específicos > promessas vagas** — "47 clientes em BH" > "vários clientes"
+4. **Benefício > Feature** — sempre
+5. **CTA com verbo de ação** — "Quero meus leads" > "Enviar" > "Submit"
+6. **Sem jargão não traduzido** — se usar ROI, explique
+7. **Escaneabilidade** — negritos, bullets, espaço em branco. Ninguém lê parágrafo longo
+8. **WhatsApp como CTA principal** — no Brasil, WhatsApp converte mais que formulário
+9. **Mobile-first** — 70%+ do tráfego brasileiro é mobile. Teste no celular primeiro
+10. **Velocidade** — LP lenta = lead perdido. Máximo 3s de carregamento

--- a/.claude/skills/designer-landing-page/schema.json
+++ b/.claude/skills/designer-landing-page/schema.json
@@ -1,0 +1,431 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Landing Page",
+  "description": "Output estruturado da landing page: copy por seção, FAQ, prova social, meta tags e URL de deploy.",
+  "type": "object",
+  "required": [
+    "summary",
+    "sections",
+    "faq",
+    "social_proof",
+    "meta",
+    "client_name",
+    "summary_headline",
+    "summary_highlights",
+    "summary_key_findings"
+  ],
+  "properties": {
+    "client_name": {
+      "type": "string",
+      "description": "Nome do cliente — sempre presente em todo output."
+    },
+    "summary": {
+      "type": "string",
+      "description": "Resumo de 1-2 frases da landing page. Inclui proposta central da página e número de seções criadas."
+    },
+    "summary_headline": {
+      "type": "string",
+      "description": "Manchete em 1 linha (~120 caracteres) com o veredito da skill."
+    },
+    "summary_highlights": {
+      "type": "array",
+      "description": "KPIs em destaque (4-6 itens). Categorias: posicao | competicao | janela | maturidade | oportunidade | risco.",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "label",
+          "value",
+          "tone"
+        ],
+        "properties": {
+          "category": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "subtext": {
+            "type": "string"
+          },
+          "tone": {
+            "type": "string",
+            "enum": [
+              "green",
+              "yellow",
+              "red",
+              "blue",
+              "gray"
+            ]
+          }
+        }
+      }
+    },
+    "summary_key_findings": {
+      "type": "array",
+      "description": "3-5 achados categorizados (vantagem | contexto | ameaca | acao).",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "text"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "vantagem",
+              "contexto",
+              "ameaca",
+              "acao"
+            ]
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "sections": {
+      "type": "array",
+      "description": "Seções da LP em ordem de exibição.",
+      "minItems": 6,
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "enum": [
+              "hero",
+              "problem",
+              "authority",
+              "solution",
+              "how_it_works",
+              "deliverables",
+              "social_proof",
+              "secondary_audience",
+              "faq",
+              "final_cta",
+              "location"
+            ],
+            "description": "Identificador da seção. Aceita seções extras além do core (authority, secondary_audience, location/map) para LPs mais ricas."
+          },
+          "eyebrow": {
+            "type": "string",
+            "description": "Texto pequeno acima do headline (estilo eyebrow/sticker — ex: '· A profissional')."
+          },
+          "stats": {
+            "type": "array",
+            "description": "Stats inline da seção (ex: hero stats — alternativa a social_proof.stats).",
+            "items": {
+              "type": "object",
+              "required": [
+                "number",
+                "label"
+              ],
+              "properties": {
+                "number": {
+                  "type": "string"
+                },
+                "label": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "credential_card": {
+            "type": "object",
+            "description": "Card flutuante com credencial (ex: nome do profissional + CRMV).",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "role": {
+                "type": "string"
+              }
+            }
+          },
+          "credentials": {
+            "type": "array",
+            "description": "Timeline de credenciais (formato 'year' + 'title' — usado em seções de autoridade).",
+            "items": {
+              "type": "object",
+              "required": [
+                "year",
+                "title"
+              ],
+              "properties": {
+                "year": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "headline": {
+            "type": "string",
+            "description": "Título principal da seção"
+          },
+          "subheadline": {
+            "type": "string",
+            "description": "Subtítulo (quando aplicável)"
+          },
+          "body": {
+            "type": "string",
+            "description": "Texto do corpo (quando aplicável)"
+          },
+          "cta_primary": {
+            "type": "string",
+            "description": "Texto do CTA primário (hero e final_cta)"
+          },
+          "cta_secondary": {
+            "type": "string",
+            "description": "Texto do CTA secundário (hero)"
+          },
+          "cards": {
+            "type": "array",
+            "description": "Cards de dor (seção problem)",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "body"
+              ],
+              "properties": {
+                "title": {
+                  "type": "string"
+                },
+                "body": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "benefits": {
+            "type": "array",
+            "description": "Benefícios com ícone (seção solution)",
+            "items": {
+              "type": "object",
+              "required": [
+                "icon",
+                "title",
+                "body"
+              ],
+              "properties": {
+                "icon": {
+                  "type": "string",
+                  "description": "Nome do ícone sugerido (Lucide/Heroicons)"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "body": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "steps": {
+            "type": "array",
+            "description": "Passos do como funciona",
+            "items": {
+              "type": "object",
+              "required": [
+                "number",
+                "title",
+                "body"
+              ],
+              "properties": {
+                "number": {
+                  "type": "integer"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "body": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "items": {
+            "type": "array",
+            "description": "Itens de entregáveis",
+            "items": {
+              "type": "object",
+              "required": [
+                "title",
+                "benefit"
+              ],
+              "properties": {
+                "title": {
+                  "type": "string"
+                },
+                "benefit": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "faq": {
+      "type": "array",
+      "description": "5 perguntas frequentes que respondem às objeções do ICP.",
+      "minItems": 5,
+      "items": {
+        "type": "object",
+        "required": [
+          "question",
+          "answer"
+        ],
+        "properties": {
+          "question": {
+            "type": "string"
+          },
+          "answer": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "social_proof": {
+      "type": "object",
+      "required": [
+        "testimonials"
+      ],
+      "properties": {
+        "testimonials": {
+          "type": "array",
+          "description": "Depoimentos de clientes (reais ou placeholders). Aceita formato simples (name/role/text) ou rico (com photo, source, when, rating, neighborhood, pet, photo_caption).",
+          "items": {
+            "type": "object",
+            "required": [
+              "name",
+              "text"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "role": {
+                "type": "string",
+                "description": "Cargo ou contexto da pessoa (opcional — pode ser derivado de source/when/neighborhood)"
+              },
+              "text": {
+                "type": "string",
+                "description": "Texto do depoimento"
+              },
+              "photo": {
+                "type": "string",
+                "description": "Caminho relativo da foto do depoimento (ex: /photos/testimonials/x.webp)"
+              },
+              "photo_caption": {
+                "type": "string",
+                "description": "Legenda da foto (ex: 'Arlete · cachorrinha levada para exame')"
+              },
+              "source": {
+                "type": "string",
+                "description": "Fonte do depoimento (ex: 'Google Reviews', 'Google · Local Guide')"
+              },
+              "when": {
+                "type": "string",
+                "description": "Quando foi escrito (ex: '6 meses atrás')"
+              },
+              "rating": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 5,
+                "description": "Nota em estrelas (1-5)"
+              },
+              "neighborhood": {
+                "type": "string",
+                "description": "Bairro/cidade da pessoa"
+              },
+              "pet": {
+                "type": "string",
+                "description": "Nome e raça/idade do pet (ex: 'Mel · Siamês, 4 anos')"
+              }
+            }
+          }
+        },
+        "stats": {
+          "type": "array",
+          "description": "Números de impacto (clientes, anos, resultados).",
+          "items": {
+            "type": "object",
+            "required": [
+              "number",
+              "label"
+            ],
+            "properties": {
+              "number": {
+                "type": "string",
+                "description": "Número formatado (ex: '500+')"
+              },
+              "label": {
+                "type": "string",
+                "description": "Descrição do número"
+              }
+            }
+          }
+        }
+      }
+    },
+    "meta": {
+      "type": "object",
+      "required": [
+        "title",
+        "description",
+        "og_title",
+        "og_description",
+        "og_type"
+      ],
+      "properties": {
+        "title": {
+          "type": "string",
+          "maxLength": 60,
+          "description": "Title tag para SEO"
+        },
+        "description": {
+          "type": "string",
+          "maxLength": 155,
+          "description": "Meta description para SEO"
+        },
+        "og_title": {
+          "type": "string"
+        },
+        "og_description": {
+          "type": "string"
+        },
+        "og_type": {
+          "type": "string",
+          "enum": [
+            "website"
+          ],
+          "default": "website"
+        }
+      }
+    },
+    "deploy_url": {
+      "type": "string",
+      "format": "uri",
+      "description": "URL da LP deployada na Vercel"
+    },
+    "whatsapp_link": {
+      "type": "string",
+      "description": "Link completo do WhatsApp com mensagem pré-formatada"
+    }
+  }
+}

--- a/.claude/skills/designer-lp-asset-pipeline/SKILL.md
+++ b/.claude/skills/designer-lp-asset-pipeline/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: designer-lp-asset-pipeline
+description: Preparar e governar assets de landing pages com rastreabilidade de origem, direitos, original, derivados e uso responsivo. Usar quando assets aprovados precisarem ser selecionados ou preparados para produção; não usar para buscar stock automaticamente, instalar processadores ou substituir imagens sem aprovação.
+area: designer
+author: nicolaskobayashi-v4
+version: 1.0.0
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta skill foi portada do repositorio v4-unidade-integrada. As regras abaixo tem precedencia sobre caminhos, zonas e ferramentas citados no corpo original:
+
+- **Posicao no fluxo.** Este pipeline fica a jusante de `designer-landing-page`, que e a porta do hub para `ee-s3-landing-page`. O `designer-landing-page` responde por estrategia, copy e geracao de codigo. Este pipeline responde por baseline, adaptacao, assets, quality gate e release controlada. O passo `vercel --yes --prod` do `designer-landing-page` fica **suspenso** quando o pipeline estiver em uso: release passa por `designer-lp-release`, e Production continua proibida.
+- **Governanca.** Onde o corpo cita "o `AGENTS.md` raiz prevalece", leia o `CLAUDE.md` e o `AGENTS.md` da raiz do hub mais o `CLAUDE.md` da KB do cliente. Nenhuma regra local pode enfraquece-los.
+- **Zonas somente leitura.** Onde o corpo cita "matriz" e "plugin", leia: `.claude/skills/`, `.agents/skills/` e `REGISTRY.md` sao somente leitura durante o pipeline. `REGISTRY.md` e auto-gerado e nunca se edita a mao.
+- **Caminhos.** Trabalhe em `squads/{squad}/clientes/{cliente}/`. A estrutura do projeto e `squads/{squad}/clientes/{cliente}/outputs/landing-pages/<projeto>/`, com `reference/` e `src/` dentro dela.
+- **`client.json`.** Opcional no hub. So a KB migrada do EE tem esse arquivo. Se nao existir, derive o contexto de `CLAUDE.md`, `mission-control/`, `docs/` e `links.md`, e nao invente o arquivo.
+- **Scripts da matriz.** `validate_output.py`, `page_audit.py`, `page_audit_deep.py` e o agente `revisor-qualidade` **nao existem no hub**. Onde o corpo os cita, declare o gap e faca a verificacao equivalente a mao, registrando o que foi checado e como.
+- **Vercel.** O hub nao tem projeto Vercel configurado. Preview exige configurar o projeto antes e autorizacao explicita do usuario na hora. Production permanece proibida por esta skill.
+- **Registro.** Decisao, gate aprovado e bloqueio vao para `mission-control/historico-checkins.md` da KB do cliente.
+- **Git.** Nunca commite `squads/` nem `bases/`. Sao pessoais e ficam no `.gitignore`.
+
+---
+
+
+# LP Asset Pipeline
+
+## 1. Propósito
+
+Definir o fluxo seguro de assets do original aprovado até o código, preservando origem e direitos e documentando todas as derivações usadas na landing page.
+
+## 2. Quando usar
+
+- Quando a seção autorizada usar imagens, logos, ícones, vídeos ou outros arquivos de mídia.
+- Quando um asset exigir otimização, recorte, variantes responsivas ou fallback.
+- Quando a implementação contiver base64 ou arquivos sem origem e direitos documentados.
+
+## 3. Quando NÃO usar
+
+- Para escolher fotografia de stock sem solicitação e aprovação humanas.
+- Para alterar copy, layout, links ou identidade visual.
+- Para instalar automaticamente bibliotecas, codecs ou processadores.
+- Quando não houver autorização de uso ou origem verificável.
+
+## 4. Pré-condições
+
+1. Confirmar baseline, seção e arquivos autorizados.
+2. Inventariar assets existentes sem modificar originals ou referência.
+3. Confirmar origem, direito de uso e papel de cada asset.
+4. Apresentar transformações e destinos propostos.
+5. Obter aprovação explícita antes de criar derivados ou alterar referências no código.
+
+## 5. Entradas
+
+- Assets oficiais aprovados e seus metadados disponíveis.
+- Baseline e cópia de trabalho.
+- Manual de Marca e diagnóstico visual aprovados.
+- Requisitos de exibição, recorte, densidade e viewports.
+- Restrições técnicas da implementação.
+
+## 6. Fontes permitidas
+
+- Assets oficiais do cliente com uso autorizado.
+- Derivados existentes cuja relação com o original seja comprovável.
+- Ícones já aprovados e integrantes do sistema visual.
+- Referências externas apenas para repertório, sem reutilização do arquivo.
+
+## 7. Precedência das fontes
+
+- Fatos: confirmação explícita mais recente → `client.json` → base estratégica aprovada → outputs estratégicos aprovados → implementação existente.
+- Visual: confirmação explícita mais recente → Manual aprovado mais recente → diagnóstico visual aprovado → assets oficiais → referências externas → implementação existente.
+- Copy: copy explicitamente aprovada → output estratégico de landing page aprovado → implementação existente.
+- Links: confirmação explícita → implementação existente aprovada.
+
+Em conflito de asset ou orientação visual, registrar e solicitar decisão. Documento especializado posterior prevalece apenas no seu domínio e com registro.
+
+## 8. Procedimento
+
+1. Inventariar arquivo, origem, proprietário/direito conhecido, função e ocorrências no código.
+2. Identificar o original preservado e separar qualquer derivado existente.
+3. Registrar para cada variante: dimensões, formato, peso, crop, densidade e fallback.
+4. Classificar uso como decorativo, informativo, marca, ícone ou mídia funcional.
+5. Propor a cadeia `original → derivado otimizado → asset de produção → referência no código`.
+6. Preservar o original sem conversão, renomeação ou sobrescrita.
+7. Preferir WebP quando compatível e manter fallback adequado ao projeto.
+8. Para imagens responsivas, propor múltiplas larguras e uso coerente de `picture`, `srcset` e `sizes`.
+9. Documentar recortes intencionais e comportamento por viewport.
+10. Tratar base64 como tolerável em protótipo; para produção, registrar pendência até haver asset rastreável e aprovado.
+11. Depois da autorização, criar somente derivados previstos e atualizar apenas código autorizado.
+12. Verificar visualmente distorção, nitidez, crop e fallback.
+
+## 9. Saídas esperadas
+
+- Inventário de assets com origem e direito de uso conhecido.
+- Mapa de original, derivados, dimensões, formato, peso, crop e fallback.
+- Plano responsivo e referências de código propostas.
+- Pendências explícitas para base64, direitos ausentes ou qualidade insuficiente.
+
+## 10. Critérios de parada
+
+Parar se origem ou direito de uso forem desconhecidos, se não houver original preservável, se a transformação comprometer identidade ou fidelidade, ou se a atualização exigir arquivo não autorizado. Ausência de foto não autoriza stock.
+
+## 11. Checkpoints humanos
+
+- Aprovar direito de uso e seleção dos assets.
+- Aprovar transformações, crops, variantes e fallbacks.
+- Aprovar mudança das referências no código.
+- Revisar resultado visual antes do quality gate.
+
+## 12. Proteções
+
+O `AGENTS.md` raiz prevalece. Original, `reference/`, plugin e matriz são somente leitura. Não modificar asset, link ou copy sem aprovação. Não ler secrets. Commit/push e Preview exigem autorização separada; Production é proibida.
+
+## 13. Integração com a matriz
+
+Consumir Manual de Marca, diagnóstico visual, diagnóstico de criativos e output estratégico aprovados. Esta skill acrescenta rastreabilidade e preparação técnica de assets; não duplica diagnóstico, não altera os outputs da matriz e não herda mutações ou deploys.
+
+## 14. Ferramentas reutilizáveis
+
+- Disponíveis: metadados do filesystem, `Get-FileHash` e inspeção de referências com `rg`.
+- Condicionais: recursos já instalados no projeto; descobrir e validar as ferramentas existentes antes de propor seu uso, sem instalar dependências automaticamente.
+- Planejadas: processador de imagens, gerador de variantes e verificador de peso; nenhum está implementado nesta fase.
+- Humanas: confirmação de direitos, crop, qualidade e adequação à marca.
+- Proibidas: instalação automática de processador e busca automática de stock.
+
+## 15. Ações proibidas
+
+- Sobrescrever ou recomprimir o original.
+- Baixar ou incorporar asset externo sem autorização e direitos confirmados.
+- Alterar silenciosamente crop, formato, nome ou uso no código.
+- Usar base64 como asset final de produção sem pendência documentada.
+- Fazer commit, push ou deploy.
+
+## 16. Definição de sucesso
+
+Cada asset de produção é rastreável a um original autorizado, possui derivados documentados e comportamento responsivo validado, sem perda do original nem incorporação não autorizada.

--- a/.claude/skills/designer-lp-baseline-prepare/SKILL.md
+++ b/.claude/skills/designer-lp-baseline-prepare/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: designer-lp-baseline-prepare
+description: Preparar uma baseline imutável e uma cópia de trabalho isolada para uma landing page após auditoria aprovada. Usar antes da primeira alteração de implementação; não usar sem fonte inequívoca, autorização de escrita ou possibilidade de preservar a referência sem sobrescrita.
+area: designer
+author: nicolaskobayashi-v4
+version: 1.0.0
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta skill foi portada do repositorio v4-unidade-integrada. As regras abaixo tem precedencia sobre caminhos, zonas e ferramentas citados no corpo original:
+
+- **Posicao no fluxo.** Este pipeline fica a jusante de `designer-landing-page`, que e a porta do hub para `ee-s3-landing-page`. O `designer-landing-page` responde por estrategia, copy e geracao de codigo. Este pipeline responde por baseline, adaptacao, assets, quality gate e release controlada. O passo `vercel --yes --prod` do `designer-landing-page` fica **suspenso** quando o pipeline estiver em uso: release passa por `designer-lp-release`, e Production continua proibida.
+- **Governanca.** Onde o corpo cita "o `AGENTS.md` raiz prevalece", leia o `CLAUDE.md` e o `AGENTS.md` da raiz do hub mais o `CLAUDE.md` da KB do cliente. Nenhuma regra local pode enfraquece-los.
+- **Zonas somente leitura.** Onde o corpo cita "matriz" e "plugin", leia: `.claude/skills/`, `.agents/skills/` e `REGISTRY.md` sao somente leitura durante o pipeline. `REGISTRY.md` e auto-gerado e nunca se edita a mao.
+- **Caminhos.** Trabalhe em `squads/{squad}/clientes/{cliente}/`. A estrutura do projeto e `squads/{squad}/clientes/{cliente}/outputs/landing-pages/<projeto>/`, com `reference/` e `src/` dentro dela.
+- **`client.json`.** Opcional no hub. So a KB migrada do EE tem esse arquivo. Se nao existir, derive o contexto de `CLAUDE.md`, `mission-control/`, `docs/` e `links.md`, e nao invente o arquivo.
+- **Scripts da matriz.** `validate_output.py`, `page_audit.py`, `page_audit_deep.py` e o agente `revisor-qualidade` **nao existem no hub**. Onde o corpo os cita, declare o gap e faca a verificacao equivalente a mao, registrando o que foi checado e como.
+- **Vercel.** O hub nao tem projeto Vercel configurado. Preview exige configurar o projeto antes e autorizacao explicita do usuario na hora. Production permanece proibida por esta skill.
+- **Registro.** Decisao, gate aprovado e bloqueio vao para `mission-control/historico-checkins.md` da KB do cliente.
+- **Git.** Nunca commite `squads/` nem `bases/`. Sao pessoais e ficam no `.gitignore`.
+
+---
+
+
+# LP Baseline Prepare
+
+## 1. Propósito
+
+Criar a fronteira imutável entre a referência aprovada e a implementação editável, permitindo comparação e recuperação sem tocar o original.
+
+## 2. Quando usar
+
+- Depois de `designer-lp-source-audit` concluir que a fonte está pronta.
+- Antes de qualquer adaptação visual, de assets ou de código.
+- Quando ainda não existir uma referência congelada e uma cópia de trabalho isolada.
+
+## 3. Quando NÃO usar
+
+- Quando a auditoria estiver bloqueada ou houver versões conflitantes.
+- Para reorganizar outputs existentes ou transformar uma referência em área editável.
+- Sem aprovação explícita dos caminhos e das operações de escrita.
+
+## 4. Pré-condições
+
+1. Ter relatório de fonte aprovado e implementação de origem inequívoca.
+2. Auditar branch, worktree, arquivos-alvo e instruções locais.
+3. Apresentar plano com origem, `reference/`, `src/` e operações exatas.
+4. Confirmar que os caminhos são novos e isolados.
+5. Obter aprovação explícita antes de criar ou copiar qualquer arquivo.
+
+## 5. Entradas
+
+- Implementação aprovada pela auditoria.
+- Caminho novo do projeto, preferencialmente `outputs/landing-pages/<project>/`.
+- Lista de arquivos necessários à execução.
+- Hashes, estado Git e confirmação humana da versão de origem.
+
+## 6. Fontes permitidas
+
+- Implementação existente aprovada e seus assets oficiais.
+- Histórico Git para registrar versão de origem.
+- Outputs estratégicos aprovados apenas para conferência.
+
+Não incorporar material externo novo durante a preparação da baseline.
+
+## 7. Precedência das fontes
+
+- Fatos: confirmação explícita mais recente → `client.json` → base estratégica aprovada → outputs estratégicos aprovados → implementação existente.
+- Visual: confirmação explícita mais recente → Manual de Marca aprovado mais recente → diagnóstico visual aprovado → assets oficiais → referências externas → implementação existente.
+- Copy: copy explicitamente aprovada → output estratégico de landing page aprovado → implementação existente.
+- Links: confirmação explícita → implementação existente aprovada.
+
+Registrar todo conflito descoberto nesta etapa, invalidar a prontidão e retornar à auditoria; não o resolver durante a cópia. Posicionamento, CRO, diagnóstico ou outro output estratégico não substituem silenciosamente a copy específica aprovada da landing page.
+
+## 8. Procedimento
+
+1. Validar novamente que origem e destinos correspondem ao plano aprovado.
+2. Confirmar que `reference/` e `src/` não contêm arquivos preexistentes.
+3. Registrar origem, caminho relativo, hash, timestamp de preparação e função de cada arquivo.
+4. Em execução autorizada, copiar a implementação aprovada para `reference/` sem transformação.
+5. Validar a cópia de referência por hash e contagem.
+6. Criar `src/` como cópia de trabalho separada, preservando estrutura necessária.
+7. Validar que `reference/` e `src/` começam equivalentes.
+8. Marcar `reference/` como fronteira somente leitura no relatório operacional.
+9. Registrar diferenças preexistentes, se houver, e bloquear em vez de normalizá-las.
+
+Estrutura recomendada:
+
+```text
+outputs/landing-pages/<project>/
+├── reference/  # cópia congelada, nunca editada
+└── src/        # única área autorizável para implementação
+```
+
+## 9. Saídas esperadas
+
+- Baseline congelada em caminho novo e isolado.
+- Cópia de trabalho inicialmente equivalente.
+- Manifesto humano com origem, caminho, hash, timestamp e função.
+- Registro de autorização e validação pós-cópia.
+
+## 10. Critérios de parada
+
+Parar se qualquer destino existir, se hashes não coincidirem, se houver risco de sobrescrita, se a origem mudar durante a operação ou se faltar autorização. Não improvisar nomes, conteúdo, links ou assets.
+
+## 11. Checkpoints humanos
+
+- Aprovar caminhos, lista de arquivos e operação de cópia.
+- Confirmar o manifesto e a imutabilidade de `reference/`.
+- Autorizar separadamente a primeira seção a ser alterada em `src/`.
+
+## 12. Proteções
+
+O `AGENTS.md` raiz prevalece. Nunca modificar origem, outputs existentes, plugin ou `reference/`. Cada execução altera no máximo uma seção autorizada na etapa posterior. Não ler secrets. Commit, push e Vercel Preview exigem aprovações próprias; Production é proibida.
+
+## 13. Integração com a matriz
+
+Consumir a implementação indicada por `designer-lp-source-audit` e outputs aprovados da matriz como evidência. Esta skill cria uma proteção operacional nova; não altera contratos, outputs ou scripts da matriz e não herda comandos de deploy ou mutação do cliente.
+
+## 14. Ferramentas reutilizáveis
+
+- Disponíveis: `Get-FileHash`, `git status`, `git diff --no-index` e listagem nativa de arquivos.
+- Planejadas: manifesto gerado por ferramenta própria, ainda não implementado.
+- Humanas: confirmação da versão e autorização de caminho.
+- Proibidas: sincronização destrutiva, formatação automática da referência e scaffolding que adicione arquivos não aprovados.
+
+## 15. Ações proibidas
+
+- Sobrescrever, mover, renomear, reformatar ou otimizar a origem ou `reference/`.
+- Usar um output atual como diretório editável.
+- Incluir arquivos além dos aprovados.
+- Fazer mudanças visuais, de copy, link ou asset nesta etapa.
+
+## 16. Definição de sucesso
+
+Referência e trabalho ficam fisicamente separados, verificáveis e inicialmente equivalentes, com origem e autorização rastreáveis e nenhuma alteração no original.

--- a/.claude/skills/designer-lp-design-adapter/SKILL.md
+++ b/.claude/skills/designer-lp-design-adapter/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: designer-lp-design-adapter
+description: Adaptar visualmente uma landing page em uma cópia de trabalho autorizada, preservando conteúdo, links, claims e estrutura comercial congelados. Usar por seção, para aplicação de marca, correções visuais ou programas de redesign conduzidos em sucessivas execuções de uma seção; não usar para alterar a página inteira em uma execução, criar estratégia, trocar assets sem aprovação ou editar referência/original.
+area: designer
+author: nicolaskobayashi-v4
+version: 1.0.0
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta skill foi portada do repositorio v4-unidade-integrada. As regras abaixo tem precedencia sobre caminhos, zonas e ferramentas citados no corpo original:
+
+- **Posicao no fluxo.** Este pipeline fica a jusante de `designer-landing-page`, que e a porta do hub para `ee-s3-landing-page`. O `designer-landing-page` responde por estrategia, copy e geracao de codigo. Este pipeline responde por baseline, adaptacao, assets, quality gate e release controlada. O passo `vercel --yes --prod` do `designer-landing-page` fica **suspenso** quando o pipeline estiver em uso: release passa por `designer-lp-release`, e Production continua proibida.
+- **Governanca.** Onde o corpo cita "o `AGENTS.md` raiz prevalece", leia o `CLAUDE.md` e o `AGENTS.md` da raiz do hub mais o `CLAUDE.md` da KB do cliente. Nenhuma regra local pode enfraquece-los.
+- **Zonas somente leitura.** Onde o corpo cita "matriz" e "plugin", leia: `.claude/skills/`, `.agents/skills/` e `REGISTRY.md` sao somente leitura durante o pipeline. `REGISTRY.md` e auto-gerado e nunca se edita a mao.
+- **Caminhos.** Trabalhe em `squads/{squad}/clientes/{cliente}/`. A estrutura do projeto e `squads/{squad}/clientes/{cliente}/outputs/landing-pages/<projeto>/`, com `reference/` e `src/` dentro dela.
+- **`client.json`.** Opcional no hub. So a KB migrada do EE tem esse arquivo. Se nao existir, derive o contexto de `CLAUDE.md`, `mission-control/`, `docs/` e `links.md`, e nao invente o arquivo.
+- **Scripts da matriz.** `validate_output.py`, `page_audit.py`, `page_audit_deep.py` e o agente `revisor-qualidade` **nao existem no hub**. Onde o corpo os cita, declare o gap e faca a verificacao equivalente a mao, registrando o que foi checado e como.
+- **Vercel.** O hub nao tem projeto Vercel configurado. Preview exige configurar o projeto antes e autorizacao explicita do usuario na hora. Production permanece proibida por esta skill.
+- **Registro.** Decisao, gate aprovado e bloqueio vao para `mission-control/historico-checkins.md` da KB do cliente.
+- **Git.** Nunca commite `squads/` nem `bases/`. Sao pessoais e ficam no `.gitignore`.
+
+---
+
+
+# LP Design Adapter
+
+## 1. Propósito
+
+Transformar a apresentação visual da implementação autorizada com fidelidade à marca e à referência, sem redefinir estratégia, copy, oferta, claims, links ou função comercial.
+
+## 2. Quando usar
+
+- Para executar uma etapa de um programa de redesign completo, sempre limitada a uma seção autorizada.
+- Para adaptação de uma única seção por execução.
+- Para aplicação de Manual de Marca ou rodada de correções visuais delimitadas.
+
+“Redesign completo” significa um programa composto por sucessivas execuções desta skill, uma seção por vez. Nunca interpretar o programa como autorização para alterar toda a página em uma única execução.
+
+## 3. Quando NÃO usar
+
+- Sem baseline aprovada e seção/arquivos explicitamente autorizados.
+- Para escrever estratégia, substituir copy ou decidir claims, preços, métricas e links.
+- Para buscar stock automaticamente ou reutilizar identidade, código, estrutura completa ou assets externos.
+
+## 4. Pré-condições
+
+1. Confirmar `source_audited` e `baseline_approved`.
+2. Identificar `reference/` somente leitura e `src/` editável.
+3. Congelar copy, links, claims e estrutura comercial da seção.
+4. Ler Manual de Marca e diagnóstico visual aprovados, quando disponíveis.
+5. Apresentar plano e obter autorização explícita para uma seção e arquivos definidos.
+
+## 5. Entradas
+
+- Baseline e cópia de trabalho.
+- Copy, links, claims e estrutura comercial aprovados.
+- Manual de Marca, diagnóstico visual e assets oficiais aprovados.
+- Referências visuais autorizadas e escopo de adaptação.
+- Restrições técnicas e viewports-alvo.
+
+## 6. Fontes permitidas
+
+- Fontes internas aprovadas e assets oficiais.
+- Output estratégico aprovado como restrição de conteúdo.
+- Referências externas apenas como repertório de composição, ritmo e padrões.
+
+Referências externas nunca autorizam copiar identidade, código, estrutura integral, conteúdo ou assets.
+
+## 7. Precedência das fontes
+
+- Fatos: confirmação explícita mais recente → `client.json` → base estratégica aprovada → outputs estratégicos aprovados → implementação existente.
+- Visual: confirmação explícita mais recente → Manual aprovado mais recente → diagnóstico visual aprovado → assets oficiais → referências externas → implementação existente.
+- Copy: copy explicitamente aprovada → output estratégico de landing page aprovado → implementação existente.
+- Links: confirmação explícita → implementação existente aprovada.
+
+Registrar todo conflito e interromper o trecho afetado. Documento especializado posterior pode prevalecer apenas em seu domínio e com decisão registrada.
+
+## 8. Procedimento
+
+1. Selecionar o modo: etapa de programa de redesign completo, adaptação por seção, aplicação de marca ou rodada de correções visuais.
+2. Se o modo for redesign completo, registrar o programa geral apenas como roteiro; não tratá-lo como autorização de escrita.
+3. Delimitar arquivos, seletores, componentes e conteúdo que não podem mudar.
+4. Comparar `reference/` e `src/` antes da edição e registrar diferenças preexistentes.
+5. Traduzir Manual e diagnóstico em decisões explícitas de tipografia, cor, espaçamento, grid, hierarquia e componentes.
+6. Tratar benchmarks como repertório, nunca como template.
+7. Adaptar somente a seção autorizada em `src/`.
+8. Manter copy, links, claims, preços, métricas e ordem comercial congelados.
+9. Se não houver fotografia oficial aprovada, manter solução sem foto; não inserir stock.
+10. Usar ícones de forma sistemática e coerente; evitar ilustrações improvisadas.
+11. Permitir assimetria apenas quando controlada por grid, hierarquia e comportamento responsivo.
+12. Remover ou não criar decoração sem função comunicacional.
+13. Verificar visualmente 390, 768, 1024 e 1440 px, comparando com a referência.
+14. Submeter a seção à revisão estética humana antes de encerrar a execução.
+15. Exigir nova autorização para a seção seguinte; a aprovação atual nunca se propaga automaticamente.
+
+## 9. Saídas esperadas
+
+- Alteração limitada à área `src/`, aos arquivos e à seção autorizados.
+- Registro das decisões visuais e dos itens preservados.
+- Comparação com baseline e lista de desvios intencionais.
+- Pendências encaminhadas a assets, qualidade ou decisão humana.
+- Em programa de redesign completo, registro da etapa concluída sem autorizar as seções seguintes.
+
+## 10. Critérios de parada
+
+Parar se a fidelidade visual, copy, links, claims, assets ou estrutura comercial não puderem ser preservados; se faltar fonte visual crítica; ou se a mudança exigir outro arquivo/seção. Não inventar solução factual nem ampliar escopo.
+
+## 11. Checkpoints humanos
+
+- Aprovar modo, seção, arquivos e plano antes da escrita.
+- Aprovar qualquer exceção de conteúdo ou asset antes da mudança.
+- Realizar revisão estética e responsiva antes do quality gate.
+
+## 12. Proteções
+
+O `AGENTS.md` raiz prevalece. Plugin, matriz, original e `reference/` são somente leitura. Uma execução modifica no máximo uma seção. Não alterar copy, links ou assets sem aprovação. Não ler secrets. Commit/push e Preview têm aprovações separadas; Production é proibida.
+
+## 13. Integração com a matriz
+
+Consumir `ee-s3-landing-page`, Manual de Marca, posicionamento, diagnósticos aprovados e padrões de copy como restrições e repertório. Esta skill estende a camada visual operacional; não substitui estratégia, não reescreve outputs e não executa deploys ou mutações sugeridos pela matriz.
+
+## 14. Ferramentas reutilizáveis
+
+- Disponíveis: inspeção estática de HTML/CSS/JS e Git diff.
+- Condicionais: renderização local; descobrir primeiro se o projeto possui mecanismo utilizável e autorizado antes de propor seu uso.
+- Planejadas: comparação visual automatizada e tokens normalizados, ainda não implementados.
+- Humanas: revisão estética, confirmação de marca e aceitação de desvios.
+- Proibidas: instalação automática de frameworks, busca automática de stock e edição do Figma original.
+
+## 15. Ações proibidas
+
+- Editar `reference/`, original, plugin ou outputs não autorizados.
+- Inventar claims, depoimentos, preços, métricas, links ou conteúdo.
+- Copiar identidade, código, estrutura completa ou assets de terceiros.
+- Inserir imagem genérica para preencher ausência de fotografia.
+- Fazer commit, push ou deploy.
+
+## 16. Definição de sucesso
+
+A seção autorizada apresenta adaptação visual coerente e responsiva, mantém integralmente o conteúdo e a função aprovados, possui desvios rastreáveis e passa pela revisão estética humana sem tocar os originais.

--- a/.claude/skills/designer-lp-orchestrator/SKILL.md
+++ b/.claude/skills/designer-lp-orchestrator/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: designer-lp-orchestrator
+description: Coordenar o pipeline de produção de landing pages por estados, gates humanos e contratos entre skills. Usar para iniciar, retomar ou determinar a próxima etapa segura; não usar para editar design/código, decidir copy/claims/imagens, alterar links ou executar deploy.
+area: designer
+author: nicolaskobayashi-v4
+version: 1.0.0
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta skill foi portada do repositorio v4-unidade-integrada. As regras abaixo tem precedencia sobre caminhos, zonas e ferramentas citados no corpo original:
+
+- **Posicao no fluxo.** Este pipeline fica a jusante de `designer-landing-page`, que e a porta do hub para `ee-s3-landing-page`. O `designer-landing-page` responde por estrategia, copy e geracao de codigo. Este pipeline responde por baseline, adaptacao, assets, quality gate e release controlada. O passo `vercel --yes --prod` do `designer-landing-page` fica **suspenso** quando o pipeline estiver em uso: release passa por `designer-lp-release`, e Production continua proibida.
+- **Governanca.** Onde o corpo cita "o `AGENTS.md` raiz prevalece", leia o `CLAUDE.md` e o `AGENTS.md` da raiz do hub mais o `CLAUDE.md` da KB do cliente. Nenhuma regra local pode enfraquece-los.
+- **Zonas somente leitura.** Onde o corpo cita "matriz" e "plugin", leia: `.claude/skills/`, `.agents/skills/` e `REGISTRY.md` sao somente leitura durante o pipeline. `REGISTRY.md` e auto-gerado e nunca se edita a mao.
+- **Caminhos.** Trabalhe em `squads/{squad}/clientes/{cliente}/`. A estrutura do projeto e `squads/{squad}/clientes/{cliente}/outputs/landing-pages/<projeto>/`, com `reference/` e `src/` dentro dela.
+- **`client.json`.** Opcional no hub. So a KB migrada do EE tem esse arquivo. Se nao existir, derive o contexto de `CLAUDE.md`, `mission-control/`, `docs/` e `links.md`, e nao invente o arquivo.
+- **Scripts da matriz.** `validate_output.py`, `page_audit.py`, `page_audit_deep.py` e o agente `revisor-qualidade` **nao existem no hub**. Onde o corpo os cita, declare o gap e faca a verificacao equivalente a mao, registrando o que foi checado e como.
+- **Vercel.** O hub nao tem projeto Vercel configurado. Preview exige configurar o projeto antes e autorizacao explicita do usuario na hora. Production permanece proibida por esta skill.
+- **Registro.** Decisao, gate aprovado e bloqueio vao para `mission-control/historico-checkins.md` da KB do cliente.
+- **Git.** Nunca commite `squads/` nem `bases/`. Sao pessoais e ficam no `.gitignore`.
+
+---
+
+
+# LP Orchestrator
+
+## 1. Propósito
+
+Coordenar a sequência operacional da landing page, preservar o estado auditável e impedir que uma etapa avance sem evidência e checkpoint humano. Não realizar o trabalho especializado das skills coordenadas.
+
+Ao executar, ler [references/pipeline-contract.md](references/pipeline-contract.md) integralmente.
+
+## 2. Quando usar
+
+- Para iniciar um novo fluxo de landing page.
+- Para retomar trabalho interrompido e localizar o último gate válido.
+- Para identificar a próxima skill, evidência ou autorização necessária.
+
+## 3. Quando NÃO usar
+
+- Para editar HTML, CSS, JavaScript, design, Figma ou assets.
+- Para decidir ou alterar copy, claims, imagens, preços, métricas ou links.
+- Para executar commit, push ou deploy.
+- Para contornar um `STOP` emitido por outra skill.
+
+## 4. Pré-condições
+
+1. Ler o `AGENTS.md` raiz e instruções locais.
+2. Auditar branch, worktree, cliente, projeto e escopo.
+3. Confirmar que plugin e outputs da matriz são somente leitura.
+4. Identificar registros existentes de estados e aprovações.
+5. Não presumir que uma ação passada autoriza a próxima.
+
+## 5. Entradas
+
+- Pedido atual e escopo autorizado.
+- Evidências e saídas das skills do pipeline.
+- Aprovações humanas registradas.
+- Estado Git e identificação do projeto.
+- Outputs estratégicos aprovados da matriz, apenas como entradas.
+
+## 6. Fontes permitidas
+
+- Registros produzidos pelas oito skills locais.
+- Confirmações explícitas do responsável.
+- Estado Git e arquivos do cliente permitidos pela governança.
+- Outputs aprovados da matriz em modo somente leitura.
+
+Referências externas não definem estado nem fatos do projeto.
+
+## 7. Precedência das fontes
+
+- Fatos: confirmação explícita mais recente → `client.json` → base estratégica aprovada → outputs estratégicos aprovados → implementação existente.
+- Visual: confirmação explícita mais recente → Manual aprovado mais recente → diagnóstico visual aprovado → assets oficiais → referências externas → implementação existente.
+- Copy: copy explicitamente aprovada → output estratégico de landing page aprovado → implementação existente.
+- Links: confirmação explícita → implementação existente aprovada.
+
+Uma confirmação recente não apaga o histórico: registrar a decisão e o conflito. Documento especializado posterior pode prevalecer apenas em seu domínio.
+
+## 8. Procedimento
+
+1. Identificar o último estado comprovado por evidência ainda válida.
+2. Validar as condições de entrada e saída desse estado no contrato do pipeline.
+3. Se houver mudança posterior, invalidar os estados dependentes e retornar ao gate apropriado.
+4. Determinar uma única próxima etapa segura.
+5. Apresentar escopo, arquivos, ações e checkpoint humano exigidos pela etapa.
+6. Invocar conceitualmente a skill responsável; não executar sua função no orquestrador.
+7. Para todo `STOP` ou `BLOCKED`, informar obrigatoriamente: condição bloqueadora; evidência, autorização ou informação exata ausente; responsável esperado pela resolução; último estado válido; e próximo gate possível depois da resolução.
+8. Interromper em qualquer `STOP`; retomar somente após a condição ser resolvida.
+9. Encerrar em `human_approved`. Não criar estado ou caminho para Production.
+
+Estados, em ordem:
+
+```text
+source_audited
+→ baseline_approved
+→ section_authorized
+→ implementation_reviewed
+→ assets_approved
+→ quality_gate_passed
+→ preview_authorized
+→ human_approved
+```
+
+## 9. Saídas esperadas
+
+- Estado atual e evidência que o sustenta.
+- Próxima etapa única, skill responsável e pré-condições.
+- Checkpoint humano pendente e escopo de autorização.
+- Registro de interrupção/retomada e invalidações.
+- Para todo bloqueio, identificação precisa da condição, do item ausente, do responsável, do último estado válido e do próximo gate possível.
+
+## 10. Critérios de parada
+
+`STOP` é a ação operacional de interromper a execução porque falta uma pré-condição, evidência ou autorização. `BLOCKED` é o estado ou resultado formal de um gate que não pode ser aprovado. Ausência de autorização para executar produz `STOP`; um quality gate que detecta baseline modificada produz `BLOCKED`. Não criar novos estados do pipeline.
+
+Parar se evidência, dado crítico, fonte, autorização ou estado anterior estiver ausente ou conflitante; se houver mudança inesperada; ou se a próxima ação exceder o escopo. Identificar exatamente o item ausente e nunca usar mensagens vagas como “faltam dados”, “aguardando aprovação” ou “há pendências”. Nunca inventar fatos, claims, depoimentos, links, preços ou métricas para avançar.
+
+## 11. Checkpoints humanos
+
+- Aprovar baseline e fronteira imutável.
+- Autorizar uma seção e os arquivos de cada execução.
+- Revisar implementação e assets.
+- Aceitar o quality gate e seus warnings.
+- Autorizar Preview explicitamente.
+- Homologar a Preview sem implicar Production.
+
+## 12. Proteções
+
+O `AGENTS.md` raiz prevalece e regras locais não podem enfraquecê-lo. Plugin e outputs da matriz são somente leitura. Não modificar copy, link ou asset sem aprovação, não ler secrets e não agrupar autorizações. Commit/push são separados; Preview exige autorização; Production é proibida.
+
+## 13. Integração com a matriz
+
+Coordenar consumo de outputs aprovados de `ee-s3-landing-page`, Manual de Marca, posicionamento, diagnósticos e revisão. A matriz responde por estratégia e seus artefatos; a unidade responde por baseline, adaptação, assets, quality gate e Preview controlada. Não modificar a matriz nem executar seus fluxos incompatíveis.
+
+## 14. Ferramentas reutilizáveis
+
+- Disponíveis: estado Git, arquivos de evidência existentes e leitura dos contratos locais.
+- Planejadas: armazenamento estruturado de estado; não implementado nesta fase.
+- Humanas: todas as aprovações e decisões de conflito.
+- Proibidas: edição especializada, mutação automática de estado do cliente e qualquer deploy pelo orquestrador.
+
+## 15. Ações proibidas
+
+- Editar design, código, Figma, copy, claims, imagens ou links.
+- Escolher silenciosamente entre fontes conflitantes.
+- Marcar estado sem evidência ou pular gate.
+- Comunicar `STOP` ou `BLOCKED` sem identificar precisamente o item ausente e o responsável pela resolução.
+- Executar commit, push, Vercel Preview ou Production.
+- Criar o estado `production_authorized`.
+
+## 16. Definição de sucesso
+
+Em qualquer momento, o projeto possui um único estado comprovado, uma próxima ação segura e um checkpoint humano claro; interrupções são retomáveis e nenhum gate ou proteção de release pode ser contornado.

--- a/.claude/skills/designer-lp-orchestrator/references/pipeline-contract.md
+++ b/.claude/skills/designer-lp-orchestrator/references/pipeline-contract.md
@@ -1,0 +1,126 @@
+# Contrato do pipeline de landing pages
+
+## Fluxo exato
+
+```text
+client-knowledge-sync (quando necessário)
+→ designer-lp-source-audit
+→ designer-lp-baseline-prepare
+→ designer-lp-design-adapter
+→ designer-lp-asset-pipeline
+→ designer-lp-quality-gate
+→ designer-lp-release
+→ revisão humana
+```
+
+`client-knowledge-sync` é condicional e não cria um estado próprio no pipeline da landing page. Nenhuma etapa autoriza implicitamente a seguinte.
+
+## Contrato de estados
+
+### `source_audited`
+
+- Responsável: `designer-lp-source-audit`.
+- Entrada: fontes acessíveis em modo somente leitura.
+- Saída exigida: implementação e fontes identificadas, lacunas e conflitos registrados.
+- Gate humano: confirmar a implementação candidata.
+- STOP: fonte crítica ausente, versão ambígua ou conflito não resolvido.
+
+### `baseline_approved`
+
+- Responsável: `designer-lp-baseline-prepare`.
+- Entrada: `source_audited` e plano de caminhos aprovado.
+- Saída exigida: `reference/` imutável, `src/` separado e manifesto conferido.
+- Gate humano: aprovar baseline e fronteira de proteção.
+- STOP: destino existente, hash divergente ou risco de sobrescrita.
+
+### `section_authorized`
+
+- Responsáveis: humano e `designer-lp-design-adapter`.
+- Entrada: baseline aprovada e proposta delimitada.
+- Saída exigida: uma seção, arquivos e operações explicitamente autorizados.
+- Gate humano: autorização anterior à escrita.
+- STOP: escopo genérico, conteúdo não congelado ou múltiplas seções.
+
+### `implementation_reviewed`
+
+- Responsável: `designer-lp-design-adapter`.
+- Entrada: `section_authorized`.
+- Saída exigida: implementação local concluída e revisão estética/responsiva humana.
+- Gate humano: aceitar fidelidade visual e itens preservados.
+- STOP: perda visual, alteração de copy/link/claim ou asset não autorizado.
+
+### `assets_approved`
+
+- Responsável: `designer-lp-asset-pipeline`.
+- Entrada: implementação revisada e assets identificados.
+- Saída exigida: origem, direitos, derivados, comportamento responsivo e fallbacks aprovados.
+- Gate humano: aprovar seleção e transformações.
+- STOP: origem/direito desconhecido, original ausente ou stock não autorizado.
+
+### `quality_gate_passed`
+
+- Responsável: `designer-lp-quality-gate`.
+- Entrada: implementação e assets aprovados.
+- Saída exigida: `PASS` ou `PASS_WITH_WARNINGS` aceito, com evidências atuais.
+- Gate humano: revisão e aceitação de warnings.
+- STOP: `BLOCKED`, teste crítico ausente ou mudança inesperada.
+
+### `preview_authorized`
+
+- Responsáveis: humano e `designer-lp-release`.
+- Entrada: quality gate válido e destino confirmado.
+- Saída exigida: autorização explícita para uma Preview específica.
+- Gate humano: confirmar projeto, equipe, diretório e ação.
+- STOP: autorização ambígua, worktree mudou ou qualquer risco de Production.
+
+### `human_approved`
+
+- Responsável: revisor humano.
+- Entrada: Preview criada de forma autorizada ou artefato local apresentado para homologação.
+- Saída exigida: decisão de homologação registrada.
+- Estado terminal deste contrato.
+- Não autoriza Production.
+
+Não existe `production_authorized`.
+
+## Interrupção, invalidação e retomada
+
+- `STOP` é a ação operacional de interromper a execução porque uma pré-condição, evidência ou autorização está ausente.
+- `BLOCKED` é o estado ou resultado formal de um gate que não pode ser aprovado.
+- Ausência de autorização para executar produz `STOP`; quality gate com baseline modificada produz `BLOCKED`.
+- Nenhuma dessas definições cria novo estado no pipeline.
+- Ao receber `STOP` ou `BLOCKED`, manter o último estado comprovado e informar obrigatoriamente: condição bloqueadora; evidência, autorização ou informação exata ausente; responsável esperado pela resolução; último estado válido; e próximo gate possível depois da resolução.
+- Não usar mensagens vagas como “faltam dados”, “aguardando aprovação” ou “há pendências”.
+- Retomar pela etapa bloqueada depois de evidência ou autorização nova.
+- Mudança em fonte invalida auditoria e todos os estados dependentes.
+- Mudança em baseline invalida autorização de seção e estados posteriores.
+- Mudança em implementação ou asset invalida quality gate e release.
+- Mudança após o quality gate exige nova execução do gate.
+- Não pular estados nem converter silêncio em aprovação.
+
+## Responsabilidades da matriz
+
+- Produzir e manter estratégia aprovada.
+- Fornecer `client.json`, base estratégica, posicionamento e diagnósticos.
+- Produzir output estratégico de landing page e Manual de Marca quando aplicáveis.
+- Oferecer revisores e validadores como componentes consultáveis.
+- Permanecer somente leitura para a camada local durante esta fase.
+
+## Responsabilidades da unidade
+
+- Sincronizar conhecimento operacional somente quando necessário e autorizado.
+- Auditar fontes e escolher a implementação com evidência.
+- Proteger a baseline em cópia isolada.
+- Adaptar uma seção autorizada sem alterar estratégia ou conteúdo congelado.
+- Governar assets e derivados.
+- Executar quality gate integrado e registrar evidências reais.
+- Preparar e, apenas com autorização, criar Vercel Preview.
+- Manter Production desabilitada.
+
+## Limites de integração
+
+- Outputs da matriz podem ser consumidos; nunca modificados por este pipeline.
+- Instruções matriciais de mutação de cliente, cache, deploy ou Production não são herdadas.
+- Componentes matriciais podem ser citados e compostos conceitualmente sem copiar instruções inteiras.
+- O `AGENTS.md` raiz prevalece em todas as etapas.
+- Commit, push, Preview e qualquer escrita possuem autorizações distintas e limitadas.

--- a/.claude/skills/designer-lp-quality-gate/SKILL.md
+++ b/.claude/skills/designer-lp-quality-gate/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: designer-lp-quality-gate
+description: Executar o gate integrado de qualidade de uma landing page antes de release, reunindo conteúdo, baseline, visual, acessibilidade, responsividade, código, assets e Git. Usar após implementação e assets revisados; não usar para corrigir silenciosamente problemas, aprovar fatos ou substituir revisão humana.
+area: designer
+author: nicolaskobayashi-v4
+version: 1.0.0
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta skill foi portada do repositorio v4-unidade-integrada. As regras abaixo tem precedencia sobre caminhos, zonas e ferramentas citados no corpo original:
+
+- **Posicao no fluxo.** Este pipeline fica a jusante de `designer-landing-page`, que e a porta do hub para `ee-s3-landing-page`. O `designer-landing-page` responde por estrategia, copy e geracao de codigo. Este pipeline responde por baseline, adaptacao, assets, quality gate e release controlada. O passo `vercel --yes --prod` do `designer-landing-page` fica **suspenso** quando o pipeline estiver em uso: release passa por `designer-lp-release`, e Production continua proibida.
+- **Governanca.** Onde o corpo cita "o `AGENTS.md` raiz prevalece", leia o `CLAUDE.md` e o `AGENTS.md` da raiz do hub mais o `CLAUDE.md` da KB do cliente. Nenhuma regra local pode enfraquece-los.
+- **Zonas somente leitura.** Onde o corpo cita "matriz" e "plugin", leia: `.claude/skills/`, `.agents/skills/` e `REGISTRY.md` sao somente leitura durante o pipeline. `REGISTRY.md` e auto-gerado e nunca se edita a mao.
+- **Caminhos.** Trabalhe em `squads/{squad}/clientes/{cliente}/`. A estrutura do projeto e `squads/{squad}/clientes/{cliente}/outputs/landing-pages/<projeto>/`, com `reference/` e `src/` dentro dela.
+- **`client.json`.** Opcional no hub. So a KB migrada do EE tem esse arquivo. Se nao existir, derive o contexto de `CLAUDE.md`, `mission-control/`, `docs/` e `links.md`, e nao invente o arquivo.
+- **Scripts da matriz.** `validate_output.py`, `page_audit.py`, `page_audit_deep.py` e o agente `revisor-qualidade` **nao existem no hub**. Onde o corpo os cita, declare o gap e faca a verificacao equivalente a mao, registrando o que foi checado e como.
+- **Vercel.** O hub nao tem projeto Vercel configurado. Preview exige configurar o projeto antes e autorizacao explicita do usuario na hora. Production permanece proibida por esta skill.
+- **Registro.** Decisao, gate aprovado e bloqueio vao para `mission-control/historico-checkins.md` da KB do cliente.
+- **Git.** Nunca commite `squads/` nem `bases/`. Sao pessoais e ficam no `.gitignore`.
+
+---
+
+
+# LP Quality Gate
+
+## 1. Propósito
+
+Emitir uma decisão verificável — `PASS`, `PASS_WITH_WARNINGS` ou `BLOCKED` — sobre a prontidão da cópia de trabalho, sem alterar a implementação durante a avaliação.
+
+Ao executar, ler [references/quality-checklist.md](references/quality-checklist.md) integralmente e registrar cada item aplicável.
+
+## 2. Quando usar
+
+- Depois da revisão da implementação e da aprovação de assets.
+- Antes de solicitar autorização para Vercel Preview.
+- Novamente após qualquer correção que afete o resultado anterior.
+
+## 3. Quando NÃO usar
+
+- Antes de baseline e escopo estarem aprovados.
+- Para validar estratégia ainda não aprovada ou preencher lacunas.
+- Para alterar código, copy, links ou assets como efeito colateral.
+
+## 4. Pré-condições
+
+1. Confirmar referência imutável e arquivos autorizados em `src/`.
+2. Ter revisão estética humana e assets aprovados.
+3. Auditar branch e worktree.
+4. Confirmar como a página pode ser executada localmente sem instalar dependências novas.
+5. Identificar quais verificações são disponíveis, planejadas, humanas ou proibidas.
+
+## 5. Entradas
+
+- `reference/`, `src/` e escopo autorizado.
+- Copy, links, claims e assets aprovados.
+- Manual, diagnósticos e output estratégico aplicáveis.
+- Evidências de execução local e estado Git.
+- Checklist de qualidade desta skill.
+
+## 6. Fontes permitidas
+
+- Implementação e baseline locais.
+- Fontes aprovadas do cliente e outputs estratégicos somente leitura.
+- Logs locais e resultados reais de ferramentas existentes.
+- Avaliação humana documentada.
+
+Não declarar teste executado sem evidência da execução.
+
+## 7. Precedência das fontes
+
+- Fatos: confirmação explícita mais recente → `client.json` → base estratégica aprovada → outputs estratégicos aprovados → implementação existente.
+- Visual: confirmação explícita mais recente → Manual aprovado mais recente → diagnóstico visual aprovado → assets oficiais → referências externas → implementação existente.
+- Copy: copy explicitamente aprovada → output estratégico de landing page aprovado → implementação existente.
+- Links: confirmação explícita → implementação existente aprovada.
+
+Conflitos não resolvidos bloqueiam o gate; documento especializado posterior prevalece apenas no domínio correspondente e com registro.
+
+## 8. Procedimento
+
+1. Ler o checklist e marcar aplicabilidade, método e evidência de cada item.
+2. Comparar baseline e implementação para localizar mudanças autorizadas e inesperadas.
+3. Conferir copy, links, claims, preços, métricas e estrutura contra fontes aprovadas.
+4. Inspecionar HTML, CSS, JavaScript, SVG e assets por integridade, semântica e referências quebradas.
+5. Executar apenas comandos locais já disponíveis e permitidos; registrar comando e resultado real.
+6. Testar 390, 768, 1024 e 1440 px para layout, overflow, legibilidade e interação.
+7. Verificar acessibilidade básica: estrutura semântica, teclado, foco, nomes acessíveis, contraste e texto alternativo.
+8. Verificar console e comportamento de runtime, quando houver ambiente local executável.
+9. Auditar Git para arquivos inesperados, fora do escopo ou não autorizados.
+10. Se houver arquivos untracked, inspecioná-los diretamente: `git diff --check` não os cobre. Verificar trailing whitespace, tabs acidentais, encoding, arquivos vazios, marcadores `TODO`/`FIXME` não intencionais, headings duplicados quando pertinente e referências ou caminhos obviamente quebrados.
+11. Não executar `git add` nem `git add -N` para viabilizar a auditoria.
+12. Classificar cada achado por severidade e responsável.
+13. Emitir resultado sem corrigir durante o gate.
+
+## 9. Saídas esperadas
+
+- Checklist preenchido com evidência, resultado e observação.
+- Lista de achados bloqueadores e warnings.
+- Relação de mudanças autorizadas e inesperadas.
+- Decisão final `PASS`, `PASS_WITH_WARNINGS` ou `BLOCKED`.
+
+`PASS_WITH_WARNINGS` só admite riscos não factuais, não estruturais e aceitos explicitamente. Nenhum critério nominal de `BLOCKED` pode ser rebaixado silenciosamente para `PASS_WITH_WARNINGS`.
+
+## 10. Critérios de parada
+
+Parar com `BLOCKED` diante de qualquer uma destas condições:
+
+- baseline alterada ou violada;
+- arquivo criado ou modificado fora do escopo autorizado;
+- alteração factual inesperada;
+- copy não autorizada;
+- link não autorizado;
+- claim não validado;
+- asset sem autorização quando exigível;
+- erro crítico de responsividade;
+- erro crítico de acessibilidade;
+- erro de runtime que impeça ou prejudique o uso essencial;
+- fonte crítica ausente ou impossibilidade de comprovar teste necessário.
+
+## 11. Checkpoints humanos
+
+- Validar fidelidade visual e experiência nos quatro viewports.
+- Resolver ou aceitar warnings não bloqueadores.
+- Aprovar correções em execução separada e reexecutar o gate.
+- Aceitar o resultado antes de encaminhar ao release.
+
+## 12. Proteções
+
+O `AGENTS.md` raiz prevalece. O gate é somente leitura e não modifica plugin, matriz, baseline ou código. Não inventar evidência nem ler secrets. Não autoriza commit, push ou Preview. Production é proibida.
+
+## 13. Integração com a matriz
+
+Compor, sem duplicar, conceitos de `revisor-qualidade`, `validate_output.py`, `page_audit.py` e `page_audit_deep.py`. Esses componentes podem ser consultados e, em execução futura, usados apenas se forem compatíveis e não escreverem dados não autorizados. O gate local adiciona baseline, escopo, Git, runtime e release readiness.
+
+## 14. Ferramentas reutilizáveis
+
+- Disponíveis: Git, `rg` e inspeção estática.
+- Disponíveis na matriz: revisores e scripts citados, sem garantia de execução segura neste fluxo.
+- Condicionais: executor local e ferramentas nativas do navegador; descobrir e confirmar sua disponibilidade e adequação antes do uso.
+- Dependências futuras: Playwright, axe ou equivalentes quando não estiverem presentes e autorizados; não instalar automaticamente.
+- Planejadas: screenshot/diff visual, auditor automatizado de links e suíte multi-viewport integrada.
+- Humanas: estética, contexto de marca, claims e aceitação de warnings.
+- Proibidas: correção automática, instalação de dependências e diagnóstico que escreva em cliente/cache sem aprovação.
+
+## 15. Ações proibidas
+
+- Corrigir código durante o gate ou reclassificar falha para avançar o fluxo.
+- Marcar como testado o que foi apenas inspecionado ou planejado.
+- Ignorar arquivo inesperado, mudança factual ou estrutural.
+- Executar `git add` ou `git add -N` apenas para tornar arquivos untracked visíveis à auditoria.
+- Fazer commit, push, Preview ou Production.
+
+## 16. Definição de sucesso
+
+O resultado é reproduzível, cobre todo o checklist aplicável, distingue evidência automática de avaliação humana e impede release diante de qualquer desvio crítico ou não autorizado.

--- a/.claude/skills/designer-lp-quality-gate/references/quality-checklist.md
+++ b/.claude/skills/designer-lp-quality-gate/references/quality-checklist.md
@@ -1,0 +1,91 @@
+# Checklist do quality gate
+
+Usar este checklist como contrato humano legível. Para cada item, registrar `PASS`, `WARNING`, `BLOCKED` ou `N/A`, o método (`disponível`, `planejado` ou `humano`) e a evidência. Um controle planejado não pode ser marcado como executado.
+
+## Conteúdo
+
+- Copy idêntica à versão explicitamente aprovada ou alteração autorizada registrada.
+- Links idênticos aos confirmados e destinos essenciais verificados.
+- Claims, preços, métricas, depoimentos e condições comerciais possuem fonte aprovada.
+- Nenhum placeholder plausível, fato inventado ou conteúdo externo incorporado.
+- Estrutura e sequência comercial preservadas, salvo autorização explícita.
+- Conflitos de precedência resolvidos e registrados.
+
+## Design
+
+- Implementação comparada com a baseline imutável.
+- Mudanças limitadas à seção e aos arquivos autorizados.
+- Tipografia, cores, espaçamento, grid e componentes coerentes com o Manual aprovado.
+- Hierarquia visual e ações principais são claras.
+- Assimetria, ícones e elementos decorativos possuem função e sistema coerente.
+- Revisão estética humana concluída.
+
+## Acessibilidade
+
+- Estrutura de headings é lógica e existe landmark principal.
+- Controles são acessíveis por teclado e possuem foco visível.
+- Botões, links, formulários e ícones interativos têm nomes acessíveis.
+- Imagens informativas têm texto alternativo; decorativas são corretamente ignoradas.
+- Contraste e legibilidade foram avaliados.
+- Não há dependência exclusiva de cor, hover ou movimento.
+- Preferência de movimento reduzido é respeitada quando aplicável.
+
+## Responsividade
+
+- Viewports 390, 768, 1024 e 1440 px foram verificados.
+- Não há overflow horizontal não intencional.
+- Conteúdo, navegação e CTAs permanecem legíveis e utilizáveis.
+- Imagens mantêm proporção, crop intencional e resolução suficiente.
+- Quebras de texto não ocultam conteúdo nem alteram significado.
+- Estados interativos funcionam com mouse, teclado e toque quando aplicável.
+
+## Código e runtime
+
+- HTML possui semântica válida e referências locais resolvíveis.
+- CSS não introduz regra global inesperada ou dependência implícita.
+- JavaScript não apresenta erro de sintaxe nem falha observada no console.
+- Interações preservam comportamento e progressive enhancement quando aplicável.
+- SVGs não contêm IDs conflitantes, conteúdo indevido ou dimensões quebradas.
+- Dependências são existentes e autorizadas; nenhuma foi instalada pelo gate.
+- Execução local foi comprovada ou a impossibilidade está marcada como bloqueio.
+
+## Assets
+
+- Cada asset usado possui origem e autorização conhecidas.
+- Original permanece preservado e derivados são rastreáveis.
+- Dimensões, formato, peso, crop, fallback e papel estão documentados.
+- `picture`, `srcset` e `sizes` são coerentes quando há variantes responsivas.
+- Nenhum stock foi incluído automaticamente.
+- Base64 de protótipo está substituído ou explicitamente bloqueado para produção.
+- Não há asset quebrado, ausente ou inesperadamente substituído.
+
+## Git e escopo
+
+- Branch corresponde à execução aprovada.
+- Worktree foi auditado antes e depois dos testes.
+- Somente arquivos e seção autorizados foram alterados.
+- Não há arquivo inesperado, secret, cache, temporário ou build gerado.
+- `reference/`, plugin e outputs protegidos permanecem intocados.
+- `git diff --check` não reporta erro.
+- Arquivos untracked foram inspecionados diretamente, pois `git diff --check` não cobre arquivos ainda não adicionados ao índice.
+- A inspeção direta de untracked verificou trailing whitespace, tabs acidentais, encoding, arquivos vazios, marcadores `TODO`/`FIXME` não intencionais, headings duplicados quando pertinente e referências ou caminhos obviamente quebrados.
+- Nenhum `git add` ou `git add -N` foi executado apenas para viabilizar a auditoria.
+- Commit e push não foram realizados sem aprovação separada.
+
+## Release readiness
+
+- Testes locais aplicáveis foram concluídos com evidência.
+- Resultado global é `PASS` ou `PASS_WITH_WARNINGS` aceito por humano.
+- Warnings possuem responsável, impacto e decisão registrada.
+- Branch, commit pretendido e diretório de projeto estão identificados.
+- Projeto/equipe Vercel não são presumidos.
+- Autorização de Preview ainda será solicitada separadamente.
+- Nenhuma ação de Production, domínio ou alias de produção está habilitada.
+
+## Regra de decisão
+
+- `PASS`: todos os itens aplicáveis passaram e não há warnings abertos.
+- `PASS_WITH_WARNINGS`: somente riscos não factuais e não estruturais foram aceitos explicitamente por responsável humano.
+- `BLOCKED`: baseline alterada ou violada; arquivo criado/modificado fora do escopo autorizado; alteração factual inesperada; copy ou link não autorizado; claim não validado; asset sem autorização quando exigível; erro crítico de responsividade ou acessibilidade; erro de runtime que impeça ou prejudique uso essencial; ou qualquer outra falha crítica ou evidência obrigatória ausente.
+
+Essas condições, assim como mudanças factuais, estruturais, de copy, link, claim, preço, métrica ou asset, nunca podem ser rebaixadas silenciosamente a warning ou `PASS_WITH_WARNINGS`. O gate identifica, classifica e bloqueia; não corrige automaticamente.

--- a/.claude/skills/designer-lp-release/SKILL.md
+++ b/.claude/skills/designer-lp-release/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: designer-lp-release
+description: Preparar uma landing page aprovada para release controlado e, somente com autorização explícita, habilitar uma Vercel Preview. Usar após quality gate válido; não usar para Production, domínio, alias de produção, projeto não confirmado ou deploy automático.
+area: designer
+author: nicolaskobayashi-v4
+version: 1.0.0
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta skill foi portada do repositorio v4-unidade-integrada. As regras abaixo tem precedencia sobre caminhos, zonas e ferramentas citados no corpo original:
+
+- **Posicao no fluxo.** Este pipeline fica a jusante de `designer-landing-page`, que e a porta do hub para `ee-s3-landing-page`. O `designer-landing-page` responde por estrategia, copy e geracao de codigo. Este pipeline responde por baseline, adaptacao, assets, quality gate e release controlada. O passo `vercel --yes --prod` do `designer-landing-page` fica **suspenso** quando o pipeline estiver em uso: release passa por `designer-lp-release`, e Production continua proibida.
+- **Governanca.** Onde o corpo cita "o `AGENTS.md` raiz prevalece", leia o `CLAUDE.md` e o `AGENTS.md` da raiz do hub mais o `CLAUDE.md` da KB do cliente. Nenhuma regra local pode enfraquece-los.
+- **Zonas somente leitura.** Onde o corpo cita "matriz" e "plugin", leia: `.claude/skills/`, `.agents/skills/` e `REGISTRY.md` sao somente leitura durante o pipeline. `REGISTRY.md` e auto-gerado e nunca se edita a mao.
+- **Caminhos.** Trabalhe em `squads/{squad}/clientes/{cliente}/`. A estrutura do projeto e `squads/{squad}/clientes/{cliente}/outputs/landing-pages/<projeto>/`, com `reference/` e `src/` dentro dela.
+- **`client.json`.** Opcional no hub. So a KB migrada do EE tem esse arquivo. Se nao existir, derive o contexto de `CLAUDE.md`, `mission-control/`, `docs/` e `links.md`, e nao invente o arquivo.
+- **Scripts da matriz.** `validate_output.py`, `page_audit.py`, `page_audit_deep.py` e o agente `revisor-qualidade` **nao existem no hub**. Onde o corpo os cita, declare o gap e faca a verificacao equivalente a mao, registrando o que foi checado e como.
+- **Vercel.** O hub nao tem projeto Vercel configurado. Preview exige configurar o projeto antes e autorizacao explicita do usuario na hora. Production permanece proibida por esta skill.
+- **Registro.** Decisao, gate aprovado e bloqueio vao para `mission-control/historico-checkins.md` da KB do cliente.
+- **Git.** Nunca commite `squads/` nem `bases/`. Sao pessoais e ficam no `.gitignore`.
+
+---
+
+
+# LP Release
+
+## 1. Propósito
+
+Verificar a identidade exata do artefato e todas as aprovações necessárias antes de uma eventual Vercel Preview, mantendo Production tecnicamente e processualmente fora do fluxo.
+
+Ao executar, ler [references/release-policy.md](references/release-policy.md) integralmente.
+
+## 2. Quando usar
+
+- Depois de `quality_gate_passed`.
+- Para preparar o pacote de evidências de release.
+- Para executar uma Preview somente após autorização humana explícita e específica.
+
+## 3. Quando NÃO usar
+
+- Com quality gate `BLOCKED`, expirado por novas mudanças ou warnings não aceitos.
+- Para Production, alias de produção, domínio ou promoção de Preview.
+- Sem confirmação de projeto, equipe, diretório, branch e commit.
+- Para criar projeto Vercel por inferência ou aceitar configuração desconhecida.
+
+## 4. Pré-condições
+
+1. Ter `PASS` ou `PASS_WITH_WARNINGS` aceito por responsável humano.
+2. Confirmar que testes locais foram concluídos.
+3. Auditar branch, commit pretendido e worktree.
+4. Identificar destino de Preview sem fazer deploy.
+5. Obter autorização explícita separada para commit, push e Preview conforme cada operação necessária.
+
+## 5. Entradas
+
+- Relatório mais recente do quality gate e suas evidências.
+- Diretório exato da implementação.
+- Branch, commit pretendido e estado do worktree.
+- Projeto e equipe Vercel confirmados pelo responsável.
+- Metadados locais `.vercel/project.json`, se existirem, sem secrets.
+- Autorizações humanas com escopo e momento.
+
+## 6. Fontes permitidas
+
+- Estado local do Git e arquivos de configuração não secretos.
+- Quality gate aprovado e registros de autorização.
+- Confirmações explícitas do responsável.
+- Painel ou CLI Vercel somente quando a execução de Preview for autorizada.
+
+Não inferir destino por nome de pasta, histórico de outro cliente ou configuração semelhante.
+
+## 7. Precedência das fontes
+
+- Fatos: confirmação explícita mais recente → `client.json` → base estratégica aprovada → outputs estratégicos aprovados → implementação existente.
+- Visual: confirmação explícita mais recente → Manual de Marca aprovado mais recente → diagnóstico visual aprovado → assets oficiais → referências externas → implementação existente.
+- Copy: copy explicitamente aprovada → output estratégico de landing page aprovado → implementação existente.
+- Links: confirmação explícita → implementação existente aprovada.
+
+Registrar todo conflito de precedência. Para destino de release, vale apenas confirmação explícita do projeto/equipe e configuração local coerente. Qualquer conflito bloqueia; posicionamento, CRO, diagnóstico ou outro output estratégico não substituem silenciosamente a copy específica aprovada da landing page.
+
+## 8. Procedimento
+
+1. Confirmar que o relatório do quality gate corresponde ao estado atual dos arquivos.
+2. Verificar branch, commit pretendido, worktree e diferenças desde o gate.
+3. Confirmar o diretório exato que seria enviado.
+4. Confirmar projeto e equipe Vercel com o responsável.
+5. Se `.vercel/project.json` existir, conferir identidade do projeto sem expor tokens; divergência bloqueia.
+6. Confirmar que não haverá criação automática de projeto, domínio ou alias.
+7. Confirmar que nenhuma opção, script ou configuração aciona Production.
+8. Preparar um resumo com artefato, destino, evidências, warnings aceitos e comando proposto.
+9. Solicitar autorização explícita de Vercel Preview imediatamente antes da ação.
+10. Somente depois da autorização, executar exclusivamente a Preview aprovada.
+11. Registrar URL de Preview e evidência de que nenhum domínio/alias de produção foi alterado.
+12. Encaminhar a URL para revisão humana; não promover o deploy.
+
+## 9. Saídas esperadas
+
+- Checklist de release e identidade do artefato.
+- Destino de Preview confirmado, ou estado `BLOCKED`.
+- Comando/ação de Preview proposto antes da execução.
+- Se autorizado, URL de Preview e registro de revisão pendente.
+
+## 10. Critérios de parada
+
+Parar se houver arquivo alterado após o gate, worktree inesperado, projeto/equipe/diretório não confirmado, configuração divergente, autorização ambígua ou qualquer indício de Production. Falta de dado crítico sempre produz `STOP`.
+
+## 11. Checkpoints humanos
+
+- Aceitar warnings do quality gate, se houver.
+- Autorizar commit e push separadamente, se necessários.
+- Confirmar projeto, equipe e diretório.
+- Autorizar explicitamente a Vercel Preview.
+- Revisar a Preview antes de qualquer decisão posterior.
+
+## 12. Proteções
+
+O `AGENTS.md` raiz prevalece. Plugin, matriz, original e baseline são somente leitura. Preview não equivale a Production. Production, domínio e alias de produção permanecem proibidos. Não ler nem exibir tokens ou secrets.
+
+## 13. Integração com a matriz
+
+Consumir outputs e validações aprovados da matriz, mas rejeitar comandos incompatíveis, inclusive qualquer `vercel --prod` ou mutação de cliente/cache. Esta skill estende a matriz com gates locais de destino, Git e aprovação; não altera os componentes matriciais.
+
+## 14. Ferramentas reutilizáveis
+
+- Disponíveis: Git e inspeção local de configuração não secreta.
+- Condicional: Vercel CLI somente se já disponível, destino confirmado e Preview explicitamente autorizada.
+- Planejadas: verificador dedicado de release; não implementado nesta fase.
+- Humanas: confirmação de destino, autorização e homologação da Preview.
+- Proibidas: `vercel --prod`, promoção, domínio, alias de produção e criação automática de projeto.
+
+## 15. Ações proibidas
+
+- Executar Production direta ou indiretamente.
+- Usar `vercel --prod`, promover Preview ou configurar domínio/alias de produção.
+- Fazer deploy para projeto ou equipe não confirmados.
+- Criar projeto Vercel automaticamente.
+- Tratar autorização de escrita, commit ou push como autorização de Preview.
+
+## 16. Definição de sucesso
+
+O artefato e o destino estão inequivocamente identificados, todos os gates foram respeitados e, quando expressamente autorizada, somente uma Preview isolada é criada para revisão humana, sem efeito em Production.

--- a/.claude/skills/designer-lp-release/references/release-policy.md
+++ b/.claude/skills/designer-lp-release/references/release-policy.md
@@ -1,0 +1,80 @@
+# Política de release de landing pages
+
+## Princípio central
+
+Vercel Preview não é Production. A camada de produção de landing pages encerra sua responsabilidade na preparação e, quando autorizada, na criação de uma Preview isolada para homologação humana.
+
+Production está desabilitada neste fluxo.
+
+## Estados permitidos
+
+- `release_not_ready`: quality gate ausente, inválido ou desatualizado.
+- `release_ready`: artefato e destino conferidos; Preview ainda não autorizada.
+- `preview_authorized`: responsável autorizou explicitamente uma Preview específica.
+- `preview_created`: URL de Preview registrada e aguardando revisão humana.
+- `human_approved`: Preview revisada; não implica autorização de Production.
+- `blocked`: requisito, identidade ou autorização ausente ou conflitante.
+
+Não existe estado `production_authorized` neste contrato.
+
+## Checklist anterior à Preview
+
+Verificar e registrar:
+
+1. Projeto/cliente e diretório exato da implementação.
+2. Branch correta.
+3. Commit pretendido e sua relação com os arquivos avaliados.
+4. Worktree limpo ou diferenças explicitamente compreendidas e aprovadas.
+5. Quality gate atual em `PASS` ou `PASS_WITH_WARNINGS` aceito.
+6. Testes locais concluídos.
+7. Projeto e equipe Vercel confirmados pelo responsável.
+8. `.vercel/project.json`, se existir, coerente com a confirmação e lido sem expor secrets.
+9. Ausência de criação automática de projeto.
+10. Ausência de flags, scripts ou configurações de Production.
+11. Autorização humana explícita para esta Preview, após apresentação do destino e da ação.
+
+Se qualquer item falhar, retornar `blocked` sem deploy.
+
+## Autorizações independentes
+
+- Aprovação de edição não autoriza commit.
+- Aprovação de commit não autoriza push.
+- Aprovação de push não autoriza Preview.
+- Aprovação de Preview não autoriza Production, promoção, domínio ou alias.
+- Homologação humana da Preview não cria autorização implícita para Production.
+
+Cada operação exige consentimento explícito no seu próprio contexto.
+
+## Ações permitidas
+
+- Inspecionar estado Git e configurações locais não secretas.
+- Preparar o resumo de release sem executar deploy.
+- Executar somente a Vercel Preview descrita e autorizada.
+- Registrar a URL de Preview e encaminhá-la para revisão humana.
+
+## Ações proibidas
+
+- Executar `vercel --prod` ou qualquer equivalente.
+- Promover Preview para Production.
+- Criar ou alterar domínio ou alias de produção.
+- Selecionar projeto/equipe por inferência.
+- Criar projeto Vercel automaticamente.
+- Ler, copiar, registrar ou exibir credenciais, tokens ou `.env`.
+- Modificar código, copy, link, asset ou configuração durante o release.
+- Fazer commit ou push sem autorização específica.
+
+## Mudança após o quality gate
+
+Qualquer alteração no artefato, dependência ou configuração depois do gate invalida a decisão anterior. Retornar ao `designer-lp-quality-gate` antes de solicitar nova autorização de Preview.
+
+## Registro mínimo
+
+Registrar sem secrets:
+
+- data e responsável pela autorização;
+- branch, commit e estado do worktree;
+- diretório e projeto/equipe confirmados;
+- resultado do quality gate;
+- ação executada;
+- URL da Preview;
+- confirmação de que Production, domínio e alias permaneceram intocados.

--- a/.claude/skills/designer-lp-source-audit/SKILL.md
+++ b/.claude/skills/designer-lp-source-audit/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: designer-lp-source-audit
+description: Auditar somente em leitura as fontes disponíveis para uma landing page e determinar a implementação correta e seu grau de prontidão. Usar antes de baseline, design ou retomada de projeto; não usar para editar arquivos, produzir estratégia ou corrigir automaticamente lacunas.
+area: designer
+author: nicolaskobayashi-v4
+version: 1.0.0
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta skill foi portada do repositorio v4-unidade-integrada. As regras abaixo tem precedencia sobre caminhos, zonas e ferramentas citados no corpo original:
+
+- **Posicao no fluxo.** Este pipeline fica a jusante de `designer-landing-page`, que e a porta do hub para `ee-s3-landing-page`. O `designer-landing-page` responde por estrategia, copy e geracao de codigo. Este pipeline responde por baseline, adaptacao, assets, quality gate e release controlada. O passo `vercel --yes --prod` do `designer-landing-page` fica **suspenso** quando o pipeline estiver em uso: release passa por `designer-lp-release`, e Production continua proibida.
+- **Governanca.** Onde o corpo cita "o `AGENTS.md` raiz prevalece", leia o `CLAUDE.md` e o `AGENTS.md` da raiz do hub mais o `CLAUDE.md` da KB do cliente. Nenhuma regra local pode enfraquece-los.
+- **Zonas somente leitura.** Onde o corpo cita "matriz" e "plugin", leia: `.claude/skills/`, `.agents/skills/` e `REGISTRY.md` sao somente leitura durante o pipeline. `REGISTRY.md` e auto-gerado e nunca se edita a mao.
+- **Caminhos.** Trabalhe em `squads/{squad}/clientes/{cliente}/`. A estrutura do projeto e `squads/{squad}/clientes/{cliente}/outputs/landing-pages/<projeto>/`, com `reference/` e `src/` dentro dela.
+- **`client.json`.** Opcional no hub. So a KB migrada do EE tem esse arquivo. Se nao existir, derive o contexto de `CLAUDE.md`, `mission-control/`, `docs/` e `links.md`, e nao invente o arquivo.
+- **Scripts da matriz.** `validate_output.py`, `page_audit.py`, `page_audit_deep.py` e o agente `revisor-qualidade` **nao existem no hub**. Onde o corpo os cita, declare o gap e faca a verificacao equivalente a mao, registrando o que foi checado e como.
+- **Vercel.** O hub nao tem projeto Vercel configurado. Preview exige configurar o projeto antes e autorizacao explicita do usuario na hora. Production permanece proibida por esta skill.
+- **Registro.** Decisao, gate aprovado e bloqueio vao para `mission-control/historico-checkins.md` da KB do cliente.
+- **Git.** Nunca commite `squads/` nem `bases/`. Sao pessoais e ficam no `.gitignore`.
+
+---
+
+
+# LP Source Audit
+
+## 1. Propósito
+
+Determinar, com evidência rastreável, qual implementação e quais fontes devem alimentar a landing page, identificando versões duplicadas, conflitos e lacunas antes de qualquer escrita.
+
+## 2. Quando usar
+
+- No início de uma produção ou retomada de landing page.
+- Quando existirem múltiplas versões de HTML, CSS, JavaScript ou assets.
+- Quando não estiver claro se copy, links, claims e referências visuais estão aprovados.
+
+## 3. Quando NÃO usar
+
+- Para editar, normalizar, mover ou excluir arquivos.
+- Para executar diagnósticos que escrevam cache ou dados do cliente.
+- Para inventar conteúdo ausente ou escolher silenciosamente entre fontes conflitantes.
+
+## 4. Pré-condições
+
+1. Ler as instruções de governança aplicáveis.
+2. Confirmar branch, worktree, cliente e escopo da landing page.
+3. Definir diretórios permitidos para leitura e excluir secrets.
+4. Confirmar que plugin, Figma original e outputs existentes são somente leitura.
+
+## 5. Entradas
+
+- `client.json`, base de conhecimento e outputs estratégicos aprovados.
+- Output estratégico de landing page, se existir.
+- Implementações HTML, CSS e JavaScript candidatas.
+- Assets, Manual de Marca, diagnóstico visual, posicionamento, CRO e diagnóstico de criativos.
+- Copy, links, claims, dependências e fontes externas explicitamente indicadas.
+
+## 6. Fontes permitidas
+
+- Fontes internas aprovadas do cliente e histórico Git.
+- Implementações e referências existentes em modo somente leitura.
+- Resultados já aprovados da matriz.
+- Referências externas apenas como repertório visual, nunca como fonte factual.
+
+## 7. Precedência das fontes
+
+- Fatos: confirmação explícita mais recente → `client.json` → base estratégica aprovada → outputs estratégicos aprovados → implementação existente.
+- Visual: confirmação explícita mais recente → Manual de Marca aprovado mais recente → diagnóstico visual aprovado → assets oficiais → referências externas → implementação existente.
+- Copy: copy explicitamente aprovada → output estratégico de landing page aprovado → implementação existente.
+- Links: link explicitamente confirmado → implementação existente aprovada.
+
+Documento especializado aprovado posteriormente pode prevalecer em seu domínio com conflito registrado. Não resolver divergências silenciosamente.
+
+## 8. Procedimento
+
+1. Inventariar todos os candidatos de implementação e registrar caminho, função e estado Git.
+2. Localizar o output estratégico de landing page e verificar se é identificável e aprovado.
+3. Mapear HTML, CSS, JavaScript, frameworks, dependências e instruções de execução.
+4. Inventariar assets, variantes, formatos, dimensões conhecidas, origem e referências no código.
+5. Localizar Manual de Marca, diagnóstico visual, posicionamento, CRO e diagnóstico de criativos.
+6. Extrair, sem alterar, a copy, os links e os claims presentes na estratégia e na implementação.
+7. Comparar as fontes segundo a precedência contextual e registrar cada conflito.
+8. Avaliar estrutura responsiva, breakpoints, conteúdo oculto e diferenças relevantes entre versões.
+9. Identificar duplicatas por caminho, conteúdo e hash; não eleger vencedor sem evidência.
+10. Classificar cada requisito como disponível, ausente, conflitante ou dependente de validação humana.
+11. Indicar a implementação recomendada apenas quando a evidência for suficiente; caso contrário, bloquear.
+
+## 9. Saídas esperadas
+
+- Mapa de fontes com caminho, papel, aprovação e precedência.
+- Implementação candidata recomendada e justificativa, ou estado `BLOCKED`.
+- Lista de lacunas, duplicatas, conflitos e dependências.
+- Avaliação de prontidão para criar a baseline.
+
+## 10. Critérios de parada
+
+Parar se a implementação exata não puder ser determinada, se fontes críticas estiverem ausentes, se houver conflito factual, de copy, links ou claims, ou se a inspeção exigir acesso a secret. Toda lacuna crítica produz `STOP`; não criar placeholders plausíveis.
+
+## 11. Checkpoints humanos
+
+- Confirmar a implementação candidata e a versão estratégica correta.
+- Resolver conflitos de copy, links, claims e assets.
+- Aprovar a passagem para `designer-lp-baseline-prepare`.
+
+## 12. Proteções
+
+O `AGENTS.md` raiz prevalece. Esta auditoria é estritamente somente leitura: não modificar plugin, matriz, cliente, output, Figma ou referência. Não ler `.env` ou credenciais. Não autoriza copy, assets, commit, push, Preview ou Production; Production permanece proibida.
+
+## 13. Integração com a matriz
+
+Consultar conceitualmente `ee-s3-landing-page`, Manual de Marca, posicionamento, diagnóstico CRO, diagnóstico de criativos, `revisor-qualidade`, `validate_output.py`, `page_audit.py` e `page_audit_deep.py`. Consumir apenas resultados aprovados; não executar rotinas incompatíveis que escrevam cache, cliente, deploy ou produção.
+
+## 14. Ferramentas reutilizáveis
+
+- Disponíveis: `rg`, `rg --files`, `Get-FileHash`, Git e inspeção estática de HTML/CSS/JS.
+- Disponíveis para consulta: scripts de auditoria da matriz; sua execução não é pressuposta.
+- Planejadas: inventário normalizado e detector genérico de links/assets, ainda não implementados.
+- Humanas: confirmação de aprovação, leitura estética e validação de claims.
+- Proibidas: crawlers ou diagnósticos que façam escrita não autorizada.
+
+## 15. Ações proibidas
+
+- Corrigir arquivos durante a auditoria.
+- Executar deploy, instalar dependências ou criar outputs auxiliares.
+- Tratar referência externa como fato ou copiar identidade, código, estrutura completa ou assets externos.
+- Fazer commit ou push.
+
+## 16. Definição de sucesso
+
+Existe uma decisão auditável sobre qual implementação e quais fontes são válidas, com prontidão, conflitos e lacunas explícitos, sem qualquer mutação do workspace ou das fontes.


### PR DESCRIPTION
## O que é

Sete skills que quebram a produção de landing page em etapas com gate humano entre elas, no lugar de uma skill única que decide e publica sozinha.

| Skill | Faz |
|---|---|
| `designer-lp-source-audit` | Auditoria read-only das fontes, determina qual é a implementação correta |
| `designer-lp-baseline-prepare` | Baseline imutável + cópia de trabalho isolada |
| `designer-lp-design-adapter` | Adaptação visual por seção, com conteúdo/claims/links congelados |
| `designer-lp-asset-pipeline` | Assets com rastreabilidade de origem, direitos e derivados |
| `designer-lp-quality-gate` | Gate integrado antes do release |
| `designer-lp-release` | Preview só com autorização explícita; Production proibido |
| `designer-lp-orchestrator` | Decide a próxima etapa segura e retoma execução |

Inclui também `designer-landing-page` (estratégia, copy e código), que ainda não estava no hub. Ela passa a ceder precedência ao pipeline quando ele estiver em uso e não roda mais `vercel --prod` por conta própria.

## Por que em etapas

Cada skill tem um "não usar para" explícito. Nenhuma delas edita a referência original, troca asset sem aprovação ou publica em Production. O orchestrator só aponta a próxima etapa — quem aprova é a pessoa.

## Checagens

- Duplo-write verificado: `.claude/skills/` e `.agents/skills/` idênticos
- Frontmatter com `name`, `description`, `area`, `author`, `version` em todas
- `REGISTRY.md` fora do PR — a Action regenera no merge
- Sem arquivos de `squads/` ou `bases/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)