### PR TITLE
feat(skills): designer-criativos-anuncios e designer-manual-marca

### DIFF
--- a/.agents/skills/designer-criativos-anuncios/SKILL.md
+++ b/.agents/skills/designer-criativos-anuncios/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: designer-criativos-anuncios
+description: "Cria o briefing criativo para anúncios: 5 variações com hooks diferentes, prompts Midjourney/Ideogram e organização do pack. Semi-manual — operador gera imagens externamente. Use quando disser /designer-criativos-anuncios ou 'criativos de ads' ou 'pack de anúncios' ou 'imagens para anúncio'."
+area: designer
+author: luizfreitasv4
+version: 1.0.0
+dependencies:
+  - designer-manual-marca
+  - gt-diagnostico-criativos
+inputs:
+  - client.json (briefing)
+  - designer-manual-marca.json
+  - gt-diagnostico-criativos.json
+output: designer-criativos-anuncios.json
+week: 4
+type: semi-manual
+estimated_time: "4h"
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta versao foi portada do sistema de Estruturacao Estrategica. As regras abaixo tem precedencia sobre caminhos e persistencia citados no fluxo original:
+
+- Trabalhe somente em `squads/{squad}/clientes/{cliente}/`, nunca em um diretorio `clientes/` solto na raiz.
+- Leia primeiro o `CLAUDE.md` ou `AGENTS.md` da KB, `mission-control/`, `calls/`, `docs/` e `campanhas/`.
+- Se `client.json` existir, use-o como fonte complementar. Se nao existir, derive o contexto da KB e do Mission Control; nao exija nem invente esse arquivo.
+- Salve entregaveis em `squads/{squad}/clientes/{cliente}/outputs/`, em JSON e Markdown quando o fluxo pedir ambos.
+- Registre decisoes e progresso no `mission-control/historico-checkins.md` ou no arquivo de historico equivalente encontrado na KB.
+- Resolva recursos empacotados a partir do proprio diretorio desta skill. Se uma integracao externa nao estiver configurada, declare o gap e continue apenas com os dados reais disponiveis.
+
+
+# Criativos de Anúncios — Briefing + Prompts + Pack (POP 3.11)
+
+> **Posição no fluxo:** Semana 4 — Identidade de Comunicação e Plano de Mídia (**comum** a todos os modelos) (e-commerce / inside-sales / pdv). Entregável-alvo do POP 3.11: **4 criativos finalizados**, **1 ângulo distinto por peça**, cada um **amarrado a uma fase de funil** e com **hipótese de teste** documentada + **nomenclatura** `fase_ângulo_formato_versão`. (A 5ª variação abaixo é reserva opcional.)
+
+Você é um diretor criativo especializado em performance marketing para PMEs brasileiras. Vai criar o briefing criativo completo para a primeira rodada de anúncios: 4 variações com ângulos distintos (hook diferente), cada uma testando uma hipótese e amarrada a uma fase de funil.
+
+## Dados necessários
+
+1. `client.json` (seção `briefing`) — nome, segmento, produto/serviço, objetivo da campanha, CTA principal
+2. `outputs/designer-manual-marca.json` — tom de voz, vocabulário, headlines, paleta, tipografia, conceito visual (substitui os antigos brandbook + identidade-visual)
+3. `outputs/gt-diagnostico-criativos.json` — análise dos criativos atuais, o que funciona/não funciona, recomendações
+5. `client.json` (seção `history`) — decisões anteriores
+
+Se alguma dependência faltar, avise o operador.
+
+---
+
+## Geração
+
+Gere o output COMPLETO de uma vez: briefing criativo com **4 variações** (1 ângulo distinto cada, amarrada a uma fase de funil) + prompts Midjourney/Ideogram + guias de montagem + hipótese e nomenclatura por peça. Use os dados de `client.json` (briefing) e outputs de skills dependentes em `outputs/`.
+
+Consulte `references/hooks-que-funcionam.md` para fórmulas de hook testadas.
+
+### 4 variações de criativo, cada uma com ângulo/hook distinto e fase de funil
+> (A Variação 5 abaixo é **reserva opcional** — use se quiser um 5º ângulo para a primeira leva.)
+
+**Variação 1 — Hook de Dor/Problema:** espelha a frustração do ICP
+**Variação 2 — Hook de Resultado/Transformação:** mostra o "depois"
+**Variação 3 — Hook de Curiosidade/Pergunta:** gera clique
+**Variação 4 — Hook de Prova Social/Número:** dado concreto, caso real
+**Variação 5 — Hook de Urgência/Escassez:** escassez real
+
+Para cada variação:
+1. Hook type + Hook text (máx. 10 palavras)
+2. Copy curta (até 50 palavras) + Copy média (50-100 palavras)
+3. Headline do anúncio (máx. 30 chars) + Descrição (máx. 90 chars) + CTA do botão
+4. Conceito visual (descrição detalhada da imagem/composição)
+5. Formato recomendado (feed 1080x1080 / 1080x1350 / stories 1080x1920 / carrossel)
+
+### Prompts Midjourney/Ideogram para cada variação
+
+**Prompt Midjourney:** tipo de output, cena/composição, cores hex, estilo, parâmetros (--v 6/7, --ar), negativos
+**Prompt Ideogram:** se tiver texto, incluir texto exato + tipografia + layout
+**Guia de montagem (Canva):** posição do texto, tamanho mínimo de fonte (24pt+), posição do logo, formatos de exportação
+
+### Guia de teste A/B
+
+Combinações de teste, métricas de sucesso (CTR > X%, CPC < R$ Y), prazo de teste (7 dias mínimo), critério de corte.
+
+## Auto-validação
+
+Antes de mostrar ao operador, verifique:
+
+- [ ] Mencionou o cliente pelo nome?
+- [ ] Usou dados reais do client.json (não inventou)?
+- [ ] Nenhum item genérico (ex: "quer crescer", "qualidade e compromisso")?
+- [ ] Schema da skill validou?
+- [ ] Todos os campos do schema preenchidos (ou com `null` + `unavailable_reason` no pai)?
+- [ ] Nenhuma string vazia (`""`) — substituí por `null` + reason quando o dado não existe?
+- [ ] Estimativas marcadas com `estimated: true` ou `[E]`?
+- [ ] Consistente com outputs anteriores (brandbook, identidade visual)?
+- [ ] Hooks são específicos para o ICP (não genéricos)?
+- [ ] Conceitos visuais são factíveis no Midjourney/Ideogram?
+- [ ] Cada variação testa uma hipótese DIFERENTE (não variações do mesmo)?
+
+Se falhou → regenere silenciosamente. Não avise o operador.
+
+## Apresentação e decisões
+
+Apresente o output COMPLETO ao operador — 5 variações com hooks, prompts e guias.
+
+Revise o output. O que está errado, exagerado ou faltando?
+
+- "Os hooks são específicos para o ICP?"
+- "Os conceitos visuais são factíveis?"
+- "O tom está alinhado com o brandbook?"
+- "Alguma variação deve ser substituída por outro tipo de hook?"
+- "Alguma restrição de marca? (ex: 'não pode usar vermelho', 'sem fotos de pessoas')"
+
+**Próximo passo (semi-manual):**
+1. Operador copia prompts e gera no Midjourney/Ideogram
+2. Gera pelo menos 4 opções por variação
+3. Seleciona a melhor imagem de cada
+4. Monta no Canva seguindo o guia
+5. Exporta em 3 formatos: 1080x1080 (square), 1080x1350 (feed_portrait), 1080x1920 (stories)
+
+Após o operador gerar e montar, organize o pack (inventário por variação × formato, tabela de copy resumida) e confirme checklist final.
+
+## Registro dos criativos produzidos (`produced_creatives`)
+
+Depois que o operador entrega os PNGs finais, atualize o JSON com o bloco `produced_creatives`. Esse bloco é o que o portal renderiza como grid visual + download direto e é o que `copy-anuncios` referencia via `pair_with_creative`.
+
+**Convenção de hospedagem:**
+- Salvar PNGs em `squads/{squad}/clientes/{cliente}/landing-{slug}/public/photos/criativos/`
+- Naming: `feed-0N.png` (5 unidades, 1080×1350) e `story-0N.png` (3 unidades, 1080×1920)
+- URL pública: `https://{slug}-landing.vercel.app/photos/criativos/{id}.png` após o próximo deploy da landing
+
+**Estrutura do bloco:**
+```json
+"produced_creatives": {
+  "summary": "1-2 frases — quantos foram, formatos, onde estão hospedados.",
+  "feed_instagram": [
+    {
+      "id": "feed-01",
+      "url": "https://{slug}-landing.vercel.app/photos/criativos/feed-01.png",
+      "format": "feed_portrait",
+      "dimensions": "1080×1350",
+      "linked_variation": "social_proof",
+      "caption_label": "Frase curta resumindo o conceito (vai no card)",
+      "use_with_copy": "Hook MOFU prova social — 'ex: 4,9★ + +1.200 clientes'"
+    }
+  ],
+  "stories_instagram": [
+    {
+      "id": "story-01",
+      "url": "...",
+      "format": "stories",
+      "dimensions": "1080×1920",
+      "linked_variation": "dor",
+      "caption_label": "...",
+      "use_with_copy": "..."
+    }
+  ]
+}
+```
+
+**Por que existe:** sem esse bloco, o portal de entregáveis renderiza só copy/donut/variações textuais — o cliente não vê o criativo produzido. `linked_variation` cruza com o `hook_type` da variação correspondente; `use_with_copy` orienta o gestor de tráfego a parear copy + criativo.
+
+## Finalização
+
+Operador aprova (com ou sem ajustes).
+1. Salve em `squads/{squad}/clientes/{cliente}/outputs/designer-criativos-anuncios.json` (com campo `summary` no topo)
+2. Atualize `client.json`: progress.skills → completed, version++, append em history[]
+3. Salve também uma versão Markdown do entregável na mesma pasta de outputs.
+4. Sugira próxima skill do dependency_graph
+
+## Formato do output (designer-criativos-anuncios.json)
+
+```json
+{
+  "variations": [
+    {
+      "hook_type": "dor",
+      "hook_text": "string",
+      "short_copy": "string",
+      "medium_copy": "string",
+      "headline": "string",
+      "description": "string",
+      "button_cta": "string",
+      "visual_concept": "string",
+      "recommended_format": "feed_square | feed_portrait | stories | carousel",
+      "midjourney_prompt": "string",
+      "ideogram_prompt": "string",
+      "canva_guide": "string"
+    }
+  ],
+  "ab_test_guide": {
+    "combinations": ["string"],
+    "success_metrics": { "ctr_min": "string", "cpc_max": "string" },
+    "test_duration": "7 dias",
+    "cut_criteria": "string"
+  },
+  "total_pieces": 15,
+  "produced_creatives": {
+    "summary": "string — só após produção. Ausente até o operador entregar os PNGs.",
+    "feed_instagram": [{ "id": "feed-01", "url": "...", "format": "feed_portrait", "dimensions": "1080×1350", "linked_variation": "social_proof", "caption_label": "...", "use_with_copy": "..." }],
+    "stories_instagram": [{ "id": "story-01", "url": "...", "format": "stories", "dimensions": "1080×1920", "linked_variation": "dor", "caption_label": "...", "use_with_copy": "..." }]
+  }
+}
+```
+
+
+## Campo obrigatório: summary
+
+Sempre inclua no JSON de saída:
+```json
+"summary": "Resumo de 1-2 frases do briefing de criativos: número de variações e formato/gancho principal. Seja específico — mencione o cliente, números reais e a conclusão principal."
+```
+
+Este campo alimenta o Resumo Executivo do portal de entregas. Deve ser objetivo, com dados reais, sem genéricos.

--- a/.agents/skills/designer-criativos-anuncios/references/hooks-que-funcionam.md
+++ b/.agents/skills/designer-criativos-anuncios/references/hooks-que-funcionam.md
@@ -1,0 +1,192 @@
+# Hooks que Funcionam — Fórmulas com Exemplos para Anúncios
+
+Referência de fórmulas de hook testadas em performance marketing para PMEs brasileiras. Cada fórmula inclui a estrutura, por que funciona e exemplos adaptáveis.
+
+---
+
+## 1. Hooks de Dor/Problema
+
+Princípio: O ICP age quando se vê no problema. A dor é mais motivadora que o desejo.
+
+### Fórmula 1: Espelho da frustração
+**Estrutura:** "Cansou de [frustração repetitiva]?"
+- "Cansou de perder clientes pro iFood?"
+- "Cansou de leads que somem depois do primeiro contato?"
+- "Cansou de pagar caro por resultado que não aparece?"
+
+### Fórmula 2: O custo invisível
+**Estrutura:** "Você está perdendo R$ [valor] por [período] porque [causa]"
+- "Você está perdendo R$ 5.000/mês porque ninguém responde seus leads em menos de 1 hora"
+- "Você está perdendo 30% dos clientes porque seu site demora 7 segundos pra carregar"
+- "Cada dia sem follow-up automático custa R$ 200 em leads perdidos"
+
+### Fórmula 3: A pergunta incômoda
+**Estrutura:** "[Pergunta que o ICP evita responder]?"
+- "Quantos leads você perdeu essa semana?"
+- "Quanto do seu faturamento depende do iFood?"
+- "Qual foi a última vez que alguém te indicou espontaneamente?"
+
+### Fórmula 4: O sintoma
+**Estrutura:** "Se [sintoma], [diagnóstico]"
+- "Se seus anúncios geram cliques mas não geram vendas, o problema não é o tráfego"
+- "Se você tem 5.000 seguidores mas 0 vendas pelo Instagram, seu perfil tem um erro"
+- "Se todo mês parece que começa do zero, você não tem um funil — tem uma rifa"
+
+**Por que funciona:** Dor ativa o sistema 1 do cérebro (reação emocional rápida). O ICP reconhece o problema e para o scroll.
+
+---
+
+## 2. Hooks de Resultado/Transformação
+
+Princípio: Mostra o "depois" — o estado desejado que o ICP busca.
+
+### Fórmula 1: De X para Y
+**Estrutura:** "De [estado atual ruim] para [estado desejado] em [prazo]"
+- "De 3 clientes na indicação para 30 leads qualificados por mês"
+- "De planilha no Excel para gestão financeira de verdade em 2 semanas"
+- "De R$ 2.000 em anúncios sem retorno para ROAS de 4x no primeiro mês"
+
+### Fórmula 2: Caso real com nome
+**Estrutura:** "[Nome/empresa] [resultado específico] em [prazo]"
+- "A Cantina Mineira triplicou o delivery em 4 meses"
+- "Dr. Silva lotou a agenda em 60 dias"
+- "A loja da Rua Augusta saiu de 0 para 47 pedidos online por semana"
+
+### Fórmula 3: Número impactante
+**Estrutura:** "[Número específico] + [resultado concreto]"
+- "R$ 12.000 economizados em comissões de marketplace"
+- "347 leads qualificados em 90 dias de campanha"
+- "Atendimento 87% mais rápido com automação de WhatsApp"
+
+### Fórmula 4: A vida depois
+**Estrutura:** "Imagine [cenário desejado realista]"
+- "Imagine abrir o WhatsApp segunda-feira e ter 15 leads novos esperando"
+- "Imagine saber exatamente quanto cada real de anúncio retorna"
+- "Imagine nunca mais perder um lead porque esqueceu de responder"
+
+**Por que funciona:** Resultado ativa aspiração. O ICP se projeta no futuro e deseja estar ali.
+
+---
+
+## 3. Hooks de Curiosidade/Pergunta
+
+Princípio: O cérebro humano não tolera informação incompleta. A curiosidade gera clique.
+
+### Fórmula 1: O erro que todos cometem
+**Estrutura:** "O erro que [número]% dos [ICP] cometem com [tema]"
+- "O erro que 87% dos donos de restaurante cometem com delivery"
+- "O erro que mata a conversão da maioria das landing pages"
+- "3 erros de anúncio que estão queimando seu budget"
+
+### Fórmula 2: O segredo revelado
+**Estrutura:** "O que [autoridade/caso] faz que [ICP] não faz"
+- "O que restaurantes com 4.9 estrelas fazem que você não faz"
+- "O que empresas com ROAS acima de 5x têm em comum"
+- "A única métrica que importa no seu anúncio (e não é o CTR)"
+
+### Fórmula 3: Contraintuitivo
+**Estrutura:** "[Afirmação que contradiz a crença do ICP]"
+- "Mais seguidores NÃO significa mais vendas"
+- "O melhor criativo do mundo não salva uma oferta ruim"
+- "Investir mais em anúncios pode PIORAR seu resultado"
+
+### Fórmula 4: Teste/Quiz
+**Estrutura:** "Descubra [insight sobre si mesmo]"
+- "Descubra em 30 segundos se seu anúncio está queimando dinheiro"
+- "Seu site passa no teste dos 5 segundos? A maioria não passa"
+- "Quiz: seu negócio está pronto para escalar?"
+
+**Por que funciona:** Loop aberto. O cérebro precisa fechar a informação, gerando clique.
+
+---
+
+## 4. Hooks de Prova Social/Número
+
+Princípio: Comportamento de manada. Se muitos estão fazendo, deve ser bom.
+
+### Fórmula 1: Volume impressionante
+**Estrutura:** "+[número] [ICPs] já [ação/resultado]"
+- "+500 PMEs em BH já automatizaram o follow-up de leads"
+- "+1.200 restaurantes saíram da dependência do iFood"
+- "R$ 2 milhões em vendas geradas para nossos clientes em 2025"
+
+### Fórmula 2: Depoimento direto
+**Estrutura:** "[Frase do cliente]" — [Nome, contexto]
+- "Em 60 dias, saí de 3 para 18 leads por semana" — Ana, Clínica Bella
+- "Melhor investimento que fiz no ano" — Carlos, Restaurante do Lago
+- "Finalmente sei pra onde vai cada real" — Mariana, e-commerce de moda
+
+### Fórmula 3: Avaliação/Rating
+**Estrutura:** "[Rating] com base em [número] avaliações"
+- "Avaliado com 4.9★ por 340 clientes"
+- "NPS 92 — 9 em cada 10 clientes nos recomendam"
+- "96% de satisfação medida mês a mês"
+
+### Fórmula 4: Comparação temporal
+**Estrutura:** "Em [período], [resultado mensurável]"
+- "Em 90 dias: 340 leads, 47 vendas, R$ 94.000 em faturamento"
+- "30 dias: de 0 a 12 vendas pelo WhatsApp"
+- "Primeiro mês: o investimento se pagou 3x"
+
+**Por que funciona:** Reduz risco percebido. Se outros iguais a mim tiveram resultado, eu também terei.
+
+---
+
+## 5. Hooks de Urgência/Escassez
+
+Princípio: Medo de perder (FOMO) é mais forte que desejo de ganhar. Mas APENAS se real.
+
+### Fórmula 1: Vagas limitadas (real)
+**Estrutura:** "Últimas [número] vagas para [oferta]"
+- "Últimas 5 vagas para onboarding em abril"
+- "Aceitamos apenas 3 novos clientes por mês"
+- "Turma de abril: 2 vagas restantes"
+
+### Fórmula 2: Prazo de oferta (real)
+**Estrutura:** "[Oferta] válida até [data]"
+- "Diagnóstico gratuito até sexta-feira"
+- "Preço de lançamento válido até dia 15"
+- "Setup sem custo para quem fechar até o final do mês"
+
+### Fórmula 3: Custo da inação
+**Estrutura:** "Cada [período] sem [ação] = [custo concreto]"
+- "Cada semana sem automação = ~20 leads perdidos"
+- "Cada mês sem otimização = R$ 3.000 desperdiçados em anúncios"
+- "Enquanto você espera, seu concorrente está capturando seus leads"
+
+### Fórmula 4: Janela de oportunidade
+**Estrutura:** "[Contexto temporal] + [por que agora é o momento]"
+- "O algoritmo do Meta está favorecendo vídeo curto. Quem entrar agora paga menos"
+- "Black Friday em 45 dias. Quem começa agora tem tempo de testar"
+- "Seu concorrente acabou de lançar anúncios. Cada dia conta"
+
+**Por que funciona:** Urgência ativa ação imediata. Mas FAKE urgência destrói credibilidade. Countdown falso, escassez inventada, "oferta por tempo limitado" que nunca acaba — tudo isso é detectado pelo público.
+
+### REGRA DE OURO: Só use urgência real
+- Capacidade de atendimento genuinamente limitada? OK
+- Preço de lançamento com data real? OK
+- Sazonalidade de mercado? OK
+- Countdown falso que reseta? NUNCA
+- "Últimas vagas" que nunca acabam? NUNCA
+
+---
+
+## Matriz de Decisão: Qual hook para qual fase do funil
+
+| Fase | Hook primário | Hook secundário | Por quê |
+|------|--------------|----------------|---------|
+| Topo (consciência) | Dor/Problema | Curiosidade | O ICP não sabe que existe solução, precisa reconhecer o problema |
+| Meio (consideração) | Resultado | Prova Social | O ICP já sabe do problema, precisa de evidência que existe solução |
+| Fundo (conversão) | Urgência | Resultado + Prova Social | O ICP já quer, precisa de empurrão para agir agora |
+| Remarketing | Prova Social | Urgência leve | O ICP já viu o produto, precisa de confiança e motivo para voltar |
+
+---
+
+## Checklist de Qualidade dos Hooks
+
+- [ ] Cada hook é específico para o ICP (não funcionaria para outro público)?
+- [ ] O hook funciona em 3 segundos de leitura (tela do mobile)?
+- [ ] O hook gera emoção (dor, desejo, curiosidade, medo) — não apenas informa?
+- [ ] As 5 variações testam hipóteses genuinamente diferentes?
+- [ ] Nenhum hook usa urgência/escassez fake?
+- [ ] Os hooks respeitam políticas de plataforma (sem afirmações pessoais diretas, sem promessas absolutas)?

--- a/.agents/skills/designer-criativos-anuncios/schema.json
+++ b/.agents/skills/designer-criativos-anuncios/schema.json
@@ -1,0 +1,320 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Criativos de Anúncios",
+  "description": "Output estruturado do pack de criativos: 5 variações com hooks diferentes, prompts de geração e guia de teste A/B.",
+  "type": "object",
+  "required": [
+    "summary",
+    "variations",
+    "ab_test_guide",
+    "total_pieces",
+    "client_name",
+    "summary_headline",
+    "summary_highlights",
+    "summary_key_findings"
+  ],
+  "properties": {
+    "client_name": {
+      "type": "string",
+      "description": "Nome do cliente — sempre presente em todo output."
+    },
+    "summary": {
+      "type": "string",
+      "description": "Resumo de 1-2 frases do briefing de criativos. Inclui número de variações e formato/gancho principal."
+    },
+    "summary_headline": {
+      "type": "string",
+      "description": "Manchete em 1 linha (~120 caracteres) com o veredito da skill."
+    },
+    "summary_highlights": {
+      "type": "array",
+      "description": "KPIs em destaque (4-6 itens). Categorias: posicao | competicao | janela | maturidade | oportunidade | risco.",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "label",
+          "value",
+          "tone"
+        ],
+        "properties": {
+          "category": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "subtext": {
+            "type": "string"
+          },
+          "tone": {
+            "type": "string",
+            "enum": [
+              "green",
+              "yellow",
+              "red",
+              "blue",
+              "gray"
+            ]
+          }
+        }
+      }
+    },
+    "summary_key_findings": {
+      "type": "array",
+      "description": "3-5 achados categorizados (vantagem | contexto | ameaca | acao).",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "text"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "vantagem",
+              "contexto",
+              "ameaca",
+              "acao"
+            ]
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "variations": {
+      "type": "array",
+      "description": "5 variações de criativo, cada uma com um tipo de hook diferente.",
+      "minItems": 5,
+      "maxItems": 5,
+      "items": {
+        "type": "object",
+        "required": [
+          "hook_type",
+          "hook_text",
+          "short_copy",
+          "medium_copy",
+          "headline",
+          "description",
+          "button_cta",
+          "visual_concept",
+          "recommended_format"
+        ],
+        "properties": {
+          "hook_type": {
+            "type": "string",
+            "enum": [
+              "dor",
+              "resultado",
+              "curiosidade",
+              "social_proof",
+              "urgencia"
+            ],
+            "description": "Tipo de hook testado nesta variação"
+          },
+          "hook_text": {
+            "type": "string",
+            "description": "Primeira frase/headline que para o scroll — máx 10 palavras",
+            "maxLength": 80
+          },
+          "short_copy": {
+            "type": "string",
+            "description": "Copy curta até 50 palavras para formatos compactos"
+          },
+          "medium_copy": {
+            "type": "string",
+            "description": "Copy média 50-100 palavras para formatos com mais espaço"
+          },
+          "headline": {
+            "type": "string",
+            "description": "Headline do anúncio — máx 30 caracteres",
+            "maxLength": 30
+          },
+          "description": {
+            "type": "string",
+            "description": "Descrição do anúncio — máx 90 caracteres",
+            "maxLength": 90
+          },
+          "button_cta": {
+            "type": "string",
+            "description": "Texto do botão CTA"
+          },
+          "visual_concept": {
+            "type": "string",
+            "description": "Descrição detalhada da imagem/composição visual para geração"
+          },
+          "recommended_format": {
+            "type": "string",
+            "enum": [
+              "feed_square",
+              "feed_portrait",
+              "stories",
+              "carousel"
+            ],
+            "description": "Formato visual recomendado"
+          },
+          "midjourney_prompt": {
+            "type": "string",
+            "description": "Prompt completo para Midjourney com parâmetros"
+          },
+          "ideogram_prompt": {
+            "type": "string",
+            "description": "Prompt para Ideogram (quando há texto no criativo)"
+          },
+          "canva_guide": {
+            "type": "string",
+            "description": "Instruções de montagem final no Canva"
+          }
+        }
+      }
+    },
+    "ab_test_guide": {
+      "type": "object",
+      "required": [
+        "combinations",
+        "success_metrics",
+        "test_duration",
+        "cut_criteria"
+      ],
+      "properties": {
+        "combinations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Combinações sugeridas de teste A/B"
+        },
+        "success_metrics": {
+          "type": "object",
+          "properties": {
+            "ctr_min": {
+              "type": "string",
+              "description": "CTR mínimo aceitável"
+            },
+            "cpc_max": {
+              "type": "string",
+              "description": "CPC máximo aceitável"
+            }
+          }
+        },
+        "test_duration": {
+          "type": "string",
+          "description": "Duração mínima do teste"
+        },
+        "cut_criteria": {
+          "type": "string",
+          "description": "Critério para eliminar variações de baixa performance"
+        }
+      }
+    },
+    "total_pieces": {
+      "type": "integer",
+      "description": "Total de peças no pack (variações × formatos)",
+      "minimum": 15
+    },
+    "produced_creatives": {
+      "type": "object",
+      "description": "Registro dos PNGs efetivamente produzidos (após etapa semi-manual de geração). Opcional — só presente após operador entregar os assets. Cruza com copy-anuncios via 'linked_variation' e 'pair_with_creative'.",
+      "properties": {
+        "summary": {
+          "type": "string",
+          "description": "1-2 frases — quantos foram, formatos, onde estão hospedados."
+        },
+        "feed_instagram": {
+          "type": "array",
+          "description": "Criativos de feed Instagram (4:5 / 1080×1350).",
+          "items": {
+            "type": "object",
+            "required": [
+              "id",
+              "url"
+            ],
+            "properties": {
+              "id": {
+                "type": "string",
+                "pattern": "^feed-\\d{2}$",
+                "description": "Convenção: feed-01, feed-02, ..."
+              },
+              "url": {
+                "type": "string",
+                "format": "uri",
+                "description": "URL pública do PNG (Vercel CDN da landing-{slug})."
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "feed_square",
+                  "feed_portrait"
+                ]
+              },
+              "dimensions": {
+                "type": "string",
+                "description": "Ex: '1080×1350'."
+              },
+              "linked_variation": {
+                "type": "string",
+                "description": "hook_type da variação correspondente em 'variations[]'."
+              },
+              "caption_label": {
+                "type": "string",
+                "description": "Frase curta resumindo o conceito visual (vai no card do portal)."
+              },
+              "use_with_copy": {
+                "type": "string",
+                "description": "Orientação de pareamento com copy (etapa funil + hook)."
+              }
+            }
+          }
+        },
+        "stories_instagram": {
+          "type": "array",
+          "description": "Criativos de stories Instagram (9:16 / 1080×1920).",
+          "items": {
+            "type": "object",
+            "required": [
+              "id",
+              "url"
+            ],
+            "properties": {
+              "id": {
+                "type": "string",
+                "pattern": "^story-\\d{2}$",
+                "description": "Convenção: story-01, story-02, ..."
+              },
+              "url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "stories"
+                ]
+              },
+              "dimensions": {
+                "type": "string"
+              },
+              "linked_variation": {
+                "type": "string"
+              },
+              "caption_label": {
+                "type": "string"
+              },
+              "use_with_copy": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/.agents/skills/designer-manual-marca/SKILL.md
+++ b/.agents/skills/designer-manual-marca/SKILL.md
@@ -1,0 +1,238 @@
+---
+name: designer-manual-marca
+description: "Manual de Marca completo (Brandbook estratégico + MIV técnico unificados em 5 blocos). Substitui brandbook legado + identidade visual legada. Use quando disser /designer-manual-marca ou 'manual de marca' ou 'MIV' ou 'brand guidelines'."
+area: designer
+author: luizfreitasv4
+version: 1.0.0
+dependencies:
+  - geral-posicionamento-estrategico
+  - geral-persona-icp
+  - geral-analise-swot
+  - geral-pesquisa-mercado
+inputs:
+  - client.json (briefing + brand)
+  - geral-posicionamento-estrategico.json
+  - geral-persona-icp.json
+  - geral-analise-swot.json
+  - geral-pesquisa-mercado.json
+output: designer-manual-marca.json
+week: 4
+type: automated
+estimated_time: "8h"
+supersedes:
+  - brandbook legado
+  - identidade visual legada
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta versao foi portada do sistema de Estruturacao Estrategica. As regras abaixo tem precedencia sobre caminhos e persistencia citados no fluxo original:
+
+- Trabalhe somente em `squads/{squad}/clientes/{cliente}/`, nunca em um diretorio `clientes/` solto na raiz.
+- Leia primeiro o `CLAUDE.md` ou `AGENTS.md` da KB, `mission-control/`, `calls/`, `docs/` e `campanhas/`.
+- Se `client.json` existir, use-o como fonte complementar. Se nao existir, derive o contexto da KB e do Mission Control; nao exija nem invente esse arquivo.
+- Salve entregaveis em `squads/{squad}/clientes/{cliente}/outputs/`, em JSON e Markdown quando o fluxo pedir ambos.
+- Registre decisoes e progresso no `mission-control/historico-checkins.md` ou no arquivo de historico equivalente encontrado na KB.
+- Resolva recursos empacotados a partir do proprio diretorio desta skill. Se uma integracao externa nao estiver configurada, declare o gap e continue apenas com os dados reais disponiveis.
+
+
+# Manual de Marca — Brandbook + MIV unificados (POP 3.9)
+
+> **Posição no fluxo:** Semana 4 — Identidade de Comunicação e Plano de Mídia (**comum** a todos os modelos) (igual para e-commerce / inside-sales / pdv). Deriva do posicionamento (S2). Tom de voz com exemplos de frase on/off-brand (não só adjetivos); versão operacional, não manual de 80 páginas.
+
+Você é um brand strategist + diretor de arte sênior. Vai criar o Manual de Marca completo unificando Brandbook estratégico (porquê) e Manual de Identidade Visual (como), no formato dos 5 blocos da Estrutura MIV.
+
+Esta skill **substitui** `brandbook legado` e `identidade visual legada`. Os outputs antigos ficam no histórico mas as skills downstream (LP, copy, criativos, scripts SDR) passam a depender de `designer-manual-marca`.
+
+## ⚠️ Princípio fundamental: este manual é DOCUMENTACIONAL, não criativo
+
+**O manual define COMO a MIV deve ser construída — ele não é o entregável visual final.** O entregável visual (logo finalizado, mockups de cartão, peças de IG, ícones desenhados) é trabalho do designer (Midjourney + Canva + designer humano), feito DEPOIS deste manual e usando este manual como briefing.
+
+### O que NÃO renderizar visualmente
+
+- ❌ Logo desenhado, símbolo, wordmark estilizado, mascote
+- ❌ Galeria visual de "nunca faça" do logo (com transformações, cores, distorções)
+- ❌ Ícones desenhados / iconografia simulada
+- ❌ Mockups de aplicações (cartão de visita, IG bio/feed/story, favicon, WhatsApp Business, GMB, e-mail signature, deck, fachada, uniforme)
+- ❌ Avatar da persona, mascote, ilustração
+- ❌ Simulação de fotografia, mood board renderizado
+
+### O que SIM renderizar visualmente
+
+- ✓ **Tipografia em escala real** — fonte primária e secundária mostradas no tamanho exato da hierarquia (H1, H2, H3, body, caption, CTA). Sem ver a fonte real, ninguém valida se a hierarquia funciona.
+- ✓ **Sistema cromático** — paleta em swatches com hex/rgb/cmyk/role/justificativa. Pode incluir: swatches em tamanho confortável (não precisa ser mini), proporção 60-30-10 visual, e matriz WCAG com referência da cor sobre fundo.
+- ✓ **Diagramas estratégicos estruturais** quando ajudam a leitura (matriz competitiva 2x2, escalas de personalidade) — não são criação visual de marca, são gráficos de informação.
+
+### Regras adicionais obrigatórias
+
+**Tipografia (Bloco 3) — Google Fonts é obrigatório:**
+
+- A fonte primária e a secundária devem **OBRIGATORIAMENTE** estar disponíveis no [Google Fonts](https://fonts.google.com/). Fontes proprietárias, comerciais (Adobe Fonts, MyFonts) ou desktop-only não são permitidas.
+- Para cada fonte, preencher OBRIGATORIAMENTE:
+  - `name` — nome exato da fonte
+  - `source` — sempre `"Google Fonts"` (literal)
+  - `google_fonts_url` — link direto da página da fonte (ex: `https://fonts.google.com/specimen/Fraunces`)
+  - `embed_url` — link CSS para `<link href>` ou `@import` (ex: `https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,600;9..144,700&display=swap`)
+- O renderer mostra o link clicável da fonte na documentação para que o designer/desenvolvedor abra direto.
+
+**Logo (Bloco 3) — descrição rica obrigatória:**
+
+O logo NÃO é desenhado neste manual (responsabilidade do designer). Mas a documentação precisa ser **rica o suficiente** para o designer trabalhar a partir dela. Preencher OBRIGATORIAMENTE:
+
+- `concept` — 1-2 parágrafos sobre o que o logo expressa estrategicamente
+- `style_description` — 200+ caracteres descrevendo a linguagem visual concreta: tipo (serif/sans/symbolic/wordmark), peso, tratamento, atemporalidade, escalabilidade
+- `visual_attributes` (objeto com 7 campos):
+  - `form_language` — geométrico / orgânico / mixed (com justificativa)
+  - `weight` — fino / médio / robusto
+  - `balance` — simétrico / assimétrico controlado
+  - `negative_space` — denso / equilibrado / generoso
+  - `color_application` — monocromático / duotone / gradient (com regras)
+  - `personality_in_form` — como CADA adjetivo do tom de voz se traduz na forma
+  - `scalability` — comportamento em escala mínima e máxima
+  - `differentiation_from_competitors` — como se diferencia visualmente dos concorrentes
+- `design_principles` — 4+ princípios curtos que orientam o logo (ex: "sobriedade acima de fofura", "tipografia faz o trabalho pesado")
+
+Esses campos juntos dão ao designer um briefing 10× mais rico do que apenas "logo serif roxo".
+
+### Como os demais blocos devem aparecer
+
+Tudo o que não for tipografia ou swatch de cor mini deve aparecer como:
+
+- **Texto descritivo** (definições, regras, princípios, conceitos)
+- **Tabelas** (diga/não diga, valores, do/dont, hierarquia, glossário, WCAG, matriz competitiva)
+- **Listas estruturadas** (pilares, ganchos de abertura, anti-persona, ações)
+- **Cards de texto** com título + descrição
+
+Por exemplo:
+- Galeria "nunca faça" do logo → **lista textual** "Não distorcer · razão: quebra proporção tipográfica"
+- Iconografia → **regras textuais** de stroke, grid, estilo (sem desenhar ícones)
+- Mockup de cartão de visita → **specs em texto** (dimensões, tipografia, posicionamento, hierarquia)
+- Mockup de post de IG → **specs em texto** (dimensões 1080×1080, headline em Fraunces 64px, etc.)
+- Persona Mariana → **card de texto com 6 campos** (sem avatar SVG, sem foto)
+- 3 direções de logo → **cards de texto** com nome do estilo, conceito em 1 frase, prompt do Midjourney completo (sem mini-ícones representativos)
+
+O designer (humano ou Midjourney) lê o manual e produz os assets. O manual é a régua, não o entregável.
+
+## Estrutura dos 5 blocos
+
+- **Bloco 1 — Fundamentos Estratégicos:** apresentação/manifesto, essência (propósito/visão/missão/valores/promessa/big idea/pilares), posicionamento (statement/território/arquétipo/matriz competitiva/PUV), público e persona (template padronizado, secundária, anti-persona, jornada), história e cultura.
+- **Bloco 2 — Identidade Verbal:** personalidade (escalas + arquétipo aplicado + "se a marca fosse pessoa"), tom de voz (4 pilares + variações por canal + diga/não diga), diretrizes editoriais (vocabulário categorizado por função, glossário, terminologia proibida, regras gramaticais), naming, storytelling, slogan/tagline/assinaturas.
+- **Bloco 3 — Identidade Visual Core:** logo (conceito/anatomia/grid/clear space/min-max/versões/3 direções de prompt), galeria de usos incorretos, sistema cromático (paletas + WCAG + 60-30-10), tipografia (hierarquia + pesos + fallbacks), iconografia, grafismos, fotografia, ilustração.
+- **Bloco 4 — Aplicações:** princípio de mockups contextuais; papelaria essencial (cartão, e-mail signature, deck), digital/UI (favicon, app icon, e-mail templates, WhatsApp Business), redes sociais (avatar, bio, feed, stories, GMB), materiais de venda (one-pager, brindes). Para PMEs early-stage, escopo reduzido — pula fachada/uniforme/embalagem se não escala ROI.
+- **Bloco 5 — Governança:** brand owner, processo de aprovação, cadência de revisão.
+
+## Escopo por maturidade da marca
+
+- **Early-stage (PME nova, <2 anos de operação madura):** Blocos 1-3 completos, Bloco 4 com seleção (digital + redes sociais + papelaria essencial), Bloco 5 enxuto.
+- **Estabelecida (PME com base ativa, >5 anos):** todos os blocos, Bloco 4 ampliado com fachada/uniforme/embalagem se aplicável, Bloco 5 com comitê de marca.
+
+Decida o escopo lendo `client.json.briefing` (segmento, tempo de mercado, base ativa) e o tamanho operacional. Se ambíguo, pergunte ao operador antes.
+
+## Reuso obrigatório de outputs anteriores
+
+Toda decisão estratégica que JÁ EXISTE em outputs aprovados deve ser **referenciada e reaproveitada**, nunca refeita:
+
+- **Posicionamento** → `outputs/geral-posicionamento-estrategico.json` → `chosen_statement`, `puv`, `recommended_tagline`, `brand_territory`, `canvas_4p`
+- **Persona/ICP** → `outputs/geral-persona-icp.json` → `persona`, `icp`, `key_message`, `buyer_journey`, `anti_persona`, `objection_library`, `willingness_to_pay`
+- **Diferenciais** → `outputs/geral-analise-swot.json` → `strengths`, `key_play`
+- **Mercado** → `outputs/geral-pesquisa-mercado.json` → `differentials`, `competitors`, `trends`
+- **Cores existentes** → `client.json.briefing.brand.current_colors` (se já houver paleta consolidada, manter e formalizar — não inventar nova sem motivo estratégico)
+
+Se o operador questionar qualquer dado já validado nas semanas anteriores, **NÃO modifique** outputs anteriores — pergunte se quer atualizar a fonte.
+
+## Geração
+
+Gere o output COMPLETO de uma vez. Para cada bloco, preencha todos os campos do schema. Onde o dado real do cliente não existe, use `null` + `unavailable_reason` (e nunca string vazia).
+
+### Diretrizes específicas por bloco
+
+**Bloco 1 — Manifesto:**
+- Manifesto curto (1 frase) deve caber em sticker/bio. Se trocar o nome do cliente e ainda funcionar, está genérico.
+- Manifesto narrativo (1 página) reusa a estrutura de 3 atos do brand_narrative já definido em S2 (antes/diferente/depois).
+- Big idea = 1 frase que sustenta toda a comunicação. Diferente de tagline (institucional fixa) e slogan (campanha).
+- Pilares (4-5): nome curto + 1 frase. Diferente de valores (comportamental) e USPs (argumento de venda).
+
+**Bloco 1 — Posicionamento:**
+- Statement reusa o `chosen_statement` do `geral-posicionamento-estrategico.json`.
+- Arquétipo: escolha 1 dominante + 1 secundário (Jung/Pearson). Justifique a escolha com base no posicionamento aprovado.
+- Matriz 2x2: reuse `positioning_map` do S2.
+- PUV (formato fixo): "[Marca] combina [diferencial 1] com [diferencial 2] e [bônus exclusivo] para resolver [dor central], eliminando [problema do mercado]."
+
+**Bloco 1 — Persona:**
+- Reuse `persona` e `icp` do S1. Aplique o template de 6 campos (nome+foto, idade, renda, ocupação, dor principal, motivos de compra).
+- Anti-persona reusa do S1.
+- Jornada reusa `buyer_journey` do S1.
+
+**Bloco 2 — Tom de voz:**
+- 4 pilares (não 3, não 5). Cada pilar: nome + definição em 1 frase + manifestação prática.
+- Variações por canal (LinkedIn, Instagram, e-mail transacional, WhatsApp, press release): tom específico para cada.
+- Diga / Não diga: 10-15 situações reais com forma certa vs forma errada + motivo.
+
+**Bloco 2 — Vocabulário categorizado:**
+- 3 colunas: Palavras de Essência (quem somos), Palavras Valorizadas e Repetidas (memória de marca), Palavras que Conectam com o Público (pertencimento).
+- 5-8 palavras por coluna. Glossário e terminologia proibida em listas separadas.
+
+**Bloco 3 — Logo:**
+- 3 direções de prompt para Midjourney (mantém compatibilidade com workflow atual).
+- Galeria "nunca faça": 6+ exemplos visuais com legenda (distorção, recolor, sombra, baixo contraste, rotação, contorno).
+- Min/max em px (digital) e mm (impresso).
+
+**Bloco 3 — Sistema cromático:**
+- Paleta primária + secundária + neutros + cores funcionais (UI: success/error/warning/info).
+- Para CADA cor: HEX + RGB + CMYK + role + justificativa estratégica.
+- Matriz WCAG: combinações texto/fundo com ratio AA/AAA.
+- Proporção 60-30-10 visual.
+
+**Bloco 4 — Mockups contextuais (princípio):**
+- Cada aplicação tem 2 camadas: técnica (specs) + contextual (descrição do mockup que será renderizado em SVG no portal).
+- Para PME early-stage local (vet, dentista, salão): foco em digital + redes sociais + papelaria essencial. Não documentar fachada/uniforme/embalagem se não há ROI.
+
+## Auto-validação
+
+
+Antes de apresentar:
+- [ ] Mencionou o cliente pelo nome em todos os blocos?
+- [ ] Reutilizou (sem refazer) decisões aprovadas em S1/S2?
+- [ ] Big idea, manifesto curto e PUV passam no teste "se trocar o nome funciona pra outra empresa"? Se sim, regenere.
+- [ ] Tom de voz tem exatamente 4 pilares?
+- [ ] Sistema cromático tem WCAG calculado e proporção 60-30-10 definida?
+- [ ] 3 direções de prompt para logo + galeria "nunca faça" com 6+ itens?
+- [ ] Bloco 4 tem ao menos 6 mockups contextuais descritos?
+- [ ] Schema validou?
+
+## Apresentação e decisões
+
+Apresente o output COMPLETO ao operador via portal renderizado.
+
+**DECISÃO 1:** Manifesto curto e Big Idea — passam no teste de troca de nome?
+
+**DECISÃO 2:** Arquétipos dominante + secundário — coerentes com posicionamento aprovado em S2?
+
+**DECISÃO 3:** Direção de logo (das 3 prompts) — qual gerar primeiro no Midjourney?
+
+**DECISÃO 4:** Escopo do Bloco 4 — manter reduzido (early-stage) ou expandir para fachada/uniforme/embalagem?
+
+## Finalização
+
+Operador aprova (com ou sem ajustes).
+1. Salve em `squads/{squad}/clientes/{cliente}/outputs/designer-manual-marca.json` (com `summary` no topo)
+2. Atualize `client.json`: `progress.skills.designer-manual-marca` → completed, version++, append em `history[]`
+3. Marque `brandbook legado` e `identidade visual legada` como `superseded_by: designer-manual-marca` em progress (mantenha completed se já estavam)
+4. Salve também uma versão Markdown do entregável na mesma pasta de outputs.
+5. Sugira próxima skill (geralmente `designer-landing-page` ou paralelizar `otimização do Google Business Profile (ainda não portada)` + `account-crm-setup`)
+
+## Formato do output
+
+Schema completo em `schema.json`. Estrutura geral:
+
+```json
+{
+  "summary": "string",
+  "scope": "early-stage | established",
+  "block1_strategic_foundations": { ... },
+  "block2_verbal_identity": { ... },
+  "block3_visual_identity_core": { ... },
+  "block4_applications": { ... },
+  "block5_governance": { ... }
+}
+```

--- a/.agents/skills/designer-manual-marca/schema.json
+++ b/.agents/skills/designer-manual-marca/schema.json
@@ -1,0 +1,1319 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Manual de Marca (Brandbook + MIV unificados)",
+  "description": "Output unificado: Brandbook estratégico (porquê) + MIV técnico (como) no formato de 5 blocos da Estrutura MIV.",
+  "type": "object",
+  "required": [
+    "summary",
+    "scope",
+    "block1_strategic_foundations",
+    "block2_verbal_identity",
+    "block3_visual_identity_core",
+    "block4_applications",
+    "block5_governance",
+    "client_name",
+    "summary_headline",
+    "summary_highlights",
+    "summary_key_findings"
+  ],
+  "properties": {
+    "client_name": {
+      "type": "string",
+      "description": "Nome do cliente — sempre presente em todo output."
+    },
+    "summary": {
+      "type": "string",
+      "description": "Resumo de 2-3 frases. Cliente pelo nome, principais decisões."
+    },
+    "summary_headline": {
+      "type": "string",
+      "description": "Manchete em 1 linha (~120 caracteres) com o veredito da skill."
+    },
+    "summary_highlights": {
+      "type": "array",
+      "description": "KPIs em destaque (4-6 itens). Categorias: posicao | competicao | janela | maturidade | oportunidade | risco.",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "label",
+          "value",
+          "tone"
+        ],
+        "properties": {
+          "category": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "subtext": {
+            "type": "string"
+          },
+          "tone": {
+            "type": "string",
+            "enum": [
+              "green",
+              "yellow",
+              "red",
+              "blue",
+              "gray"
+            ]
+          }
+        }
+      }
+    },
+    "summary_key_findings": {
+      "type": "array",
+      "description": "3-5 achados categorizados (vantagem | contexto | ameaca | acao).",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "text"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "vantagem",
+              "contexto",
+              "ameaca",
+              "acao"
+            ]
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "scope": {
+      "type": "string",
+      "enum": [
+        "early-stage",
+        "established"
+      ],
+      "description": "Escopo do manual: early-stage (Blocos 1-3 completos + 4 reduzido + 5 enxuto) ou established (todos os blocos completos)."
+    },
+    "block1_strategic_foundations": {
+      "type": "object",
+      "required": [
+        "presentation",
+        "essence",
+        "positioning",
+        "audience_persona"
+      ],
+      "properties": {
+        "presentation": {
+          "type": "object",
+          "required": [
+            "manifesto_short",
+            "manifesto_narrative",
+            "navigation_instructions"
+          ],
+          "properties": {
+            "opening_letter": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "manifesto_short": {
+              "type": "string",
+              "minLength": 20,
+              "maxLength": 200
+            },
+            "manifesto_narrative": {
+              "type": "string",
+              "minLength": 200
+            },
+            "navigation_instructions": {
+              "type": "string"
+            }
+          }
+        },
+        "essence": {
+          "type": "object",
+          "required": [
+            "purpose",
+            "vision",
+            "mission",
+            "values",
+            "promise",
+            "big_idea",
+            "brand_pillars"
+          ],
+          "properties": {
+            "purpose": {
+              "type": "string"
+            },
+            "vision": {
+              "type": "string"
+            },
+            "mission": {
+              "type": "string"
+            },
+            "values": {
+              "type": "array",
+              "minItems": 3,
+              "maxItems": 5,
+              "items": {
+                "type": "object",
+                "required": [
+                  "name",
+                  "behavior_yes",
+                  "behavior_no"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "behavior_yes": {
+                    "type": "string"
+                  },
+                  "behavior_no": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "promise": {
+              "type": "string"
+            },
+            "big_idea": {
+              "type": "string",
+              "maxLength": 200
+            },
+            "brand_pillars": {
+              "type": "array",
+              "minItems": 4,
+              "maxItems": 5,
+              "items": {
+                "type": "object",
+                "required": [
+                  "name",
+                  "description"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "positioning": {
+          "type": "object",
+          "required": [
+            "statement",
+            "territory",
+            "archetype_dominant",
+            "competitive_matrix",
+            "puv"
+          ],
+          "properties": {
+            "statement": {
+              "type": "string"
+            },
+            "territory": {
+              "type": "string"
+            },
+            "archetype_dominant": {
+              "type": "object",
+              "required": [
+                "name",
+                "justification"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "justification": {
+                  "type": "string"
+                }
+              }
+            },
+            "archetype_secondary": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "justification": {
+                  "type": "string"
+                }
+              }
+            },
+            "competitive_matrix": {
+              "type": "object",
+              "required": [
+                "axis_x",
+                "axis_y",
+                "client_position",
+                "competitors"
+              ],
+              "properties": {
+                "axis_x": {
+                  "type": "string"
+                },
+                "axis_y": {
+                  "type": "string"
+                },
+                "client_position": {
+                  "type": "string"
+                },
+                "competitors": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "name",
+                      "quadrant"
+                    ],
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "quadrant": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "puv": {
+              "type": "string"
+            }
+          }
+        },
+        "audience_persona": {
+          "type": "object",
+          "required": [
+            "primary_persona"
+          ],
+          "properties": {
+            "primary_persona": {
+              "type": "object",
+              "required": [
+                "name",
+                "age",
+                "income",
+                "occupation",
+                "main_pain",
+                "purchase_motivators"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "photo_description": {
+                  "type": "string"
+                },
+                "age": {
+                  "type": "string"
+                },
+                "income": {
+                  "type": "string"
+                },
+                "occupation": {
+                  "type": "string"
+                },
+                "main_pain": {
+                  "type": "string"
+                },
+                "purchase_motivators": {
+                  "type": "string"
+                }
+              }
+            },
+            "secondary_persona": {
+              "type": [
+                "object",
+                "null"
+              ]
+            },
+            "anti_persona": {
+              "type": [
+                "object",
+                "null"
+              ]
+            },
+            "buyer_journey_summary": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        },
+        "history_culture": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "origin": {
+              "type": "string"
+            },
+            "milestones": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "culture": {
+              "type": "string"
+            },
+            "legacy": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "block2_verbal_identity": {
+      "type": "object",
+      "required": [
+        "personality",
+        "tone_of_voice",
+        "editorial_guidelines",
+        "slogan_tagline_signatures"
+      ],
+      "properties": {
+        "personality": {
+          "type": "object",
+          "required": [
+            "scales",
+            "as_a_person"
+          ],
+          "properties": {
+            "scales": {
+              "type": "array",
+              "minItems": 5,
+              "items": {
+                "type": "object",
+                "required": [
+                  "trait_low",
+                  "trait_high",
+                  "position"
+                ],
+                "properties": {
+                  "trait_low": {
+                    "type": "string"
+                  },
+                  "trait_high": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "number",
+                    "minimum": 1,
+                    "maximum": 10
+                  }
+                }
+              }
+            },
+            "archetype_applied": {
+              "type": "string"
+            },
+            "as_a_person": {
+              "type": "string"
+            }
+          }
+        },
+        "tone_of_voice": {
+          "type": "object",
+          "required": [
+            "pillars",
+            "channel_variations",
+            "say_dont_say"
+          ],
+          "properties": {
+            "pillars": {
+              "type": "array",
+              "minItems": 4,
+              "maxItems": 4,
+              "items": {
+                "type": "object",
+                "required": [
+                  "name",
+                  "definition",
+                  "manifestation"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "definition": {
+                    "type": "string"
+                  },
+                  "manifestation": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "channel_variations": {
+              "type": "array",
+              "minItems": 4,
+              "items": {
+                "type": "object",
+                "required": [
+                  "channel",
+                  "adaptation"
+                ],
+                "properties": {
+                  "channel": {
+                    "type": "string"
+                  },
+                  "adaptation": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "say_dont_say": {
+              "type": "array",
+              "minItems": 8,
+              "items": {
+                "type": "object",
+                "required": [
+                  "situation",
+                  "say",
+                  "dont_say",
+                  "reason"
+                ],
+                "properties": {
+                  "situation": {
+                    "type": "string"
+                  },
+                  "say": {
+                    "type": "string"
+                  },
+                  "dont_say": {
+                    "type": "string"
+                  },
+                  "reason": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "editorial_guidelines": {
+          "type": "object",
+          "required": [
+            "vocabulary_categorized",
+            "form_of_address"
+          ],
+          "properties": {
+            "vocabulary_categorized": {
+              "type": "object",
+              "required": [
+                "essence_words",
+                "valued_repeated",
+                "audience_connection"
+              ],
+              "properties": {
+                "essence_words": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "minItems": 5
+                },
+                "valued_repeated": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "minItems": 5
+                },
+                "audience_connection": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "minItems": 5
+                }
+              }
+            },
+            "official_glossary": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "term",
+                  "definition"
+                ],
+                "properties": {
+                  "term": {
+                    "type": "string"
+                  },
+                  "definition": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "forbidden_terms": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "term",
+                  "use_instead"
+                ],
+                "properties": {
+                  "term": {
+                    "type": "string"
+                  },
+                  "use_instead": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "form_of_address": {
+              "type": "string"
+            },
+            "emoji_punctuation": {
+              "type": "string"
+            },
+            "grammar_rules": {
+              "type": "string"
+            }
+          }
+        },
+        "naming_taxonomy": {
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "storytelling": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "story_arc": {
+              "type": "object",
+              "properties": {
+                "act1_before": {
+                  "type": "string"
+                },
+                "act2_different": {
+                  "type": "string"
+                },
+                "act3_after": {
+                  "type": "string"
+                }
+              }
+            },
+            "frameworks": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "opening_hooks": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "slogan_tagline_signatures": {
+          "type": "object",
+          "required": [
+            "tagline"
+          ],
+          "properties": {
+            "slogan": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "tagline": {
+              "type": "string"
+            },
+            "verbal_signatures": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "block3_visual_identity_core": {
+      "type": "object",
+      "required": [
+        "logo",
+        "incorrect_uses",
+        "color_system",
+        "typography"
+      ],
+      "properties": {
+        "logo": {
+          "type": "object",
+          "required": [
+            "concept",
+            "style_description",
+            "visual_attributes",
+            "design_principles",
+            "anatomy",
+            "clear_space",
+            "min_max_size",
+            "official_versions",
+            "logo_directions"
+          ],
+          "properties": {
+            "concept": {
+              "type": "string",
+              "description": "Conceito do logo em 1-2 parágrafos: o que ele expressa estrategicamente"
+            },
+            "style_description": {
+              "type": "string",
+              "minLength": 200,
+              "description": "Descrição do ESTILO visual do logo: linguagem (serif/sans/script/symbolic), peso, tratamento, atemporalidade. Deve ter pelo menos 200 caracteres e descrever a personalidade visual concreta."
+            },
+            "visual_attributes": {
+              "type": "object",
+              "required": [
+                "form_language",
+                "weight",
+                "balance",
+                "color_application",
+                "personality_in_form"
+              ],
+              "properties": {
+                "form_language": {
+                  "type": "string",
+                  "description": "Geométrico, orgânico, mixed, etc."
+                },
+                "weight": {
+                  "type": "string"
+                },
+                "balance": {
+                  "type": "string"
+                },
+                "negative_space": {
+                  "type": "string"
+                },
+                "color_application": {
+                  "type": "string"
+                },
+                "personality_in_form": {
+                  "type": "string",
+                  "description": "Como cada adjetivo do tom de voz se traduz na forma"
+                },
+                "scalability": {
+                  "type": "string"
+                },
+                "differentiation_from_competitors": {
+                  "type": "string"
+                }
+              }
+            },
+            "design_principles": {
+              "type": "array",
+              "minItems": 4,
+              "items": {
+                "type": "string"
+              },
+              "description": "Princípios de design que orientam o logo (ex: 'sobriedade acima de fofura', 'tipografia faz o trabalho pesado'). 4+ itens."
+            },
+            "anatomy": {
+              "type": "object",
+              "properties": {
+                "symbol": {
+                  "type": "string"
+                },
+                "wordmark": {
+                  "type": "string"
+                },
+                "lockup": {
+                  "type": "string"
+                }
+              }
+            },
+            "construction_grid": {
+              "type": "string"
+            },
+            "clear_space": {
+              "type": "string"
+            },
+            "min_max_size": {
+              "type": "object",
+              "properties": {
+                "min_digital_px": {
+                  "type": "string"
+                },
+                "min_print_mm": {
+                  "type": "string"
+                },
+                "max_recommended": {
+                  "type": "string"
+                }
+              }
+            },
+            "official_versions": {
+              "type": "array",
+              "minItems": 3,
+              "items": {
+                "type": "object",
+                "required": [
+                  "name",
+                  "use_case"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "use_case": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "logo_directions": {
+              "type": "array",
+              "minItems": 3,
+              "maxItems": 3,
+              "items": {
+                "type": "object",
+                "required": [
+                  "direction",
+                  "concept",
+                  "prompt"
+                ],
+                "properties": {
+                  "direction": {
+                    "type": "string"
+                  },
+                  "concept": {
+                    "type": "string"
+                  },
+                  "prompt": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "chosen_direction": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        },
+        "incorrect_uses": {
+          "type": "array",
+          "minItems": 6,
+          "items": {
+            "type": "object",
+            "required": [
+              "rule",
+              "visual_demo",
+              "reason"
+            ],
+            "properties": {
+              "rule": {
+                "type": "string"
+              },
+              "visual_demo": {
+                "type": "string",
+                "description": "Como o renderer vai demonstrar visualmente — ex: 'distort_x', 'recolor_red', 'drop_shadow', 'low_contrast', 'rotated', 'outlined'"
+              },
+              "reason": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "color_system": {
+          "type": "object",
+          "required": [
+            "primary",
+            "neutrals",
+            "proportions",
+            "wcag_contrast_matrix"
+          ],
+          "properties": {
+            "primary": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "object",
+                "required": [
+                  "name",
+                  "hex",
+                  "rgb",
+                  "cmyk",
+                  "role",
+                  "justification"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "hex": {
+                    "type": "string",
+                    "pattern": "^#[0-9A-Fa-f]{6}$"
+                  },
+                  "rgb": {
+                    "type": "string"
+                  },
+                  "cmyk": {
+                    "type": "string"
+                  },
+                  "pantone": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "hsl": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "role": {
+                    "type": "string"
+                  },
+                  "justification": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "secondary": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            },
+            "neutrals": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            },
+            "functional": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            },
+            "proportions": {
+              "type": "object",
+              "required": [
+                "dominant_pct",
+                "support_pct",
+                "accent_pct",
+                "dominant_color",
+                "support_color",
+                "accent_color"
+              ],
+              "properties": {
+                "dominant_pct": {
+                  "type": "number"
+                },
+                "support_pct": {
+                  "type": "number"
+                },
+                "accent_pct": {
+                  "type": "number"
+                },
+                "dominant_color": {
+                  "type": "string"
+                },
+                "support_color": {
+                  "type": "string"
+                },
+                "accent_color": {
+                  "type": "string"
+                }
+              }
+            },
+            "gradients": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            },
+            "wcag_contrast_matrix": {
+              "type": "array",
+              "minItems": 4,
+              "items": {
+                "type": "object",
+                "required": [
+                  "foreground",
+                  "background",
+                  "ratio",
+                  "level"
+                ],
+                "properties": {
+                  "foreground": {
+                    "type": "string",
+                    "pattern": "^#[0-9A-Fa-f]{6}$"
+                  },
+                  "background": {
+                    "type": "string",
+                    "pattern": "^#[0-9A-Fa-f]{6}$"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "ratio": {
+                    "type": "number"
+                  },
+                  "level": {
+                    "type": "string",
+                    "enum": [
+                      "AAA",
+                      "AA",
+                      "AA Large",
+                      "Fail"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "typography": {
+          "type": "object",
+          "required": [
+            "primary_family",
+            "hierarchy"
+          ],
+          "properties": {
+            "primary_family": {
+              "type": "object",
+              "required": [
+                "name",
+                "source",
+                "google_fonts_url",
+                "embed_url",
+                "weights_permitted"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "Nome da fonte (deve estar disponível no Google Fonts)"
+                },
+                "source": {
+                  "type": "string",
+                  "const": "Google Fonts",
+                  "description": "Sempre Google Fonts — fontes proprietárias não são permitidas"
+                },
+                "google_fonts_url": {
+                  "type": "string",
+                  "pattern": "^https://fonts\\.google\\.com/",
+                  "description": "URL da página da fonte no Google Fonts (ex: https://fonts.google.com/specimen/Fraunces)"
+                },
+                "embed_url": {
+                  "type": "string",
+                  "pattern": "^https://fonts\\.googleapis\\.com/",
+                  "description": "URL CSS para embedar (ex: https://fonts.googleapis.com/css2?family=Fraunces:wght@600;700&display=swap)"
+                },
+                "weights_permitted": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "license": {
+                  "type": "string"
+                }
+              }
+            },
+            "secondary_family": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "source": {
+                  "type": "string",
+                  "const": "Google Fonts"
+                },
+                "google_fonts_url": {
+                  "type": "string",
+                  "pattern": "^https://fonts\\.google\\.com/"
+                },
+                "embed_url": {
+                  "type": "string",
+                  "pattern": "^https://fonts\\.googleapis\\.com/"
+                },
+                "weights_permitted": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "license": {
+                  "type": "string"
+                }
+              }
+            },
+            "hierarchy": {
+              "type": "array",
+              "minItems": 5,
+              "items": {
+                "type": "object",
+                "required": [
+                  "level",
+                  "font",
+                  "weight",
+                  "size_px",
+                  "use_case"
+                ],
+                "properties": {
+                  "level": {
+                    "type": "string"
+                  },
+                  "font": {
+                    "type": "string"
+                  },
+                  "weight": {
+                    "type": "string"
+                  },
+                  "size_px": {
+                    "type": "number"
+                  },
+                  "line_height": {
+                    "type": "string"
+                  },
+                  "use_case": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "fallbacks": {
+              "type": "string"
+            },
+            "justification": {
+              "type": "string"
+            }
+          }
+        },
+        "iconography": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "style": {
+              "type": "string"
+            },
+            "stroke_weight_px": {
+              "type": "number"
+            },
+            "corner_style": {
+              "type": "string"
+            },
+            "grid": {
+              "type": "string"
+            },
+            "color_default": {
+              "type": "string"
+            }
+          }
+        },
+        "graphic_system": {
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "photography": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "art_direction": {
+              "type": "string"
+            },
+            "mood_keywords": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "do_dont": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "do",
+                      "dont"
+                    ]
+                  },
+                  "rule": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "illustration": {
+          "type": [
+            "object",
+            "null"
+          ]
+        }
+      }
+    },
+    "block4_applications": {
+      "type": "object",
+      "required": [
+        "principle",
+        "applications"
+      ],
+      "properties": {
+        "principle": {
+          "type": "string"
+        },
+        "applications": {
+          "type": "array",
+          "minItems": 6,
+          "items": {
+            "type": "object",
+            "required": [
+              "category",
+              "name",
+              "specs",
+              "mockup"
+            ],
+            "properties": {
+              "category": {
+                "type": "string",
+                "enum": [
+                  "stationery",
+                  "digital_ui",
+                  "social_media",
+                  "sales_marketing",
+                  "signage",
+                  "events"
+                ]
+              },
+              "name": {
+                "type": "string"
+              },
+              "specs": {
+                "type": "string"
+              },
+              "mockup": {
+                "type": "object",
+                "required": [
+                  "type",
+                  "description"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "business_card",
+                      "email_signature",
+                      "ig_avatar_bio",
+                      "ig_feed_post",
+                      "ig_story",
+                      "favicon_scaling",
+                      "one_pager",
+                      "whatsapp_business",
+                      "gmb_card",
+                      "deck_cover",
+                      "branded_giveaway"
+                    ]
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "data": {
+                    "type": "object",
+                    "description": "Dados específicos do mockup (texto da bio, headline do post, etc.)"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "block5_governance": {
+      "type": "object",
+      "required": [
+        "brand_owner",
+        "approval_process"
+      ],
+      "properties": {
+        "brand_owner": {
+          "type": "string"
+        },
+        "approval_process": {
+          "type": "array",
+          "minItems": 3,
+          "items": {
+            "type": "object",
+            "required": [
+              "step",
+              "responsible"
+            ],
+            "properties": {
+              "step": {
+                "type": "string"
+              },
+              "responsible": {
+                "type": "string"
+              },
+              "estimated_time": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "review_cadence": {
+          "type": "string"
+        },
+        "committee": {
+          "type": [
+            "object",
+            "null"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/.claude/skills/designer-criativos-anuncios/SKILL.md
+++ b/.claude/skills/designer-criativos-anuncios/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: designer-criativos-anuncios
+description: "Cria o briefing criativo para anúncios: 5 variações com hooks diferentes, prompts Midjourney/Ideogram e organização do pack. Semi-manual — operador gera imagens externamente. Use quando disser /designer-criativos-anuncios ou 'criativos de ads' ou 'pack de anúncios' ou 'imagens para anúncio'."
+area: designer
+author: luizfreitasv4
+version: 1.0.0
+dependencies:
+  - designer-manual-marca
+  - gt-diagnostico-criativos
+inputs:
+  - client.json (briefing)
+  - designer-manual-marca.json
+  - gt-diagnostico-criativos.json
+output: designer-criativos-anuncios.json
+week: 4
+type: semi-manual
+estimated_time: "4h"
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta versao foi portada do sistema de Estruturacao Estrategica. As regras abaixo tem precedencia sobre caminhos e persistencia citados no fluxo original:
+
+- Trabalhe somente em `squads/{squad}/clientes/{cliente}/`, nunca em um diretorio `clientes/` solto na raiz.
+- Leia primeiro o `CLAUDE.md` ou `AGENTS.md` da KB, `mission-control/`, `calls/`, `docs/` e `campanhas/`.
+- Se `client.json` existir, use-o como fonte complementar. Se nao existir, derive o contexto da KB e do Mission Control; nao exija nem invente esse arquivo.
+- Salve entregaveis em `squads/{squad}/clientes/{cliente}/outputs/`, em JSON e Markdown quando o fluxo pedir ambos.
+- Registre decisoes e progresso no `mission-control/historico-checkins.md` ou no arquivo de historico equivalente encontrado na KB.
+- Resolva recursos empacotados a partir do proprio diretorio desta skill. Se uma integracao externa nao estiver configurada, declare o gap e continue apenas com os dados reais disponiveis.
+
+
+# Criativos de Anúncios — Briefing + Prompts + Pack (POP 3.11)
+
+> **Posição no fluxo:** Semana 4 — Identidade de Comunicação e Plano de Mídia (**comum** a todos os modelos) (e-commerce / inside-sales / pdv). Entregável-alvo do POP 3.11: **4 criativos finalizados**, **1 ângulo distinto por peça**, cada um **amarrado a uma fase de funil** e com **hipótese de teste** documentada + **nomenclatura** `fase_ângulo_formato_versão`. (A 5ª variação abaixo é reserva opcional.)
+
+Você é um diretor criativo especializado em performance marketing para PMEs brasileiras. Vai criar o briefing criativo completo para a primeira rodada de anúncios: 4 variações com ângulos distintos (hook diferente), cada uma testando uma hipótese e amarrada a uma fase de funil.
+
+## Dados necessários
+
+1. `client.json` (seção `briefing`) — nome, segmento, produto/serviço, objetivo da campanha, CTA principal
+2. `outputs/designer-manual-marca.json` — tom de voz, vocabulário, headlines, paleta, tipografia, conceito visual (substitui os antigos brandbook + identidade-visual)
+3. `outputs/gt-diagnostico-criativos.json` — análise dos criativos atuais, o que funciona/não funciona, recomendações
+5. `client.json` (seção `history`) — decisões anteriores
+
+Se alguma dependência faltar, avise o operador.
+
+---
+
+## Geração
+
+Gere o output COMPLETO de uma vez: briefing criativo com **4 variações** (1 ângulo distinto cada, amarrada a uma fase de funil) + prompts Midjourney/Ideogram + guias de montagem + hipótese e nomenclatura por peça. Use os dados de `client.json` (briefing) e outputs de skills dependentes em `outputs/`.
+
+Consulte `references/hooks-que-funcionam.md` para fórmulas de hook testadas.
+
+### 4 variações de criativo, cada uma com ângulo/hook distinto e fase de funil
+> (A Variação 5 abaixo é **reserva opcional** — use se quiser um 5º ângulo para a primeira leva.)
+
+**Variação 1 — Hook de Dor/Problema:** espelha a frustração do ICP
+**Variação 2 — Hook de Resultado/Transformação:** mostra o "depois"
+**Variação 3 — Hook de Curiosidade/Pergunta:** gera clique
+**Variação 4 — Hook de Prova Social/Número:** dado concreto, caso real
+**Variação 5 — Hook de Urgência/Escassez:** escassez real
+
+Para cada variação:
+1. Hook type + Hook text (máx. 10 palavras)
+2. Copy curta (até 50 palavras) + Copy média (50-100 palavras)
+3. Headline do anúncio (máx. 30 chars) + Descrição (máx. 90 chars) + CTA do botão
+4. Conceito visual (descrição detalhada da imagem/composição)
+5. Formato recomendado (feed 1080x1080 / 1080x1350 / stories 1080x1920 / carrossel)
+
+### Prompts Midjourney/Ideogram para cada variação
+
+**Prompt Midjourney:** tipo de output, cena/composição, cores hex, estilo, parâmetros (--v 6/7, --ar), negativos
+**Prompt Ideogram:** se tiver texto, incluir texto exato + tipografia + layout
+**Guia de montagem (Canva):** posição do texto, tamanho mínimo de fonte (24pt+), posição do logo, formatos de exportação
+
+### Guia de teste A/B
+
+Combinações de teste, métricas de sucesso (CTR > X%, CPC < R$ Y), prazo de teste (7 dias mínimo), critério de corte.
+
+## Auto-validação
+
+Antes de mostrar ao operador, verifique:
+
+- [ ] Mencionou o cliente pelo nome?
+- [ ] Usou dados reais do client.json (não inventou)?
+- [ ] Nenhum item genérico (ex: "quer crescer", "qualidade e compromisso")?
+- [ ] Schema da skill validou?
+- [ ] Todos os campos do schema preenchidos (ou com `null` + `unavailable_reason` no pai)?
+- [ ] Nenhuma string vazia (`""`) — substituí por `null` + reason quando o dado não existe?
+- [ ] Estimativas marcadas com `estimated: true` ou `[E]`?
+- [ ] Consistente com outputs anteriores (brandbook, identidade visual)?
+- [ ] Hooks são específicos para o ICP (não genéricos)?
+- [ ] Conceitos visuais são factíveis no Midjourney/Ideogram?
+- [ ] Cada variação testa uma hipótese DIFERENTE (não variações do mesmo)?
+
+Se falhou → regenere silenciosamente. Não avise o operador.
+
+## Apresentação e decisões
+
+Apresente o output COMPLETO ao operador — 5 variações com hooks, prompts e guias.
+
+Revise o output. O que está errado, exagerado ou faltando?
+
+- "Os hooks são específicos para o ICP?"
+- "Os conceitos visuais são factíveis?"
+- "O tom está alinhado com o brandbook?"
+- "Alguma variação deve ser substituída por outro tipo de hook?"
+- "Alguma restrição de marca? (ex: 'não pode usar vermelho', 'sem fotos de pessoas')"
+
+**Próximo passo (semi-manual):**
+1. Operador copia prompts e gera no Midjourney/Ideogram
+2. Gera pelo menos 4 opções por variação
+3. Seleciona a melhor imagem de cada
+4. Monta no Canva seguindo o guia
+5. Exporta em 3 formatos: 1080x1080 (square), 1080x1350 (feed_portrait), 1080x1920 (stories)
+
+Após o operador gerar e montar, organize o pack (inventário por variação × formato, tabela de copy resumida) e confirme checklist final.
+
+## Registro dos criativos produzidos (`produced_creatives`)
+
+Depois que o operador entrega os PNGs finais, atualize o JSON com o bloco `produced_creatives`. Esse bloco é o que o portal renderiza como grid visual + download direto e é o que `copy-anuncios` referencia via `pair_with_creative`.
+
+**Convenção de hospedagem:**
+- Salvar PNGs em `squads/{squad}/clientes/{cliente}/landing-{slug}/public/photos/criativos/`
+- Naming: `feed-0N.png` (5 unidades, 1080×1350) e `story-0N.png` (3 unidades, 1080×1920)
+- URL pública: `https://{slug}-landing.vercel.app/photos/criativos/{id}.png` após o próximo deploy da landing
+
+**Estrutura do bloco:**
+```json
+"produced_creatives": {
+  "summary": "1-2 frases — quantos foram, formatos, onde estão hospedados.",
+  "feed_instagram": [
+    {
+      "id": "feed-01",
+      "url": "https://{slug}-landing.vercel.app/photos/criativos/feed-01.png",
+      "format": "feed_portrait",
+      "dimensions": "1080×1350",
+      "linked_variation": "social_proof",
+      "caption_label": "Frase curta resumindo o conceito (vai no card)",
+      "use_with_copy": "Hook MOFU prova social — 'ex: 4,9★ + +1.200 clientes'"
+    }
+  ],
+  "stories_instagram": [
+    {
+      "id": "story-01",
+      "url": "...",
+      "format": "stories",
+      "dimensions": "1080×1920",
+      "linked_variation": "dor",
+      "caption_label": "...",
+      "use_with_copy": "..."
+    }
+  ]
+}
+```
+
+**Por que existe:** sem esse bloco, o portal de entregáveis renderiza só copy/donut/variações textuais — o cliente não vê o criativo produzido. `linked_variation` cruza com o `hook_type` da variação correspondente; `use_with_copy` orienta o gestor de tráfego a parear copy + criativo.
+
+## Finalização
+
+Operador aprova (com ou sem ajustes).
+1. Salve em `squads/{squad}/clientes/{cliente}/outputs/designer-criativos-anuncios.json` (com campo `summary` no topo)
+2. Atualize `client.json`: progress.skills → completed, version++, append em history[]
+3. Salve também uma versão Markdown do entregável na mesma pasta de outputs.
+4. Sugira próxima skill do dependency_graph
+
+## Formato do output (designer-criativos-anuncios.json)
+
+```json
+{
+  "variations": [
+    {
+      "hook_type": "dor",
+      "hook_text": "string",
+      "short_copy": "string",
+      "medium_copy": "string",
+      "headline": "string",
+      "description": "string",
+      "button_cta": "string",
+      "visual_concept": "string",
+      "recommended_format": "feed_square | feed_portrait | stories | carousel",
+      "midjourney_prompt": "string",
+      "ideogram_prompt": "string",
+      "canva_guide": "string"
+    }
+  ],
+  "ab_test_guide": {
+    "combinations": ["string"],
+    "success_metrics": { "ctr_min": "string", "cpc_max": "string" },
+    "test_duration": "7 dias",
+    "cut_criteria": "string"
+  },
+  "total_pieces": 15,
+  "produced_creatives": {
+    "summary": "string — só após produção. Ausente até o operador entregar os PNGs.",
+    "feed_instagram": [{ "id": "feed-01", "url": "...", "format": "feed_portrait", "dimensions": "1080×1350", "linked_variation": "social_proof", "caption_label": "...", "use_with_copy": "..." }],
+    "stories_instagram": [{ "id": "story-01", "url": "...", "format": "stories", "dimensions": "1080×1920", "linked_variation": "dor", "caption_label": "...", "use_with_copy": "..." }]
+  }
+}
+```
+
+
+## Campo obrigatório: summary
+
+Sempre inclua no JSON de saída:
+```json
+"summary": "Resumo de 1-2 frases do briefing de criativos: número de variações e formato/gancho principal. Seja específico — mencione o cliente, números reais e a conclusão principal."
+```
+
+Este campo alimenta o Resumo Executivo do portal de entregas. Deve ser objetivo, com dados reais, sem genéricos.

--- a/.claude/skills/designer-criativos-anuncios/references/hooks-que-funcionam.md
+++ b/.claude/skills/designer-criativos-anuncios/references/hooks-que-funcionam.md
@@ -1,0 +1,192 @@
+# Hooks que Funcionam — Fórmulas com Exemplos para Anúncios
+
+Referência de fórmulas de hook testadas em performance marketing para PMEs brasileiras. Cada fórmula inclui a estrutura, por que funciona e exemplos adaptáveis.
+
+---
+
+## 1. Hooks de Dor/Problema
+
+Princípio: O ICP age quando se vê no problema. A dor é mais motivadora que o desejo.
+
+### Fórmula 1: Espelho da frustração
+**Estrutura:** "Cansou de [frustração repetitiva]?"
+- "Cansou de perder clientes pro iFood?"
+- "Cansou de leads que somem depois do primeiro contato?"
+- "Cansou de pagar caro por resultado que não aparece?"
+
+### Fórmula 2: O custo invisível
+**Estrutura:** "Você está perdendo R$ [valor] por [período] porque [causa]"
+- "Você está perdendo R$ 5.000/mês porque ninguém responde seus leads em menos de 1 hora"
+- "Você está perdendo 30% dos clientes porque seu site demora 7 segundos pra carregar"
+- "Cada dia sem follow-up automático custa R$ 200 em leads perdidos"
+
+### Fórmula 3: A pergunta incômoda
+**Estrutura:** "[Pergunta que o ICP evita responder]?"
+- "Quantos leads você perdeu essa semana?"
+- "Quanto do seu faturamento depende do iFood?"
+- "Qual foi a última vez que alguém te indicou espontaneamente?"
+
+### Fórmula 4: O sintoma
+**Estrutura:** "Se [sintoma], [diagnóstico]"
+- "Se seus anúncios geram cliques mas não geram vendas, o problema não é o tráfego"
+- "Se você tem 5.000 seguidores mas 0 vendas pelo Instagram, seu perfil tem um erro"
+- "Se todo mês parece que começa do zero, você não tem um funil — tem uma rifa"
+
+**Por que funciona:** Dor ativa o sistema 1 do cérebro (reação emocional rápida). O ICP reconhece o problema e para o scroll.
+
+---
+
+## 2. Hooks de Resultado/Transformação
+
+Princípio: Mostra o "depois" — o estado desejado que o ICP busca.
+
+### Fórmula 1: De X para Y
+**Estrutura:** "De [estado atual ruim] para [estado desejado] em [prazo]"
+- "De 3 clientes na indicação para 30 leads qualificados por mês"
+- "De planilha no Excel para gestão financeira de verdade em 2 semanas"
+- "De R$ 2.000 em anúncios sem retorno para ROAS de 4x no primeiro mês"
+
+### Fórmula 2: Caso real com nome
+**Estrutura:** "[Nome/empresa] [resultado específico] em [prazo]"
+- "A Cantina Mineira triplicou o delivery em 4 meses"
+- "Dr. Silva lotou a agenda em 60 dias"
+- "A loja da Rua Augusta saiu de 0 para 47 pedidos online por semana"
+
+### Fórmula 3: Número impactante
+**Estrutura:** "[Número específico] + [resultado concreto]"
+- "R$ 12.000 economizados em comissões de marketplace"
+- "347 leads qualificados em 90 dias de campanha"
+- "Atendimento 87% mais rápido com automação de WhatsApp"
+
+### Fórmula 4: A vida depois
+**Estrutura:** "Imagine [cenário desejado realista]"
+- "Imagine abrir o WhatsApp segunda-feira e ter 15 leads novos esperando"
+- "Imagine saber exatamente quanto cada real de anúncio retorna"
+- "Imagine nunca mais perder um lead porque esqueceu de responder"
+
+**Por que funciona:** Resultado ativa aspiração. O ICP se projeta no futuro e deseja estar ali.
+
+---
+
+## 3. Hooks de Curiosidade/Pergunta
+
+Princípio: O cérebro humano não tolera informação incompleta. A curiosidade gera clique.
+
+### Fórmula 1: O erro que todos cometem
+**Estrutura:** "O erro que [número]% dos [ICP] cometem com [tema]"
+- "O erro que 87% dos donos de restaurante cometem com delivery"
+- "O erro que mata a conversão da maioria das landing pages"
+- "3 erros de anúncio que estão queimando seu budget"
+
+### Fórmula 2: O segredo revelado
+**Estrutura:** "O que [autoridade/caso] faz que [ICP] não faz"
+- "O que restaurantes com 4.9 estrelas fazem que você não faz"
+- "O que empresas com ROAS acima de 5x têm em comum"
+- "A única métrica que importa no seu anúncio (e não é o CTR)"
+
+### Fórmula 3: Contraintuitivo
+**Estrutura:** "[Afirmação que contradiz a crença do ICP]"
+- "Mais seguidores NÃO significa mais vendas"
+- "O melhor criativo do mundo não salva uma oferta ruim"
+- "Investir mais em anúncios pode PIORAR seu resultado"
+
+### Fórmula 4: Teste/Quiz
+**Estrutura:** "Descubra [insight sobre si mesmo]"
+- "Descubra em 30 segundos se seu anúncio está queimando dinheiro"
+- "Seu site passa no teste dos 5 segundos? A maioria não passa"
+- "Quiz: seu negócio está pronto para escalar?"
+
+**Por que funciona:** Loop aberto. O cérebro precisa fechar a informação, gerando clique.
+
+---
+
+## 4. Hooks de Prova Social/Número
+
+Princípio: Comportamento de manada. Se muitos estão fazendo, deve ser bom.
+
+### Fórmula 1: Volume impressionante
+**Estrutura:** "+[número] [ICPs] já [ação/resultado]"
+- "+500 PMEs em BH já automatizaram o follow-up de leads"
+- "+1.200 restaurantes saíram da dependência do iFood"
+- "R$ 2 milhões em vendas geradas para nossos clientes em 2025"
+
+### Fórmula 2: Depoimento direto
+**Estrutura:** "[Frase do cliente]" — [Nome, contexto]
+- "Em 60 dias, saí de 3 para 18 leads por semana" — Ana, Clínica Bella
+- "Melhor investimento que fiz no ano" — Carlos, Restaurante do Lago
+- "Finalmente sei pra onde vai cada real" — Mariana, e-commerce de moda
+
+### Fórmula 3: Avaliação/Rating
+**Estrutura:** "[Rating] com base em [número] avaliações"
+- "Avaliado com 4.9★ por 340 clientes"
+- "NPS 92 — 9 em cada 10 clientes nos recomendam"
+- "96% de satisfação medida mês a mês"
+
+### Fórmula 4: Comparação temporal
+**Estrutura:** "Em [período], [resultado mensurável]"
+- "Em 90 dias: 340 leads, 47 vendas, R$ 94.000 em faturamento"
+- "30 dias: de 0 a 12 vendas pelo WhatsApp"
+- "Primeiro mês: o investimento se pagou 3x"
+
+**Por que funciona:** Reduz risco percebido. Se outros iguais a mim tiveram resultado, eu também terei.
+
+---
+
+## 5. Hooks de Urgência/Escassez
+
+Princípio: Medo de perder (FOMO) é mais forte que desejo de ganhar. Mas APENAS se real.
+
+### Fórmula 1: Vagas limitadas (real)
+**Estrutura:** "Últimas [número] vagas para [oferta]"
+- "Últimas 5 vagas para onboarding em abril"
+- "Aceitamos apenas 3 novos clientes por mês"
+- "Turma de abril: 2 vagas restantes"
+
+### Fórmula 2: Prazo de oferta (real)
+**Estrutura:** "[Oferta] válida até [data]"
+- "Diagnóstico gratuito até sexta-feira"
+- "Preço de lançamento válido até dia 15"
+- "Setup sem custo para quem fechar até o final do mês"
+
+### Fórmula 3: Custo da inação
+**Estrutura:** "Cada [período] sem [ação] = [custo concreto]"
+- "Cada semana sem automação = ~20 leads perdidos"
+- "Cada mês sem otimização = R$ 3.000 desperdiçados em anúncios"
+- "Enquanto você espera, seu concorrente está capturando seus leads"
+
+### Fórmula 4: Janela de oportunidade
+**Estrutura:** "[Contexto temporal] + [por que agora é o momento]"
+- "O algoritmo do Meta está favorecendo vídeo curto. Quem entrar agora paga menos"
+- "Black Friday em 45 dias. Quem começa agora tem tempo de testar"
+- "Seu concorrente acabou de lançar anúncios. Cada dia conta"
+
+**Por que funciona:** Urgência ativa ação imediata. Mas FAKE urgência destrói credibilidade. Countdown falso, escassez inventada, "oferta por tempo limitado" que nunca acaba — tudo isso é detectado pelo público.
+
+### REGRA DE OURO: Só use urgência real
+- Capacidade de atendimento genuinamente limitada? OK
+- Preço de lançamento com data real? OK
+- Sazonalidade de mercado? OK
+- Countdown falso que reseta? NUNCA
+- "Últimas vagas" que nunca acabam? NUNCA
+
+---
+
+## Matriz de Decisão: Qual hook para qual fase do funil
+
+| Fase | Hook primário | Hook secundário | Por quê |
+|------|--------------|----------------|---------|
+| Topo (consciência) | Dor/Problema | Curiosidade | O ICP não sabe que existe solução, precisa reconhecer o problema |
+| Meio (consideração) | Resultado | Prova Social | O ICP já sabe do problema, precisa de evidência que existe solução |
+| Fundo (conversão) | Urgência | Resultado + Prova Social | O ICP já quer, precisa de empurrão para agir agora |
+| Remarketing | Prova Social | Urgência leve | O ICP já viu o produto, precisa de confiança e motivo para voltar |
+
+---
+
+## Checklist de Qualidade dos Hooks
+
+- [ ] Cada hook é específico para o ICP (não funcionaria para outro público)?
+- [ ] O hook funciona em 3 segundos de leitura (tela do mobile)?
+- [ ] O hook gera emoção (dor, desejo, curiosidade, medo) — não apenas informa?
+- [ ] As 5 variações testam hipóteses genuinamente diferentes?
+- [ ] Nenhum hook usa urgência/escassez fake?
+- [ ] Os hooks respeitam políticas de plataforma (sem afirmações pessoais diretas, sem promessas absolutas)?

--- a/.claude/skills/designer-criativos-anuncios/schema.json
+++ b/.claude/skills/designer-criativos-anuncios/schema.json
@@ -1,0 +1,320 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Criativos de Anúncios",
+  "description": "Output estruturado do pack de criativos: 5 variações com hooks diferentes, prompts de geração e guia de teste A/B.",
+  "type": "object",
+  "required": [
+    "summary",
+    "variations",
+    "ab_test_guide",
+    "total_pieces",
+    "client_name",
+    "summary_headline",
+    "summary_highlights",
+    "summary_key_findings"
+  ],
+  "properties": {
+    "client_name": {
+      "type": "string",
+      "description": "Nome do cliente — sempre presente em todo output."
+    },
+    "summary": {
+      "type": "string",
+      "description": "Resumo de 1-2 frases do briefing de criativos. Inclui número de variações e formato/gancho principal."
+    },
+    "summary_headline": {
+      "type": "string",
+      "description": "Manchete em 1 linha (~120 caracteres) com o veredito da skill."
+    },
+    "summary_highlights": {
+      "type": "array",
+      "description": "KPIs em destaque (4-6 itens). Categorias: posicao | competicao | janela | maturidade | oportunidade | risco.",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "label",
+          "value",
+          "tone"
+        ],
+        "properties": {
+          "category": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "subtext": {
+            "type": "string"
+          },
+          "tone": {
+            "type": "string",
+            "enum": [
+              "green",
+              "yellow",
+              "red",
+              "blue",
+              "gray"
+            ]
+          }
+        }
+      }
+    },
+    "summary_key_findings": {
+      "type": "array",
+      "description": "3-5 achados categorizados (vantagem | contexto | ameaca | acao).",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "text"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "vantagem",
+              "contexto",
+              "ameaca",
+              "acao"
+            ]
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "variations": {
+      "type": "array",
+      "description": "5 variações de criativo, cada uma com um tipo de hook diferente.",
+      "minItems": 5,
+      "maxItems": 5,
+      "items": {
+        "type": "object",
+        "required": [
+          "hook_type",
+          "hook_text",
+          "short_copy",
+          "medium_copy",
+          "headline",
+          "description",
+          "button_cta",
+          "visual_concept",
+          "recommended_format"
+        ],
+        "properties": {
+          "hook_type": {
+            "type": "string",
+            "enum": [
+              "dor",
+              "resultado",
+              "curiosidade",
+              "social_proof",
+              "urgencia"
+            ],
+            "description": "Tipo de hook testado nesta variação"
+          },
+          "hook_text": {
+            "type": "string",
+            "description": "Primeira frase/headline que para o scroll — máx 10 palavras",
+            "maxLength": 80
+          },
+          "short_copy": {
+            "type": "string",
+            "description": "Copy curta até 50 palavras para formatos compactos"
+          },
+          "medium_copy": {
+            "type": "string",
+            "description": "Copy média 50-100 palavras para formatos com mais espaço"
+          },
+          "headline": {
+            "type": "string",
+            "description": "Headline do anúncio — máx 30 caracteres",
+            "maxLength": 30
+          },
+          "description": {
+            "type": "string",
+            "description": "Descrição do anúncio — máx 90 caracteres",
+            "maxLength": 90
+          },
+          "button_cta": {
+            "type": "string",
+            "description": "Texto do botão CTA"
+          },
+          "visual_concept": {
+            "type": "string",
+            "description": "Descrição detalhada da imagem/composição visual para geração"
+          },
+          "recommended_format": {
+            "type": "string",
+            "enum": [
+              "feed_square",
+              "feed_portrait",
+              "stories",
+              "carousel"
+            ],
+            "description": "Formato visual recomendado"
+          },
+          "midjourney_prompt": {
+            "type": "string",
+            "description": "Prompt completo para Midjourney com parâmetros"
+          },
+          "ideogram_prompt": {
+            "type": "string",
+            "description": "Prompt para Ideogram (quando há texto no criativo)"
+          },
+          "canva_guide": {
+            "type": "string",
+            "description": "Instruções de montagem final no Canva"
+          }
+        }
+      }
+    },
+    "ab_test_guide": {
+      "type": "object",
+      "required": [
+        "combinations",
+        "success_metrics",
+        "test_duration",
+        "cut_criteria"
+      ],
+      "properties": {
+        "combinations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Combinações sugeridas de teste A/B"
+        },
+        "success_metrics": {
+          "type": "object",
+          "properties": {
+            "ctr_min": {
+              "type": "string",
+              "description": "CTR mínimo aceitável"
+            },
+            "cpc_max": {
+              "type": "string",
+              "description": "CPC máximo aceitável"
+            }
+          }
+        },
+        "test_duration": {
+          "type": "string",
+          "description": "Duração mínima do teste"
+        },
+        "cut_criteria": {
+          "type": "string",
+          "description": "Critério para eliminar variações de baixa performance"
+        }
+      }
+    },
+    "total_pieces": {
+      "type": "integer",
+      "description": "Total de peças no pack (variações × formatos)",
+      "minimum": 15
+    },
+    "produced_creatives": {
+      "type": "object",
+      "description": "Registro dos PNGs efetivamente produzidos (após etapa semi-manual de geração). Opcional — só presente após operador entregar os assets. Cruza com copy-anuncios via 'linked_variation' e 'pair_with_creative'.",
+      "properties": {
+        "summary": {
+          "type": "string",
+          "description": "1-2 frases — quantos foram, formatos, onde estão hospedados."
+        },
+        "feed_instagram": {
+          "type": "array",
+          "description": "Criativos de feed Instagram (4:5 / 1080×1350).",
+          "items": {
+            "type": "object",
+            "required": [
+              "id",
+              "url"
+            ],
+            "properties": {
+              "id": {
+                "type": "string",
+                "pattern": "^feed-\\d{2}$",
+                "description": "Convenção: feed-01, feed-02, ..."
+              },
+              "url": {
+                "type": "string",
+                "format": "uri",
+                "description": "URL pública do PNG (Vercel CDN da landing-{slug})."
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "feed_square",
+                  "feed_portrait"
+                ]
+              },
+              "dimensions": {
+                "type": "string",
+                "description": "Ex: '1080×1350'."
+              },
+              "linked_variation": {
+                "type": "string",
+                "description": "hook_type da variação correspondente em 'variations[]'."
+              },
+              "caption_label": {
+                "type": "string",
+                "description": "Frase curta resumindo o conceito visual (vai no card do portal)."
+              },
+              "use_with_copy": {
+                "type": "string",
+                "description": "Orientação de pareamento com copy (etapa funil + hook)."
+              }
+            }
+          }
+        },
+        "stories_instagram": {
+          "type": "array",
+          "description": "Criativos de stories Instagram (9:16 / 1080×1920).",
+          "items": {
+            "type": "object",
+            "required": [
+              "id",
+              "url"
+            ],
+            "properties": {
+              "id": {
+                "type": "string",
+                "pattern": "^story-\\d{2}$",
+                "description": "Convenção: story-01, story-02, ..."
+              },
+              "url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "stories"
+                ]
+              },
+              "dimensions": {
+                "type": "string"
+              },
+              "linked_variation": {
+                "type": "string"
+              },
+              "caption_label": {
+                "type": "string"
+              },
+              "use_with_copy": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/.claude/skills/designer-manual-marca/SKILL.md
+++ b/.claude/skills/designer-manual-marca/SKILL.md
@@ -1,0 +1,238 @@
+---
+name: designer-manual-marca
+description: "Manual de Marca completo (Brandbook estratégico + MIV técnico unificados em 5 blocos). Substitui brandbook legado + identidade visual legada. Use quando disser /designer-manual-marca ou 'manual de marca' ou 'MIV' ou 'brand guidelines'."
+area: designer
+author: luizfreitasv4
+version: 1.0.0
+dependencies:
+  - geral-posicionamento-estrategico
+  - geral-persona-icp
+  - geral-analise-swot
+  - geral-pesquisa-mercado
+inputs:
+  - client.json (briefing + brand)
+  - geral-posicionamento-estrategico.json
+  - geral-persona-icp.json
+  - geral-analise-swot.json
+  - geral-pesquisa-mercado.json
+output: designer-manual-marca.json
+week: 4
+type: automated
+estimated_time: "8h"
+supersedes:
+  - brandbook legado
+  - identidade visual legada
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta versao foi portada do sistema de Estruturacao Estrategica. As regras abaixo tem precedencia sobre caminhos e persistencia citados no fluxo original:
+
+- Trabalhe somente em `squads/{squad}/clientes/{cliente}/`, nunca em um diretorio `clientes/` solto na raiz.
+- Leia primeiro o `CLAUDE.md` ou `AGENTS.md` da KB, `mission-control/`, `calls/`, `docs/` e `campanhas/`.
+- Se `client.json` existir, use-o como fonte complementar. Se nao existir, derive o contexto da KB e do Mission Control; nao exija nem invente esse arquivo.
+- Salve entregaveis em `squads/{squad}/clientes/{cliente}/outputs/`, em JSON e Markdown quando o fluxo pedir ambos.
+- Registre decisoes e progresso no `mission-control/historico-checkins.md` ou no arquivo de historico equivalente encontrado na KB.
+- Resolva recursos empacotados a partir do proprio diretorio desta skill. Se uma integracao externa nao estiver configurada, declare o gap e continue apenas com os dados reais disponiveis.
+
+
+# Manual de Marca — Brandbook + MIV unificados (POP 3.9)
+
+> **Posição no fluxo:** Semana 4 — Identidade de Comunicação e Plano de Mídia (**comum** a todos os modelos) (igual para e-commerce / inside-sales / pdv). Deriva do posicionamento (S2). Tom de voz com exemplos de frase on/off-brand (não só adjetivos); versão operacional, não manual de 80 páginas.
+
+Você é um brand strategist + diretor de arte sênior. Vai criar o Manual de Marca completo unificando Brandbook estratégico (porquê) e Manual de Identidade Visual (como), no formato dos 5 blocos da Estrutura MIV.
+
+Esta skill **substitui** `brandbook legado` e `identidade visual legada`. Os outputs antigos ficam no histórico mas as skills downstream (LP, copy, criativos, scripts SDR) passam a depender de `designer-manual-marca`.
+
+## ⚠️ Princípio fundamental: este manual é DOCUMENTACIONAL, não criativo
+
+**O manual define COMO a MIV deve ser construída — ele não é o entregável visual final.** O entregável visual (logo finalizado, mockups de cartão, peças de IG, ícones desenhados) é trabalho do designer (Midjourney + Canva + designer humano), feito DEPOIS deste manual e usando este manual como briefing.
+
+### O que NÃO renderizar visualmente
+
+- ❌ Logo desenhado, símbolo, wordmark estilizado, mascote
+- ❌ Galeria visual de "nunca faça" do logo (com transformações, cores, distorções)
+- ❌ Ícones desenhados / iconografia simulada
+- ❌ Mockups de aplicações (cartão de visita, IG bio/feed/story, favicon, WhatsApp Business, GMB, e-mail signature, deck, fachada, uniforme)
+- ❌ Avatar da persona, mascote, ilustração
+- ❌ Simulação de fotografia, mood board renderizado
+
+### O que SIM renderizar visualmente
+
+- ✓ **Tipografia em escala real** — fonte primária e secundária mostradas no tamanho exato da hierarquia (H1, H2, H3, body, caption, CTA). Sem ver a fonte real, ninguém valida se a hierarquia funciona.
+- ✓ **Sistema cromático** — paleta em swatches com hex/rgb/cmyk/role/justificativa. Pode incluir: swatches em tamanho confortável (não precisa ser mini), proporção 60-30-10 visual, e matriz WCAG com referência da cor sobre fundo.
+- ✓ **Diagramas estratégicos estruturais** quando ajudam a leitura (matriz competitiva 2x2, escalas de personalidade) — não são criação visual de marca, são gráficos de informação.
+
+### Regras adicionais obrigatórias
+
+**Tipografia (Bloco 3) — Google Fonts é obrigatório:**
+
+- A fonte primária e a secundária devem **OBRIGATORIAMENTE** estar disponíveis no [Google Fonts](https://fonts.google.com/). Fontes proprietárias, comerciais (Adobe Fonts, MyFonts) ou desktop-only não são permitidas.
+- Para cada fonte, preencher OBRIGATORIAMENTE:
+  - `name` — nome exato da fonte
+  - `source` — sempre `"Google Fonts"` (literal)
+  - `google_fonts_url` — link direto da página da fonte (ex: `https://fonts.google.com/specimen/Fraunces`)
+  - `embed_url` — link CSS para `<link href>` ou `@import` (ex: `https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,600;9..144,700&display=swap`)
+- O renderer mostra o link clicável da fonte na documentação para que o designer/desenvolvedor abra direto.
+
+**Logo (Bloco 3) — descrição rica obrigatória:**
+
+O logo NÃO é desenhado neste manual (responsabilidade do designer). Mas a documentação precisa ser **rica o suficiente** para o designer trabalhar a partir dela. Preencher OBRIGATORIAMENTE:
+
+- `concept` — 1-2 parágrafos sobre o que o logo expressa estrategicamente
+- `style_description` — 200+ caracteres descrevendo a linguagem visual concreta: tipo (serif/sans/symbolic/wordmark), peso, tratamento, atemporalidade, escalabilidade
+- `visual_attributes` (objeto com 7 campos):
+  - `form_language` — geométrico / orgânico / mixed (com justificativa)
+  - `weight` — fino / médio / robusto
+  - `balance` — simétrico / assimétrico controlado
+  - `negative_space` — denso / equilibrado / generoso
+  - `color_application` — monocromático / duotone / gradient (com regras)
+  - `personality_in_form` — como CADA adjetivo do tom de voz se traduz na forma
+  - `scalability` — comportamento em escala mínima e máxima
+  - `differentiation_from_competitors` — como se diferencia visualmente dos concorrentes
+- `design_principles` — 4+ princípios curtos que orientam o logo (ex: "sobriedade acima de fofura", "tipografia faz o trabalho pesado")
+
+Esses campos juntos dão ao designer um briefing 10× mais rico do que apenas "logo serif roxo".
+
+### Como os demais blocos devem aparecer
+
+Tudo o que não for tipografia ou swatch de cor mini deve aparecer como:
+
+- **Texto descritivo** (definições, regras, princípios, conceitos)
+- **Tabelas** (diga/não diga, valores, do/dont, hierarquia, glossário, WCAG, matriz competitiva)
+- **Listas estruturadas** (pilares, ganchos de abertura, anti-persona, ações)
+- **Cards de texto** com título + descrição
+
+Por exemplo:
+- Galeria "nunca faça" do logo → **lista textual** "Não distorcer · razão: quebra proporção tipográfica"
+- Iconografia → **regras textuais** de stroke, grid, estilo (sem desenhar ícones)
+- Mockup de cartão de visita → **specs em texto** (dimensões, tipografia, posicionamento, hierarquia)
+- Mockup de post de IG → **specs em texto** (dimensões 1080×1080, headline em Fraunces 64px, etc.)
+- Persona Mariana → **card de texto com 6 campos** (sem avatar SVG, sem foto)
+- 3 direções de logo → **cards de texto** com nome do estilo, conceito em 1 frase, prompt do Midjourney completo (sem mini-ícones representativos)
+
+O designer (humano ou Midjourney) lê o manual e produz os assets. O manual é a régua, não o entregável.
+
+## Estrutura dos 5 blocos
+
+- **Bloco 1 — Fundamentos Estratégicos:** apresentação/manifesto, essência (propósito/visão/missão/valores/promessa/big idea/pilares), posicionamento (statement/território/arquétipo/matriz competitiva/PUV), público e persona (template padronizado, secundária, anti-persona, jornada), história e cultura.
+- **Bloco 2 — Identidade Verbal:** personalidade (escalas + arquétipo aplicado + "se a marca fosse pessoa"), tom de voz (4 pilares + variações por canal + diga/não diga), diretrizes editoriais (vocabulário categorizado por função, glossário, terminologia proibida, regras gramaticais), naming, storytelling, slogan/tagline/assinaturas.
+- **Bloco 3 — Identidade Visual Core:** logo (conceito/anatomia/grid/clear space/min-max/versões/3 direções de prompt), galeria de usos incorretos, sistema cromático (paletas + WCAG + 60-30-10), tipografia (hierarquia + pesos + fallbacks), iconografia, grafismos, fotografia, ilustração.
+- **Bloco 4 — Aplicações:** princípio de mockups contextuais; papelaria essencial (cartão, e-mail signature, deck), digital/UI (favicon, app icon, e-mail templates, WhatsApp Business), redes sociais (avatar, bio, feed, stories, GMB), materiais de venda (one-pager, brindes). Para PMEs early-stage, escopo reduzido — pula fachada/uniforme/embalagem se não escala ROI.
+- **Bloco 5 — Governança:** brand owner, processo de aprovação, cadência de revisão.
+
+## Escopo por maturidade da marca
+
+- **Early-stage (PME nova, <2 anos de operação madura):** Blocos 1-3 completos, Bloco 4 com seleção (digital + redes sociais + papelaria essencial), Bloco 5 enxuto.
+- **Estabelecida (PME com base ativa, >5 anos):** todos os blocos, Bloco 4 ampliado com fachada/uniforme/embalagem se aplicável, Bloco 5 com comitê de marca.
+
+Decida o escopo lendo `client.json.briefing` (segmento, tempo de mercado, base ativa) e o tamanho operacional. Se ambíguo, pergunte ao operador antes.
+
+## Reuso obrigatório de outputs anteriores
+
+Toda decisão estratégica que JÁ EXISTE em outputs aprovados deve ser **referenciada e reaproveitada**, nunca refeita:
+
+- **Posicionamento** → `outputs/geral-posicionamento-estrategico.json` → `chosen_statement`, `puv`, `recommended_tagline`, `brand_territory`, `canvas_4p`
+- **Persona/ICP** → `outputs/geral-persona-icp.json` → `persona`, `icp`, `key_message`, `buyer_journey`, `anti_persona`, `objection_library`, `willingness_to_pay`
+- **Diferenciais** → `outputs/geral-analise-swot.json` → `strengths`, `key_play`
+- **Mercado** → `outputs/geral-pesquisa-mercado.json` → `differentials`, `competitors`, `trends`
+- **Cores existentes** → `client.json.briefing.brand.current_colors` (se já houver paleta consolidada, manter e formalizar — não inventar nova sem motivo estratégico)
+
+Se o operador questionar qualquer dado já validado nas semanas anteriores, **NÃO modifique** outputs anteriores — pergunte se quer atualizar a fonte.
+
+## Geração
+
+Gere o output COMPLETO de uma vez. Para cada bloco, preencha todos os campos do schema. Onde o dado real do cliente não existe, use `null` + `unavailable_reason` (e nunca string vazia).
+
+### Diretrizes específicas por bloco
+
+**Bloco 1 — Manifesto:**
+- Manifesto curto (1 frase) deve caber em sticker/bio. Se trocar o nome do cliente e ainda funcionar, está genérico.
+- Manifesto narrativo (1 página) reusa a estrutura de 3 atos do brand_narrative já definido em S2 (antes/diferente/depois).
+- Big idea = 1 frase que sustenta toda a comunicação. Diferente de tagline (institucional fixa) e slogan (campanha).
+- Pilares (4-5): nome curto + 1 frase. Diferente de valores (comportamental) e USPs (argumento de venda).
+
+**Bloco 1 — Posicionamento:**
+- Statement reusa o `chosen_statement` do `geral-posicionamento-estrategico.json`.
+- Arquétipo: escolha 1 dominante + 1 secundário (Jung/Pearson). Justifique a escolha com base no posicionamento aprovado.
+- Matriz 2x2: reuse `positioning_map` do S2.
+- PUV (formato fixo): "[Marca] combina [diferencial 1] com [diferencial 2] e [bônus exclusivo] para resolver [dor central], eliminando [problema do mercado]."
+
+**Bloco 1 — Persona:**
+- Reuse `persona` e `icp` do S1. Aplique o template de 6 campos (nome+foto, idade, renda, ocupação, dor principal, motivos de compra).
+- Anti-persona reusa do S1.
+- Jornada reusa `buyer_journey` do S1.
+
+**Bloco 2 — Tom de voz:**
+- 4 pilares (não 3, não 5). Cada pilar: nome + definição em 1 frase + manifestação prática.
+- Variações por canal (LinkedIn, Instagram, e-mail transacional, WhatsApp, press release): tom específico para cada.
+- Diga / Não diga: 10-15 situações reais com forma certa vs forma errada + motivo.
+
+**Bloco 2 — Vocabulário categorizado:**
+- 3 colunas: Palavras de Essência (quem somos), Palavras Valorizadas e Repetidas (memória de marca), Palavras que Conectam com o Público (pertencimento).
+- 5-8 palavras por coluna. Glossário e terminologia proibida em listas separadas.
+
+**Bloco 3 — Logo:**
+- 3 direções de prompt para Midjourney (mantém compatibilidade com workflow atual).
+- Galeria "nunca faça": 6+ exemplos visuais com legenda (distorção, recolor, sombra, baixo contraste, rotação, contorno).
+- Min/max em px (digital) e mm (impresso).
+
+**Bloco 3 — Sistema cromático:**
+- Paleta primária + secundária + neutros + cores funcionais (UI: success/error/warning/info).
+- Para CADA cor: HEX + RGB + CMYK + role + justificativa estratégica.
+- Matriz WCAG: combinações texto/fundo com ratio AA/AAA.
+- Proporção 60-30-10 visual.
+
+**Bloco 4 — Mockups contextuais (princípio):**
+- Cada aplicação tem 2 camadas: técnica (specs) + contextual (descrição do mockup que será renderizado em SVG no portal).
+- Para PME early-stage local (vet, dentista, salão): foco em digital + redes sociais + papelaria essencial. Não documentar fachada/uniforme/embalagem se não há ROI.
+
+## Auto-validação
+
+
+Antes de apresentar:
+- [ ] Mencionou o cliente pelo nome em todos os blocos?
+- [ ] Reutilizou (sem refazer) decisões aprovadas em S1/S2?
+- [ ] Big idea, manifesto curto e PUV passam no teste "se trocar o nome funciona pra outra empresa"? Se sim, regenere.
+- [ ] Tom de voz tem exatamente 4 pilares?
+- [ ] Sistema cromático tem WCAG calculado e proporção 60-30-10 definida?
+- [ ] 3 direções de prompt para logo + galeria "nunca faça" com 6+ itens?
+- [ ] Bloco 4 tem ao menos 6 mockups contextuais descritos?
+- [ ] Schema validou?
+
+## Apresentação e decisões
+
+Apresente o output COMPLETO ao operador via portal renderizado.
+
+**DECISÃO 1:** Manifesto curto e Big Idea — passam no teste de troca de nome?
+
+**DECISÃO 2:** Arquétipos dominante + secundário — coerentes com posicionamento aprovado em S2?
+
+**DECISÃO 3:** Direção de logo (das 3 prompts) — qual gerar primeiro no Midjourney?
+
+**DECISÃO 4:** Escopo do Bloco 4 — manter reduzido (early-stage) ou expandir para fachada/uniforme/embalagem?
+
+## Finalização
+
+Operador aprova (com ou sem ajustes).
+1. Salve em `squads/{squad}/clientes/{cliente}/outputs/designer-manual-marca.json` (com `summary` no topo)
+2. Atualize `client.json`: `progress.skills.designer-manual-marca` → completed, version++, append em `history[]`
+3. Marque `brandbook legado` e `identidade visual legada` como `superseded_by: designer-manual-marca` em progress (mantenha completed se já estavam)
+4. Salve também uma versão Markdown do entregável na mesma pasta de outputs.
+5. Sugira próxima skill (geralmente `designer-landing-page` ou paralelizar `otimização do Google Business Profile (ainda não portada)` + `account-crm-setup`)
+
+## Formato do output
+
+Schema completo em `schema.json`. Estrutura geral:
+
+```json
+{
+  "summary": "string",
+  "scope": "early-stage | established",
+  "block1_strategic_foundations": { ... },
+  "block2_verbal_identity": { ... },
+  "block3_visual_identity_core": { ... },
+  "block4_applications": { ... },
+  "block5_governance": { ... }
+}
+```

--- a/.claude/skills/designer-manual-marca/schema.json
+++ b/.claude/skills/designer-manual-marca/schema.json
@@ -1,0 +1,1319 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Manual de Marca (Brandbook + MIV unificados)",
+  "description": "Output unificado: Brandbook estratégico (porquê) + MIV técnico (como) no formato de 5 blocos da Estrutura MIV.",
+  "type": "object",
+  "required": [
+    "summary",
+    "scope",
+    "block1_strategic_foundations",
+    "block2_verbal_identity",
+    "block3_visual_identity_core",
+    "block4_applications",
+    "block5_governance",
+    "client_name",
+    "summary_headline",
+    "summary_highlights",
+    "summary_key_findings"
+  ],
+  "properties": {
+    "client_name": {
+      "type": "string",
+      "description": "Nome do cliente — sempre presente em todo output."
+    },
+    "summary": {
+      "type": "string",
+      "description": "Resumo de 2-3 frases. Cliente pelo nome, principais decisões."
+    },
+    "summary_headline": {
+      "type": "string",
+      "description": "Manchete em 1 linha (~120 caracteres) com o veredito da skill."
+    },
+    "summary_highlights": {
+      "type": "array",
+      "description": "KPIs em destaque (4-6 itens). Categorias: posicao | competicao | janela | maturidade | oportunidade | risco.",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "label",
+          "value",
+          "tone"
+        ],
+        "properties": {
+          "category": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "subtext": {
+            "type": "string"
+          },
+          "tone": {
+            "type": "string",
+            "enum": [
+              "green",
+              "yellow",
+              "red",
+              "blue",
+              "gray"
+            ]
+          }
+        }
+      }
+    },
+    "summary_key_findings": {
+      "type": "array",
+      "description": "3-5 achados categorizados (vantagem | contexto | ameaca | acao).",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "text"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "vantagem",
+              "contexto",
+              "ameaca",
+              "acao"
+            ]
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "scope": {
+      "type": "string",
+      "enum": [
+        "early-stage",
+        "established"
+      ],
+      "description": "Escopo do manual: early-stage (Blocos 1-3 completos + 4 reduzido + 5 enxuto) ou established (todos os blocos completos)."
+    },
+    "block1_strategic_foundations": {
+      "type": "object",
+      "required": [
+        "presentation",
+        "essence",
+        "positioning",
+        "audience_persona"
+      ],
+      "properties": {
+        "presentation": {
+          "type": "object",
+          "required": [
+            "manifesto_short",
+            "manifesto_narrative",
+            "navigation_instructions"
+          ],
+          "properties": {
+            "opening_letter": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "manifesto_short": {
+              "type": "string",
+              "minLength": 20,
+              "maxLength": 200
+            },
+            "manifesto_narrative": {
+              "type": "string",
+              "minLength": 200
+            },
+            "navigation_instructions": {
+              "type": "string"
+            }
+          }
+        },
+        "essence": {
+          "type": "object",
+          "required": [
+            "purpose",
+            "vision",
+            "mission",
+            "values",
+            "promise",
+            "big_idea",
+            "brand_pillars"
+          ],
+          "properties": {
+            "purpose": {
+              "type": "string"
+            },
+            "vision": {
+              "type": "string"
+            },
+            "mission": {
+              "type": "string"
+            },
+            "values": {
+              "type": "array",
+              "minItems": 3,
+              "maxItems": 5,
+              "items": {
+                "type": "object",
+                "required": [
+                  "name",
+                  "behavior_yes",
+                  "behavior_no"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "behavior_yes": {
+                    "type": "string"
+                  },
+                  "behavior_no": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "promise": {
+              "type": "string"
+            },
+            "big_idea": {
+              "type": "string",
+              "maxLength": 200
+            },
+            "brand_pillars": {
+              "type": "array",
+              "minItems": 4,
+              "maxItems": 5,
+              "items": {
+                "type": "object",
+                "required": [
+                  "name",
+                  "description"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "positioning": {
+          "type": "object",
+          "required": [
+            "statement",
+            "territory",
+            "archetype_dominant",
+            "competitive_matrix",
+            "puv"
+          ],
+          "properties": {
+            "statement": {
+              "type": "string"
+            },
+            "territory": {
+              "type": "string"
+            },
+            "archetype_dominant": {
+              "type": "object",
+              "required": [
+                "name",
+                "justification"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "justification": {
+                  "type": "string"
+                }
+              }
+            },
+            "archetype_secondary": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "justification": {
+                  "type": "string"
+                }
+              }
+            },
+            "competitive_matrix": {
+              "type": "object",
+              "required": [
+                "axis_x",
+                "axis_y",
+                "client_position",
+                "competitors"
+              ],
+              "properties": {
+                "axis_x": {
+                  "type": "string"
+                },
+                "axis_y": {
+                  "type": "string"
+                },
+                "client_position": {
+                  "type": "string"
+                },
+                "competitors": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "name",
+                      "quadrant"
+                    ],
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "quadrant": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "puv": {
+              "type": "string"
+            }
+          }
+        },
+        "audience_persona": {
+          "type": "object",
+          "required": [
+            "primary_persona"
+          ],
+          "properties": {
+            "primary_persona": {
+              "type": "object",
+              "required": [
+                "name",
+                "age",
+                "income",
+                "occupation",
+                "main_pain",
+                "purchase_motivators"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "photo_description": {
+                  "type": "string"
+                },
+                "age": {
+                  "type": "string"
+                },
+                "income": {
+                  "type": "string"
+                },
+                "occupation": {
+                  "type": "string"
+                },
+                "main_pain": {
+                  "type": "string"
+                },
+                "purchase_motivators": {
+                  "type": "string"
+                }
+              }
+            },
+            "secondary_persona": {
+              "type": [
+                "object",
+                "null"
+              ]
+            },
+            "anti_persona": {
+              "type": [
+                "object",
+                "null"
+              ]
+            },
+            "buyer_journey_summary": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        },
+        "history_culture": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "origin": {
+              "type": "string"
+            },
+            "milestones": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "culture": {
+              "type": "string"
+            },
+            "legacy": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "block2_verbal_identity": {
+      "type": "object",
+      "required": [
+        "personality",
+        "tone_of_voice",
+        "editorial_guidelines",
+        "slogan_tagline_signatures"
+      ],
+      "properties": {
+        "personality": {
+          "type": "object",
+          "required": [
+            "scales",
+            "as_a_person"
+          ],
+          "properties": {
+            "scales": {
+              "type": "array",
+              "minItems": 5,
+              "items": {
+                "type": "object",
+                "required": [
+                  "trait_low",
+                  "trait_high",
+                  "position"
+                ],
+                "properties": {
+                  "trait_low": {
+                    "type": "string"
+                  },
+                  "trait_high": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "number",
+                    "minimum": 1,
+                    "maximum": 10
+                  }
+                }
+              }
+            },
+            "archetype_applied": {
+              "type": "string"
+            },
+            "as_a_person": {
+              "type": "string"
+            }
+          }
+        },
+        "tone_of_voice": {
+          "type": "object",
+          "required": [
+            "pillars",
+            "channel_variations",
+            "say_dont_say"
+          ],
+          "properties": {
+            "pillars": {
+              "type": "array",
+              "minItems": 4,
+              "maxItems": 4,
+              "items": {
+                "type": "object",
+                "required": [
+                  "name",
+                  "definition",
+                  "manifestation"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "definition": {
+                    "type": "string"
+                  },
+                  "manifestation": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "channel_variations": {
+              "type": "array",
+              "minItems": 4,
+              "items": {
+                "type": "object",
+                "required": [
+                  "channel",
+                  "adaptation"
+                ],
+                "properties": {
+                  "channel": {
+                    "type": "string"
+                  },
+                  "adaptation": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "say_dont_say": {
+              "type": "array",
+              "minItems": 8,
+              "items": {
+                "type": "object",
+                "required": [
+                  "situation",
+                  "say",
+                  "dont_say",
+                  "reason"
+                ],
+                "properties": {
+                  "situation": {
+                    "type": "string"
+                  },
+                  "say": {
+                    "type": "string"
+                  },
+                  "dont_say": {
+                    "type": "string"
+                  },
+                  "reason": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "editorial_guidelines": {
+          "type": "object",
+          "required": [
+            "vocabulary_categorized",
+            "form_of_address"
+          ],
+          "properties": {
+            "vocabulary_categorized": {
+              "type": "object",
+              "required": [
+                "essence_words",
+                "valued_repeated",
+                "audience_connection"
+              ],
+              "properties": {
+                "essence_words": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "minItems": 5
+                },
+                "valued_repeated": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "minItems": 5
+                },
+                "audience_connection": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "minItems": 5
+                }
+              }
+            },
+            "official_glossary": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "term",
+                  "definition"
+                ],
+                "properties": {
+                  "term": {
+                    "type": "string"
+                  },
+                  "definition": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "forbidden_terms": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "term",
+                  "use_instead"
+                ],
+                "properties": {
+                  "term": {
+                    "type": "string"
+                  },
+                  "use_instead": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "form_of_address": {
+              "type": "string"
+            },
+            "emoji_punctuation": {
+              "type": "string"
+            },
+            "grammar_rules": {
+              "type": "string"
+            }
+          }
+        },
+        "naming_taxonomy": {
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "storytelling": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "story_arc": {
+              "type": "object",
+              "properties": {
+                "act1_before": {
+                  "type": "string"
+                },
+                "act2_different": {
+                  "type": "string"
+                },
+                "act3_after": {
+                  "type": "string"
+                }
+              }
+            },
+            "frameworks": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "opening_hooks": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "slogan_tagline_signatures": {
+          "type": "object",
+          "required": [
+            "tagline"
+          ],
+          "properties": {
+            "slogan": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "tagline": {
+              "type": "string"
+            },
+            "verbal_signatures": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "block3_visual_identity_core": {
+      "type": "object",
+      "required": [
+        "logo",
+        "incorrect_uses",
+        "color_system",
+        "typography"
+      ],
+      "properties": {
+        "logo": {
+          "type": "object",
+          "required": [
+            "concept",
+            "style_description",
+            "visual_attributes",
+            "design_principles",
+            "anatomy",
+            "clear_space",
+            "min_max_size",
+            "official_versions",
+            "logo_directions"
+          ],
+          "properties": {
+            "concept": {
+              "type": "string",
+              "description": "Conceito do logo em 1-2 parágrafos: o que ele expressa estrategicamente"
+            },
+            "style_description": {
+              "type": "string",
+              "minLength": 200,
+              "description": "Descrição do ESTILO visual do logo: linguagem (serif/sans/script/symbolic), peso, tratamento, atemporalidade. Deve ter pelo menos 200 caracteres e descrever a personalidade visual concreta."
+            },
+            "visual_attributes": {
+              "type": "object",
+              "required": [
+                "form_language",
+                "weight",
+                "balance",
+                "color_application",
+                "personality_in_form"
+              ],
+              "properties": {
+                "form_language": {
+                  "type": "string",
+                  "description": "Geométrico, orgânico, mixed, etc."
+                },
+                "weight": {
+                  "type": "string"
+                },
+                "balance": {
+                  "type": "string"
+                },
+                "negative_space": {
+                  "type": "string"
+                },
+                "color_application": {
+                  "type": "string"
+                },
+                "personality_in_form": {
+                  "type": "string",
+                  "description": "Como cada adjetivo do tom de voz se traduz na forma"
+                },
+                "scalability": {
+                  "type": "string"
+                },
+                "differentiation_from_competitors": {
+                  "type": "string"
+                }
+              }
+            },
+            "design_principles": {
+              "type": "array",
+              "minItems": 4,
+              "items": {
+                "type": "string"
+              },
+              "description": "Princípios de design que orientam o logo (ex: 'sobriedade acima de fofura', 'tipografia faz o trabalho pesado'). 4+ itens."
+            },
+            "anatomy": {
+              "type": "object",
+              "properties": {
+                "symbol": {
+                  "type": "string"
+                },
+                "wordmark": {
+                  "type": "string"
+                },
+                "lockup": {
+                  "type": "string"
+                }
+              }
+            },
+            "construction_grid": {
+              "type": "string"
+            },
+            "clear_space": {
+              "type": "string"
+            },
+            "min_max_size": {
+              "type": "object",
+              "properties": {
+                "min_digital_px": {
+                  "type": "string"
+                },
+                "min_print_mm": {
+                  "type": "string"
+                },
+                "max_recommended": {
+                  "type": "string"
+                }
+              }
+            },
+            "official_versions": {
+              "type": "array",
+              "minItems": 3,
+              "items": {
+                "type": "object",
+                "required": [
+                  "name",
+                  "use_case"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "use_case": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "logo_directions": {
+              "type": "array",
+              "minItems": 3,
+              "maxItems": 3,
+              "items": {
+                "type": "object",
+                "required": [
+                  "direction",
+                  "concept",
+                  "prompt"
+                ],
+                "properties": {
+                  "direction": {
+                    "type": "string"
+                  },
+                  "concept": {
+                    "type": "string"
+                  },
+                  "prompt": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "chosen_direction": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        },
+        "incorrect_uses": {
+          "type": "array",
+          "minItems": 6,
+          "items": {
+            "type": "object",
+            "required": [
+              "rule",
+              "visual_demo",
+              "reason"
+            ],
+            "properties": {
+              "rule": {
+                "type": "string"
+              },
+              "visual_demo": {
+                "type": "string",
+                "description": "Como o renderer vai demonstrar visualmente — ex: 'distort_x', 'recolor_red', 'drop_shadow', 'low_contrast', 'rotated', 'outlined'"
+              },
+              "reason": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "color_system": {
+          "type": "object",
+          "required": [
+            "primary",
+            "neutrals",
+            "proportions",
+            "wcag_contrast_matrix"
+          ],
+          "properties": {
+            "primary": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "object",
+                "required": [
+                  "name",
+                  "hex",
+                  "rgb",
+                  "cmyk",
+                  "role",
+                  "justification"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "hex": {
+                    "type": "string",
+                    "pattern": "^#[0-9A-Fa-f]{6}$"
+                  },
+                  "rgb": {
+                    "type": "string"
+                  },
+                  "cmyk": {
+                    "type": "string"
+                  },
+                  "pantone": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "hsl": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "role": {
+                    "type": "string"
+                  },
+                  "justification": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "secondary": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            },
+            "neutrals": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            },
+            "functional": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            },
+            "proportions": {
+              "type": "object",
+              "required": [
+                "dominant_pct",
+                "support_pct",
+                "accent_pct",
+                "dominant_color",
+                "support_color",
+                "accent_color"
+              ],
+              "properties": {
+                "dominant_pct": {
+                  "type": "number"
+                },
+                "support_pct": {
+                  "type": "number"
+                },
+                "accent_pct": {
+                  "type": "number"
+                },
+                "dominant_color": {
+                  "type": "string"
+                },
+                "support_color": {
+                  "type": "string"
+                },
+                "accent_color": {
+                  "type": "string"
+                }
+              }
+            },
+            "gradients": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            },
+            "wcag_contrast_matrix": {
+              "type": "array",
+              "minItems": 4,
+              "items": {
+                "type": "object",
+                "required": [
+                  "foreground",
+                  "background",
+                  "ratio",
+                  "level"
+                ],
+                "properties": {
+                  "foreground": {
+                    "type": "string",
+                    "pattern": "^#[0-9A-Fa-f]{6}$"
+                  },
+                  "background": {
+                    "type": "string",
+                    "pattern": "^#[0-9A-Fa-f]{6}$"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "ratio": {
+                    "type": "number"
+                  },
+                  "level": {
+                    "type": "string",
+                    "enum": [
+                      "AAA",
+                      "AA",
+                      "AA Large",
+                      "Fail"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "typography": {
+          "type": "object",
+          "required": [
+            "primary_family",
+            "hierarchy"
+          ],
+          "properties": {
+            "primary_family": {
+              "type": "object",
+              "required": [
+                "name",
+                "source",
+                "google_fonts_url",
+                "embed_url",
+                "weights_permitted"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "Nome da fonte (deve estar disponível no Google Fonts)"
+                },
+                "source": {
+                  "type": "string",
+                  "const": "Google Fonts",
+                  "description": "Sempre Google Fonts — fontes proprietárias não são permitidas"
+                },
+                "google_fonts_url": {
+                  "type": "string",
+                  "pattern": "^https://fonts\\.google\\.com/",
+                  "description": "URL da página da fonte no Google Fonts (ex: https://fonts.google.com/specimen/Fraunces)"
+                },
+                "embed_url": {
+                  "type": "string",
+                  "pattern": "^https://fonts\\.googleapis\\.com/",
+                  "description": "URL CSS para embedar (ex: https://fonts.googleapis.com/css2?family=Fraunces:wght@600;700&display=swap)"
+                },
+                "weights_permitted": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "license": {
+                  "type": "string"
+                }
+              }
+            },
+            "secondary_family": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "source": {
+                  "type": "string",
+                  "const": "Google Fonts"
+                },
+                "google_fonts_url": {
+                  "type": "string",
+                  "pattern": "^https://fonts\\.google\\.com/"
+                },
+                "embed_url": {
+                  "type": "string",
+                  "pattern": "^https://fonts\\.googleapis\\.com/"
+                },
+                "weights_permitted": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "license": {
+                  "type": "string"
+                }
+              }
+            },
+            "hierarchy": {
+              "type": "array",
+              "minItems": 5,
+              "items": {
+                "type": "object",
+                "required": [
+                  "level",
+                  "font",
+                  "weight",
+                  "size_px",
+                  "use_case"
+                ],
+                "properties": {
+                  "level": {
+                    "type": "string"
+                  },
+                  "font": {
+                    "type": "string"
+                  },
+                  "weight": {
+                    "type": "string"
+                  },
+                  "size_px": {
+                    "type": "number"
+                  },
+                  "line_height": {
+                    "type": "string"
+                  },
+                  "use_case": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "fallbacks": {
+              "type": "string"
+            },
+            "justification": {
+              "type": "string"
+            }
+          }
+        },
+        "iconography": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "style": {
+              "type": "string"
+            },
+            "stroke_weight_px": {
+              "type": "number"
+            },
+            "corner_style": {
+              "type": "string"
+            },
+            "grid": {
+              "type": "string"
+            },
+            "color_default": {
+              "type": "string"
+            }
+          }
+        },
+        "graphic_system": {
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "photography": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "art_direction": {
+              "type": "string"
+            },
+            "mood_keywords": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "do_dont": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "do",
+                      "dont"
+                    ]
+                  },
+                  "rule": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "illustration": {
+          "type": [
+            "object",
+            "null"
+          ]
+        }
+      }
+    },
+    "block4_applications": {
+      "type": "object",
+      "required": [
+        "principle",
+        "applications"
+      ],
+      "properties": {
+        "principle": {
+          "type": "string"
+        },
+        "applications": {
+          "type": "array",
+          "minItems": 6,
+          "items": {
+            "type": "object",
+            "required": [
+              "category",
+              "name",
+              "specs",
+              "mockup"
+            ],
+            "properties": {
+              "category": {
+                "type": "string",
+                "enum": [
+                  "stationery",
+                  "digital_ui",
+                  "social_media",
+                  "sales_marketing",
+                  "signage",
+                  "events"
+                ]
+              },
+              "name": {
+                "type": "string"
+              },
+              "specs": {
+                "type": "string"
+              },
+              "mockup": {
+                "type": "object",
+                "required": [
+                  "type",
+                  "description"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "business_card",
+                      "email_signature",
+                      "ig_avatar_bio",
+                      "ig_feed_post",
+                      "ig_story",
+                      "favicon_scaling",
+                      "one_pager",
+                      "whatsapp_business",
+                      "gmb_card",
+                      "deck_cover",
+                      "branded_giveaway"
+                    ]
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "data": {
+                    "type": "object",
+                    "description": "Dados específicos do mockup (texto da bio, headline do post, etc.)"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "block5_governance": {
+      "type": "object",
+      "required": [
+        "brand_owner",
+        "approval_process"
+      ],
+      "properties": {
+        "brand_owner": {
+          "type": "string"
+        },
+        "approval_process": {
+          "type": "array",
+          "minItems": 3,
+          "items": {
+            "type": "object",
+            "required": [
+              "step",
+              "responsible"
+            ],
+            "properties": {
+              "step": {
+                "type": "string"
+              },
+              "responsible": {
+                "type": "string"
+              },
+              "estimated_time": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "review_cadence": {
+          "type": "string"
+        },
+        "committee": {
+          "type": [
+            "object",
+            "null"
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## O que é

Duas skills de designer.

**`designer-criativos-anuncios`** — monta o briefing criativo do pack de anúncios: 5 variações com hooks diferentes, prompts de geração e a organização dos arquivos. Semi-manual de propósito; quem gera as imagens é o operador.

**`designer-manual-marca`** — Manual de Marca completo, com Brandbook estratégico e MIV técnico unificados em cinco blocos. Substitui os dois documentos separados que existiam antes.

## Checagens

- Duplo-write verificado
- `REGISTRY.md` fora do PR — a Action regenera no merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)