### PR TITLE
feat(skills): 5 skills de account

### DIFF
--- a/.agents/skills/account-auditoria-comunicacao/SKILL.md
+++ b/.agents/skills/account-auditoria-comunicacao/SKILL.md
@@ -1,0 +1,275 @@
+---
+name: account-auditoria-comunicacao
+description: "Audita todos os pontos de contato digitais do cliente (site, Instagram, anúncios, GMB, WhatsApp) e gera matriz de gaps com quick wins. Usa capacidade multimodal para analisar screenshots. Use quando o operador disser 'auditoria', 'comunicação', 'pontos de contato', 'gaps', ou após completar geral-persona-icp."
+area: account
+author: luizfreitasv4
+version: 1.0.0
+dependencies: ["geral-persona-icp"]
+outputs: ["account-auditoria-comunicacao.json"]
+week: 1
+estimated_time: "45-75 min"
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta versao foi portada do sistema de Estruturacao Estrategica. As regras abaixo tem precedencia sobre caminhos e persistencia citados no fluxo original:
+
+- Trabalhe somente em `squads/{squad}/clientes/{cliente}/`, nunca em um diretorio `clientes/` solto na raiz.
+- Leia primeiro o `CLAUDE.md` ou `AGENTS.md` da KB, `mission-control/`, `calls/`, `docs/` e `campanhas/`.
+- Se `client.json` existir, use-o como fonte complementar. Se nao existir, derive o contexto da KB e do Mission Control; nao exija nem invente esse arquivo.
+- Salve entregaveis em `squads/{squad}/clientes/{cliente}/outputs/`, em JSON e Markdown quando o fluxo pedir ambos.
+- Registre decisoes e progresso no `mission-control/historico-checkins.md` ou no arquivo de historico equivalente encontrado na KB.
+- Resolva recursos empacotados a partir do proprio diretorio desta skill. Se uma integracao externa nao estiver configurada, declare o gap e continue apenas com os dados reais disponiveis.
+
+
+# Auditoria de Comunicação Digital (POP 1.6)
+
+Você é um auditor de comunicação digital especializado em PMEs brasileiras. Vai auditar todos os pontos de contato digitais do cliente e mapear os gaps que estão prejudicando conversão.
+
+> **Posição no fluxo:** Semana 1 — comum a todos os modelos. Avalia coerência e qualidade da comunicação pública (tom de voz, oferta, consistência cross-canal) antes de definir posicionamento na Semana 2.
+
+> **CAPACIDADE MULTIMODAL:** Esta skill usa sua capacidade de analisar imagens. O operador vai fornecer screenshots de Instagram, anúncios, site, etc. Analise cada imagem em detalhe.
+
+## Dados necessários
+
+Leia os seguintes arquivos do diretório do cliente:
+
+1. `client.json` (seção `briefing`) — dados base do cliente (OBRIGATÓRIO)
+2. `outputs/geral-persona-icp.json` — ICP e persona (OBRIGATÓRIO — é dependência)
+3. `client.json` (seção `connectors`) — dados V4MOS se disponíveis
+4. `client.json` (seção `history`) — decisões anteriores
+
+Extraia do briefing:
+- `identification.name` → nome do cliente
+- `identification.segment` → setor
+- `brand.voice_tone` → tom de voz desejado
+- `brand.adjectives` → adjetivos de marca
+- `digital_situation` → URLs e dados de presença digital
+- `accesses` → quais acessos o operador tem
+
+Da geral-persona-icp, extraia:
+- `summary` → resumo do ICP
+- `persona` → persona completa (para avaliar alinhamento da comunicação)
+- `key_message` → mensagem-chave aprovada
+- `where_to_find.digital_channels` → canais onde o ICP está
+
+Solicite ao operador screenshots e dados faltantes TUDO de uma vez:
+- Confirme URLs (site, Instagram, Facebook, GMB, WhatsApp)
+- Peça screenshots necessários: homepage (desktop + mobile), Instagram (perfil/bio + últimos 9 posts), anúncios ativos (Meta Ads Library), GMB (perfil + reviews), WhatsApp (tela de boas-vindas)
+- Se o operador não tiver screenshots ainda, avise que pode fornecer ao longo da auditoria. NÃO bloqueie o andamento.
+
+---
+
+## Geração
+
+Gere o output COMPLETO de uma vez usando os dados de `client.json` (briefing, connectors) e outputs de skills dependentes em `outputs/`.
+
+Para cada canal, consulte o checklist detalhado em `references/checklist-auditoria-por-canal.md`.
+
+### Canal 1: Site / Landing Page
+
+Se tiver URL, analise (peça screenshots se não tiver):
+
+**Proposta de valor:** Está na primeira dobra? É clara? Alinhada com a mensagem-chave?
+**Prova social:** Depoimentos com nome/foto/resultado? Logos? Certificações?
+**CTA principal:** Visível sem scroll? Texto é ação clara? Para onde direciona?
+**Coerência visual:** Consistência de cores, fontes, imagens? Imagens reais ou stock?
+**Experiência mobile:** Responsivo? Velocidade?
+**SEO básico:** Title tag? Meta description? H1 com palavra-chave?
+
+Atribua um score de 0-100 com base no checklist de referência.
+
+### Canal 2: Instagram
+
+**Bio:** Clara sobre o que faz e para quem? CTA? Palavras-chave do ICP?
+**Feed (visuais):** Consistência visual? Qualidade? Variedade de formatos?
+**Conteúdo (legendas):** Fala COM o ICP? Hooks? CTAs? Frequência?
+**Destaques/Stories:** Organizados? Cobrem dúvidas do ICP?
+
+Atribua um score de 0-100.
+
+### Canal 3: Anúncios Ativos
+
+**Hook visual:** Para o scroll? Conecta com ICP?
+**Copy do anúncio:** Específica para ICP? Dor/ganho? Prova social?
+**CTA:** Claro? Coerente com etapa do funil?
+**Coerência:** Alinhado com identidade visual e mensagem-chave?
+
+Atribua um score de 0-100. Se não houver anúncios ativos, registre como "sem anúncios ativos" e recomende como prioridade.
+
+### Canal 4: Google Meu Negócio
+
+Se aplicável (negócios com componente local):
+**Completude:** Descrição? Fotos? Horários? Categoria?
+**Reviews:** Volume? Nota? Respostas?
+**Atividade:** Posts? Atualizações?
+
+Atribua um score de 0-100.
+
+### Canal 5: WhatsApp Business
+
+**Configuração:** WhatsApp Business? Saudação? Ausência? Catálogo?
+**Atendimento:** Tempo de resposta? Tom? Script? Follow-up?
+
+Atribua um score de 0-100.
+
+### Matriz de Gaps
+
+Compile todos os gaps identificados:
+
+| # | Canal | Gap Identificado | Impacto | Esforço | Ação Recomendada |
+|---|-------|-------------------|---------|---------|-------------------|
+| 1 | [canal] | [gap específico com evidência] | Alto/Médio/Baixo | Baixo/Médio/Alto | [ação específica] |
+
+**Regras de priorização:**
+- **Impacto Alto + Esforço Baixo** → Quick Win (fazer PRIMEIRO)
+- **Impacto Alto + Esforço Alto** → Projeto estratégico (planejar)
+- **Impacto Baixo + Esforço Baixo** → Fazer quando sobrar tempo
+- **Impacto Baixo + Esforço Alto** → NÃO fazer (ou fazer por último)
+
+### Resumo Executivo
+- Top 3 problemas de comunicação que mais custam conversão AGORA
+- Para cada: evidência + impacto estimado + ação
+
+### Competitor Benchmark (OBRIGATÓRIO — 2-3 grupos, 5 canais)
+
+Não basta auditar o cliente isoladamente. Compare canal a canal com 2-3 grupos de concorrentes (ex: "top local", "grandes nacionais"). Para cada:
+
+**Groups:** 2-3 grupos de concorrência com `name`, `members` (nomes reais), `positioning` (resumo do posicionamento dominante).
+
+**Benchmark by channel:** para cada canal (site, instagram, anúncios, GMB, WhatsApp):
+- `channel`: nome
+- `client_score`: score do cliente (0-100) — **nome preferido**
+- `best_in_class_score`: score do melhor do grupo — **nome preferido** (alternativa aceita: `competitor_avg_score`)
+- `gap`: diferença
+- `best_practice_observed`: o que o melhor faz (específico) — **nome preferido** (alternativa aceita: `evidence`)
+- `opportunity_for_client`: como o cliente pode fechar o gap (não genérico — específico) — **nome preferido** (alternativa aceita: `immediate_win`)
+
+> O renderer do portal aceita ambos os conjuntos de nomes. Priorize `client_score`/`best_in_class_score`/`best_practice_observed`/`opportunity_for_client`; use as alternativas apenas se o contexto exigir outra semântica.
+
+Feche com `strategic_read`: 1 parágrafo que interpreta os gaps — onde o cliente está muito atrás, onde está à frente, onde a competição é fraca.
+
+### Journey Friction Map (OBRIGATÓRIO — funil completo com leakage)
+
+Mapeie o funil real da persona do primeiro contato ao fechamento. Para cada estágio:
+- `stage`: nome (ex: "Exposição", "Clique", "LP", "WhatsApp click", "Resposta", "Agendamento", "Comparecimento")
+- `current_volume`: número real ou estimado (evidência se estimado)
+- `leakage_pct`: % que vaza para o próximo estágio
+- `root_cause`: por que vaza aqui
+- `fix_effort`: baixo/médio/alto
+- `fix_impact_estimate`: impacto estimado se fixar (leads a mais, % conversão a mais)
+
+Feche com:
+- `biggest_leakage_summary`: qual o estágio crítico, quanto vaza, quanto custa
+- `projected_funnel_90d_realistic`: projeção com quick wins aplicados
+
+### Tone-of-Voice Analysis (OBRIGATÓRIO — coerência entre canais)
+
+Comunicação quebra quando o tom muda de canal para canal. Audite:
+
+**Brand voice target:** o tom PROMETIDO pela marca.
+- `pillars`: 3-5 atributos declarados (ex: "acolhedor", "técnico", "sem jargão")
+- `avoid`: o que NÃO é (ex: "não é frio", "não é jocoso")
+
+**Channel drift:** para cada canal (site, instagram, anúncios, GMB, WhatsApp):
+- `channel`
+- `actual_tone`: como soa hoje (com exemplo citado) — **nome preferido** (alternativa: `current_tone`)
+- `target_alignment`: **CAMPO RECOMENDADO** — alinhamento qualitativo com a brand voice. Use um dos enums: `alinhado`, `bom`/`boa`, `parcial`/`media`, `baixa`, `desalinhado`, `crítico`, `nenhum`. O renderer do portal mapeia cada valor para uma barra visual no gráfico "Alinhamento por Canal" (alinhado=100, bom=80, parcial/média=55, baixa=25, desalinhado=20, crítico=10, nenhum=0). **Prefira este campo** em vez de `alignment_score` numérico — é mais legível e consistente.
+- `alignment_score`: 0-100 (opcional; use apenas se quiser sobrescrever o mapeamento do enum)
+- `drift_notes`: onde desalinhou — **nome preferido** (alternativa: `gap`)
+- `fix`: correção sugerida (opcional; renderiza como ação complementar ao drift)
+- `example`: citação textual do canal que ilustra o drift
+
+> **IMPORTANTE:** O gráfico "Alinhamento por Canal" no portal só renderiza canais que têm `target_alignment` (enum) ou `alignment_score` (numérico). Se ambos estiverem ausentes, o canal é omitido. **Sempre preencha `target_alignment`** para garantir visualização.
+
+Feche com `coherence_score`: média ponderada 0-100 que mede coerência geral da marca. Se <60, é prioridade editorial imediata. O renderer exibe esse score em uma barra horizontal com marcadores de Meta/Atual (escala 0/40/70/100).
+
+### URL Audit (OBRIGATÓRIO — lista de URLs a verificar)
+
+Lista com `url`, `purpose` (LP produto X, bio Instagram, etc.), `status_expected` (o que deveria estar lá), `verify_checklist` (3-5 pontos rápidos para QA do operador).
+
+### Quick Wins (3-5 ações)
+
+Para cada quick win:
+1. **O que fazer** — ação concreta, passo a passo
+2. **Em qual canal** — onde implementar
+3. **Tempo estimado** — horas para implementar
+4. **Impacto esperado** — o que melhora
+5. **Quem faz** — operador, cliente, ou equipe do cliente
+
+### Estrutura visual (obrigatória)
+
+Siga o padrão canônico de `references/padrao-output.md`. Além dos campos acima, SEMPRE inclua:
+
+- **`summary_headline`** (max 200 char) — manchete do veredito. Ex: "[Cliente] tem 4 canais ativos mas 0 coerência de voz — maior vazamento na Consideração (-47%)."
+- **`summary_highlights`** (4-6 itens, `{category, label, value, subtext, tone}`) — para auditoria de comunicação sugestões:
+  - `maturidade`: nº de canais auditados, score médio, coherence_score de voz
+  - `risco`: maior vazamento (`biggest_leakage_summary`) com %
+  - `oportunidade`: quick win de maior impacto, tempo de execução
+  - `competicao`: gap vs melhor concorrente benchmark
+- **`summary_key_findings`** (3-5 itens, `{category, text}`) — `vantagem|contexto|ameaca|acao`.
+
+### Ponto de alavancagem
+
+Em auditoria de comunicação, o ponto de alavancagem é o **maior vazamento no funil com causa-raiz clara** (tipicamente o `biggest_leakage_summary` + o quick win que o destrava). Estruture em `key_insight`:
+```json
+"key_insight": {
+  "headline": "Frase sobre o vazamento (ex: '47% dos leads somem entre Descoberta e Consideração porque o Google Maps está incompleto')",
+  "context": "2-3 linhas ligando causa-raiz a impacto de receita",
+  "numbered_reasons": ["(1) evidência do vazamento", "(2) causa-raiz", "(3) quick win que destrava"],
+  "discussion_anchor": "Por que o stakeholder precisa aprovar este quick win antes de escalar mídia"
+}
+```
+
+Se a auditoria revelou ausência de ativos críticos (sem site, GMB sem reviews, redes zeradas), inclua `honesty_alert`.
+
+## Auto-validação
+
+Antes de mostrar ao operador, verifique:
+
+- [ ] Mencionou o cliente pelo nome?
+- [ ] Usou dados reais do client.json (não inventou)?
+- [ ] Nenhum item genérico (ex: "quer crescer", "qualidade e compromisso")?
+- [ ] Schema da skill validou?
+- [ ] Todos os campos do schema preenchidos (ou com `null` + `unavailable_reason` no pai)?
+- [ ] Nenhuma string vazia (`""`) — substituí por `null` + reason quando o dado não existe?
+- [ ] Estimativas marcadas com `estimated: true` ou `[E]`?
+- [ ] Consistente com outputs anteriores (ICP, posicionamento)?
+- [ ] Cada gap tem evidência concreta (não opinião vaga)?
+- [ ] Quick wins são realmente executáveis em < 1 semana sem custo?
+- [ ] Scores por canal estão calibrados (nem tudo é 50/100)?
+- [ ] `competitor_benchmark` tem 2-3 grupos e tabela canal-a-canal com melhor prática observada e oportunidade específica?
+- [ ] `journey_friction_map` mapeia o funil completo com leakage_pct e root_cause para cada estágio?
+- [ ] `biggest_leakage_summary` identifica QUAL estágio é o maior buraco (com número)?
+- [ ] `tone_of_voice_analysis` compara brand voice declarada vs atual por canal, com coherence_score final?
+- [ ] `url_audit` lista todas as URLs críticas com verify_checklist?
+- [ ] Tem `summary_headline` específico?
+- [ ] `summary_highlights` tem 4-6 itens com categorias e tons válidos?
+- [ ] `summary_key_findings` cobre pelo menos 3 dos 4 tipos?
+- [ ] Identificou `key_insight` (maior vazamento + quick win)?
+- [ ] Se há fragilidade estrutural (ativos faltando), incluiu `honesty_alert`?
+
+Se falhou → regenere silenciosamente. Não avise o operador.
+
+## Apresentação e decisões
+
+Apresente o output COMPLETO ao operador — auditoria canal por canal com scores, matriz de gaps, resumo executivo e quick wins.
+
+Revise o output. O que está errado, exagerado ou faltando?
+
+- "Algum canal que eu avaliei de forma que não condiz com a realidade?"
+- "Tem algum canal adicional que deveria ser auditado? (YouTube, TikTok, LinkedIn, etc.)"
+- "A priorização faz sentido?"
+- "Algum gap que é mais urgente do que parece por contexto que eu não conheço?"
+- "Esses quick wins são viáveis no contexto deste cliente?"
+
+## Finalização
+
+Operador aprova (com ou sem ajustes).
+1. Salve em `squads/{squad}/clientes/{cliente}/outputs/account-auditoria-comunicacao.json` (com campo `summary` no topo)
+2. Atualize `client.json`: progress.skills → completed, version++, append em history[]
+3. Salve também uma versão Markdown do entregável na mesma pasta de outputs.
+4. Sugira próxima skill do dependency_graph
+   - "Auditoria salva. Os gaps identificados serão endereçados na produção da Semana 3: designer-manual-marca, designer-landing-page, copy-anuncios."
+   - "Os quick wins podem ser implementados AGORA enquanto as próximas skills são executadas."
+   - Sugira a próxima skill (se semana 1 ainda não completou, sugira as faltantes)

--- a/.agents/skills/account-auditoria-comunicacao/references/checklist-auditoria-por-canal.md
+++ b/.agents/skills/account-auditoria-comunicacao/references/checklist-auditoria-por-canal.md
@@ -1,0 +1,319 @@
+# Checklist de Auditoria por Canal
+
+Checklist detalhado para auditar cada ponto de contato digital. Use como base para atribuir scores e identificar gaps.
+
+---
+
+## Canal 1: Site / Landing Page
+
+### 1.1 Primeira Dobra (Above the Fold)
+
+| # | Item | O que verificar | Peso |
+|---|------|-----------------|------|
+| 1 | Proposta de valor | Visitante entende em 5 segundos o que o negocio faz e para quem? | Alto |
+| 2 | Headline | E especifica, orientada a beneficio, e fala com o ICP? | Alto |
+| 3 | Subheadline | Complementa a headline com detalhe ou prova? | Medio |
+| 4 | CTA principal | Visivel sem scroll? Texto e acao clara (nao "Saiba mais")? | Alto |
+| 5 | Imagem/video hero | Representa o publico-alvo ou o resultado? (nao stock generico) | Medio |
+| 6 | Navegacao | Simples, sem excesso de opcoes? Facilita encontrar o que importa? | Baixo |
+
+### 1.2 Prova Social
+
+| # | Item | O que verificar | Peso |
+|---|------|-----------------|------|
+| 7 | Depoimentos | Tem? Com nome + foto + resultado especifico? | Alto |
+| 8 | Quantidade | Pelo menos 3 depoimentos? | Medio |
+| 9 | Diversidade | Depoimentos de perfis diferentes (segmentos, tamanhos)? | Baixo |
+| 10 | Logos/selos | Clientes conhecidos, certificacoes, premios? | Medio |
+| 11 | Numeros | "500+ clientes", "R$X em resultados" — dados quantificaveis? | Medio |
+| 12 | Rating | Estrelas / nota de satisfacao visivel? | Baixo |
+
+### 1.3 Conteudo e Estrutura
+
+| # | Item | O que verificar | Peso |
+|---|------|-----------------|------|
+| 13 | Beneficios | Lista beneficios (nao features)? Fala a lingua do ICP? | Alto |
+| 14 | Objecoes | Trata as principais objecoes do ICP na pagina? | Alto |
+| 15 | Como funciona | Explica o processo em 3-4 etapas simples? | Medio |
+| 16 | Pricing | Se aplicavel, precos claros? Ou pelo menos "a partir de"? | Medio |
+| 17 | FAQ | Responde as perguntas mais comuns? | Medio |
+| 18 | Garantia/risco | Tem garantia, trial, ou reducao de risco? | Medio |
+
+### 1.4 Tecnico
+
+| # | Item | O que verificar | Peso |
+|---|------|-----------------|------|
+| 19 | HTTPS | Site seguro (cadeado)? | Alto |
+| 20 | Velocidade | Carrega em menos de 3 segundos? (PageSpeed score > 50 mobile) | Alto |
+| 21 | Mobile | Responsivo? Elementos acessiveis no celular? Texto legivel? | Alto |
+| 22 | Formulario | Se tem, tem poucos campos? (nome + telefone/email minimo) | Medio |
+| 23 | WhatsApp float | Botao de WhatsApp visivel e funcionando? | Medio |
+| 24 | Pixel/Tag | Meta Pixel e Google Tag instalados? (verificar via extensao) | Alto |
+
+### 1.5 SEO Basico
+
+| # | Item | O que verificar | Peso |
+|---|------|-----------------|------|
+| 25 | Title tag | Existe, tem ate 60 caracteres, inclui palavra-chave? | Alto |
+| 26 | Meta description | Existe, tem ate 155 caracteres, e persuasiva? | Medio |
+| 27 | H1 | Unico, relevante, contem palavra-chave principal? | Alto |
+| 28 | URLs amigaveis | Sem parametros estranhos, com palavras-chave? | Baixo |
+| 29 | Alt text | Imagens tem alt text descritivo? | Baixo |
+| 30 | Sitemap | Sitemap.xml existe e esta enviado ao Search Console? | Baixo |
+
+### Tabela de Scoring — Site
+
+| Score | Criterio |
+|-------|----------|
+| 0-20 | Site nao existe, esta fora do ar, ou e tao ruim que prejudica a marca |
+| 21-40 | Site existe mas sem proposta de valor clara, sem CTA, sem prova social, lento |
+| 41-60 | Site funcional: tem proposta, CTA, e alguma prova social. Mobile OK mas nao otimizado |
+| 61-80 | Site bom: proposta clara, CTAs estrategicos, prova social forte, rapido, mobile-first |
+| 81-100 | Site excelente: otimizado para conversao, A/B testado, tracking completo, experiencia premium |
+
+---
+
+## Canal 2: Instagram
+
+### 2.1 Perfil/Bio
+
+| # | Item | O que verificar | Peso |
+|---|------|-----------------|------|
+| 1 | Foto de perfil | Profissional? Logo ou rosto reconhecivel? Visivel em tamanho pequeno? | Medio |
+| 2 | Nome | Contem o nome do negocio + palavra-chave? (ex: "Dr. Paulo \| Dentista Curitiba") | Alto |
+| 3 | Bio - O que faz | Claro em 1 linha o que o negocio faz? | Alto |
+| 4 | Bio - Para quem | Fala para quem e o servico/produto? | Alto |
+| 5 | Bio - Diferencial | Tem algo que diferencia dos concorrentes? | Medio |
+| 6 | Bio - CTA | Tem CTA claro? ("Agende", "Compre", "Fale conosco") | Alto |
+| 7 | Link | Link funcional na bio? (Linktree, site, WhatsApp) | Alto |
+| 8 | Categoria | Categoria correta do perfil business? | Baixo |
+| 9 | Contato | Botoes de contato configurados (telefone, email, endereco)? | Medio |
+
+### 2.2 Feed
+
+| # | Item | O que verificar | Peso |
+|---|------|-----------------|------|
+| 10 | Consistencia visual | Paleta de cores consistente? Estilo reconhecivel? | Alto |
+| 11 | Qualidade das imagens | Profissionais ou amadoras? Boa iluminacao e composicao? | Alto |
+| 12 | Variedade de formatos | Usa estático + carrossel + Reels? Ou so 1 formato? | Medio |
+| 13 | Frequencia | Quantos posts por semana? Consistente ou irregular? | Alto |
+| 14 | Grid | Grid visualmente harmonioso (nao precisa ser perfeito, mas coerente)? | Baixo |
+
+### 2.3 Conteudo
+
+| # | Item | O que verificar | Peso |
+|---|------|-----------------|------|
+| 15 | Hooks nas legendas | Primeira linha prende atencao? Gera curiosidade? | Alto |
+| 16 | Valor para o ICP | Conteudo e util/relevante para o cliente ideal? | Alto |
+| 17 | Mix de conteudo | Tem educativo + social proof + produto + bastidores + entretenimento? | Medio |
+| 18 | CTAs nos posts | Pede acao? (salvar, compartilhar, comentar, clicar no link) | Alto |
+| 19 | Hashtags | Usa hashtags relevantes? Nao excessivas (5-15)? | Baixo |
+| 20 | Engajamento | Comentarios e likes condizem com o numero de seguidores? | Medio |
+
+### 2.4 Stories e Destaques
+
+| # | Item | O que verificar | Peso |
+|---|------|-----------------|------|
+| 21 | Stories ativos | Posta Stories regularmente? (diariamente e ideal) | Alto |
+| 22 | Destaques organizados | Capas bonitas e nomeadas? | Medio |
+| 23 | Destaques essenciais | Tem: Sobre nos, Servicos/Produtos, Depoimentos, FAQ/Como funciona? | Alto |
+| 24 | Interatividade | Usa enquetes, perguntas, quizzes? | Baixo |
+
+### Tabela de Scoring — Instagram
+
+| Score | Criterio |
+|-------|----------|
+| 0-20 | Perfil inexistente, abandonado (ultimo post 3+ meses), ou tao amador que prejudica |
+| 21-40 | Perfil existe mas bio fraca, feed inconsistente, sem estrategia de conteudo |
+| 41-60 | Perfil ativo: bio OK, feed razoavel, posts regulares. Mas sem estrategia para o ICP |
+| 61-80 | Perfil bom: bio estrategica, feed consistente, conteudo para o ICP, bom engajamento |
+| 81-100 | Perfil excelente: estrategia clara, conteudo premium, community ativa, Reels virais |
+
+---
+
+## Canal 3: Anuncios Ativos
+
+### 3.1 Criativos
+
+| # | Item | O que verificar | Peso |
+|---|------|-----------------|------|
+| 1 | Hook visual | Para o scroll em 1 segundo? Destaca do feed? | Alto |
+| 2 | Texto no criativo | Se tem, e legivel e impactante? (max 20% da area) | Alto |
+| 3 | Formato | Usa formatos variados (video, carrossel, colecao)? | Medio |
+| 4 | Persona visual | Pessoas no criativo representam o ICP? | Alto |
+| 5 | Branding | Logo/cores da marca presentes sem poluir? | Medio |
+
+### 3.2 Copy do Anuncio
+
+| # | Item | O que verificar | Peso |
+|---|------|-----------------|------|
+| 6 | Hook textual | Primeira linha prende (pergunta, numero, provocacao)? | Alto |
+| 7 | Dor/Ganho | Menciona dor ou ganho especifico do ICP? | Alto |
+| 8 | Prova social | Inclui numero, depoimento, ou resultado no copy? | Medio |
+| 9 | CTA | Claro, especifico, e orientado a acao? | Alto |
+| 10 | Urgencia/escassez | Tem elemento de urgencia quando apropriado? | Baixo |
+
+### 3.3 Estrategia
+
+| # | Item | O que verificar | Peso |
+|---|------|-----------------|------|
+| 11 | Funil | Tem anuncios de topo, meio e fundo? Ou so 1 tipo? | Alto |
+| 12 | Volume | Quantos criativos ativos? (ideal: 5+ por campanha) | Alto |
+| 13 | Teste A/B | Variações de criativo/copy rodando ao mesmo tempo? | Medio |
+| 14 | Coerencia | Anuncio → LP → CTA: jornada coerente? | Alto |
+
+### Tabela de Scoring — Anuncios
+
+| Score | Criterio |
+|-------|----------|
+| 0-20 | Sem anuncios ativos ou 1 anuncio generico rodando ha meses |
+| 21-40 | Poucos anuncios, sem variacao, copy generica, sem hook visual |
+| 41-60 | Anuncios funcionais: hook razoavel, copy com beneficio, mas sem testes ou funil |
+| 61-80 | Anuncios bons: criativos variados, copy especifica para ICP, funil configurado |
+| 81-100 | Anuncios excelentes: framework criativo, testes continuos, funil completo, dados de performance |
+
+---
+
+## Canal 4: Google Meu Negocio (GMB)
+
+### 4.1 Perfil
+
+| # | Item | O que verificar | Peso |
+|---|------|-----------------|------|
+| 1 | Reivindicado | Perfil reivindicado e verificado? | Alto |
+| 2 | Nome | Correto (sem keyword stuffing)? | Medio |
+| 3 | Categoria | Categoria primaria correta? Categorias secundarias relevantes? | Alto |
+| 4 | Descricao | Preenchida, com palavras-chave, orientada ao cliente? | Alto |
+| 5 | Horarios | Atualizados e corretos? Inclui horarios especiais? | Medio |
+| 6 | Telefone | Correto e rastreavel? | Medio |
+| 7 | Site | Link correto para o site? | Medio |
+| 8 | Endereco | Correto, com pin no mapa posicionado certo? | Medio |
+
+### 4.2 Conteudo Visual
+
+| # | Item | O que verificar | Peso |
+|---|------|-----------------|------|
+| 9 | Foto de capa | Profissional e representativa? | Medio |
+| 10 | Fotos do local | Pelo menos 10 fotos profissionais? (fachada, interior, equipe, produtos) | Alto |
+| 11 | Fotos atualizadas | Fotos dos ultimos 6 meses? | Medio |
+| 12 | Videos | Tem video curto do negocio? | Baixo |
+
+### 4.3 Reviews
+
+| # | Item | O que verificar | Peso |
+|---|------|-----------------|------|
+| 13 | Volume | Quantas reviews tem? (benchmark: 50+ e bom, 100+ e otimo) | Alto |
+| 14 | Nota media | Acima de 4.0? Acima de 4.5? | Alto |
+| 15 | Respostas | Negocio responde reviews? Todas ou so algumas? | Alto |
+| 16 | Qualidade das respostas | Respostas personalizadas ou copy-paste? | Medio |
+| 17 | Reviews negativos | Como lida com criticas? Profissional ou defensivo? | Alto |
+| 18 | Recencia | Tem reviews recentes (ultimo mes)? | Medio |
+
+### 4.4 Posts e Atividade
+
+| # | Item | O que verificar | Peso |
+|---|------|-----------------|------|
+| 19 | Posts ativos | Publica posts/updates no GMB? Com que frequencia? | Medio |
+| 20 | Ofertas | Usa funcao de ofertas/eventos? | Baixo |
+| 21 | Perguntas | Respondeu as perguntas dos usuarios? | Medio |
+| 22 | Produtos/servicos | Lista de produtos/servicos preenchida? | Medio |
+
+### Tabela de Scoring — GMB
+
+| Score | Criterio |
+|-------|----------|
+| 0-20 | Nao reivindicado, ou reivindicado mas vazio (sem fotos, sem descricao) |
+| 21-40 | Basico preenchido mas poucas fotos, sem reviews respondidos, sem posts |
+| 41-60 | Perfil completo: fotos, descricao, reviews respondidos. Mas sem posts ativos |
+| 61-80 | Perfil bom: completo + reviews fortes + posts regulares + fotos profissionais |
+| 81-100 | Perfil excelente: domina pack local, 100+ reviews 4.5+, posts semanais, Q&A respondidos |
+
+---
+
+## Canal 5: WhatsApp Business
+
+### 5.1 Configuracao
+
+| # | Item | O que verificar | Peso |
+|---|------|-----------------|------|
+| 1 | Tipo | WhatsApp Business (nao pessoal)? | Alto |
+| 2 | Perfil | Foto profissional, descricao do negocio, endereco, horario? | Medio |
+| 3 | Saudacao | Mensagem automatica de boas-vindas configurada? | Alto |
+| 4 | Ausencia | Mensagem de ausencia configurada fora do horario? | Medio |
+| 5 | Respostas rapidas | Templates de respostas frequentes salvos? | Medio |
+| 6 | Catalogo | Catalogo de produtos/servicos preenchido com fotos e precos? | Medio |
+| 7 | Labels | Etiquetas para organizar conversas (novo lead, em negociacao, cliente)? | Baixo |
+
+### 5.2 Atendimento
+
+| # | Item | O que verificar | Peso |
+|---|------|-----------------|------|
+| 8 | Tempo de resposta | Responde em quanto tempo? (ideal: < 5min em horario comercial) | Alto |
+| 9 | Tom de atendimento | Profissional e alinhado com o tom de voz da marca? | Alto |
+| 10 | Script de qualificacao | Tem perguntas padrao para qualificar o lead? | Alto |
+| 11 | Follow-up | Faz follow-up se o lead nao responde? Em quanto tempo? | Alto |
+| 12 | Encerramento | Fecha o atendimento de forma profissional? Pede feedback? | Baixo |
+
+### 5.3 Integracao
+
+| # | Item | O que verificar | Peso |
+|---|------|-----------------|------|
+| 13 | CRM | Integrado com CRM? Leads sao registrados automaticamente? | Alto |
+| 14 | Multi-atendentes | Tem mais de 1 pessoa atendendo? Como organizam? | Medio |
+| 15 | Automacao | Usa chatbot ou fluxos automatizados? | Medio |
+| 16 | Historico | Mantem historico de conversas organizavel? | Baixo |
+
+### Tabela de Scoring — WhatsApp
+
+| Score | Criterio |
+|-------|----------|
+| 0-20 | WhatsApp pessoal, sem saudacao, sem perfil, atendimento caótico |
+| 21-40 | WhatsApp Business mas sem saudacao, sem catalogo, resposta demorada |
+| 41-60 | Configurado basico: saudacao + catalogo. Mas sem script, sem follow-up padrao |
+| 61-80 | Bom: saudacao + catalogo + script + follow-up. Integrado com CRM |
+| 81-100 | Excelente: automatizado, qualificacao, integrado com CRM, multi-atendente, metricas |
+
+---
+
+## Checklist Transversal: Coerencia entre Canais
+
+Alem de auditar cada canal individualmente, verifique a coerencia ENTRE canais:
+
+| # | Item | O que verificar |
+|---|------|-----------------|
+| 1 | Tom de voz | O tom e consistente no site, Instagram, WhatsApp e GMB? |
+| 2 | Identidade visual | Cores, fontes e estilo sao os mesmos em todos os canais? |
+| 3 | Mensagem | A proposta de valor e a mesma em todos os canais? |
+| 4 | Informacoes | Telefone, endereco, horario sao iguais em todos os canais? |
+| 5 | Links | Todos os links entre canais funcionam? (Instagram → site, GMB → WhatsApp, etc.) |
+| 6 | Jornada | A jornada do lead faz sentido? (viu anuncio → clicou → site → WhatsApp → fechou?) |
+
+Se houver incoerencia entre canais, registre como gap na matriz com impacto ALTO (confunde o cliente e reduz confianca).
+
+---
+
+## Gaps mais Comuns por Tipo de Negocio
+
+### E-commerce
+- Site sem reviews de produto
+- Instagram sem link para produtos especificos (so link geral)
+- Anuncios levam para home em vez de pagina do produto
+- Sem remarketing para abandonadores de carrinho
+
+### Servicos Locais (clinica, escritorio, restaurante)
+- GMB incompleto ou sem reviews respondidos
+- Instagram fala sobre o negocio mas nao para o cliente
+- Site sem agendamento online
+- WhatsApp demora para responder e nao faz follow-up
+
+### Educacao (cursos, escolas)
+- LP sem prova social de resultados de alunos
+- Instagram so posta conteudo educativo, nao converte
+- Sem urgencia/escassez nas ofertas
+- CRM nao faz nurturing de leads frios
+
+### SaaS / Tech
+- Site cheio de features, sem beneficios claros
+- Sem trial ou demonstracao acessivel
+- Conteudo tecnico demais para o decisor (que e gestor, nao tecnico)
+- CTA generico ("Fale conosco" em vez de "Comece seu teste gratis")

--- a/.agents/skills/account-auditoria-comunicacao/references/padrao-output.md
+++ b/.agents/skills/account-auditoria-comunicacao/references/padrao-output.md
@@ -1,0 +1,202 @@
+# Padrão de Output das Skills — V4 Estruturação IA
+
+Este documento define a **estrutura canônica** que todos os outputs de skill devem seguir para renderizar no portal com hierarquia visual consistente. O objetivo é que o operador e o stakeholder final abram qualquer entregável e encontrem o mesmo ritmo: manchete → KPIs → achados categorizados → ponto de alavancagem destacado → detalhes expansíveis.
+
+---
+
+## Princípios
+
+1. **Manchete antes de texto.** Toda skill abre com uma frase única e específica que resume a conclusão. Não é parágrafo, é headline.
+2. **Números em destaque, não escondidos no corpo do texto.** KPIs que importam viram cards. Texto corrido é para contexto, não para fato quantitativo.
+3. **Achados categorizados por intenção.** Cada insight é classificado como `vantagem | contexto | ameaca | acao` — o leitor identifica o tom antes de ler.
+4. **Ponto de alavancagem visualmente isolado.** Toda skill tem UM ponto onde a conversa com o stakeholder precisa acontecer. Esse ponto ganha hero visual (border, gradient, quote destacada).
+5. **Detalhe denso → colapsável.** Listas longas (concorrentes, itens de checklist, fontes) ficam em `<details>` para não afogar a leitura.
+
+---
+
+## Campos obrigatórios no JSON
+
+Todo output de skill DEVE ter estes campos no topo (antes dos campos específicos da skill):
+
+```json
+{
+  "client_name": "Nome do Cliente",
+  "summary": "Resumo em 1-2 frases. Específico, com dados reais. Alimenta o resumo executivo do portal.",
+
+  "summary_headline": "Manchete em 1 linha (max 120 caracteres). A frase que o stakeholder lê primeiro.",
+
+  "summary_highlights": [
+    {
+      "category": "posicao | competicao | janela | maturidade | oportunidade | risco",
+      "label": "Rótulo curto (max 30 char)",
+      "value": "Valor em destaque (número, %, status)",
+      "subtext": "Contexto em 1 linha (max 60 char)",
+      "tone": "green | yellow | red | blue | gray"
+    }
+  ],
+
+  "summary_key_findings": [
+    {
+      "category": "vantagem | contexto | ameaca | acao",
+      "text": "Achado em 1-2 linhas. Específico, acionável."
+    }
+  ]
+}
+```
+
+### Regras dos campos de summary
+
+**`summary_headline`**: É a ÚNICA frase que o stakeholder precisa ler se só tiver 5 segundos. Deve conter o veredito da skill. Exemplos bons:
+- ✓ "[Cliente] é o ÚNICO player premium da microrregião com [diferencial declarado] — janela competitiva de 12-18 meses."
+- ✗ "Análise de mercado concluída com sucesso."
+
+**`summary_highlights`** (4-6 itens): KPIs visuais. Categorias sugeridas:
+- `posicao` — onde o cliente está hoje vs potencial
+- `competicao` — quem disputa o mesmo espaço
+- `janela` — tempo/urgência
+- `maturidade` — estágio atual em algum eixo
+- `oportunidade` — tamanho do ganho possível
+- `risco` — tamanho da ameaça
+
+Agrupar de 2 em 2 por categoria no renderer (dá layout balanceado 3x2 ou 2x2).
+
+**`summary_key_findings`** (3-5 itens): Achados que embasam a manchete. Categorias:
+- `vantagem` (✓ verde) — o que o cliente tem a favor
+- `contexto` (i azul) — o que é fato do mercado, neutro
+- `ameaca` (! vermelho) — o que pode dar errado
+- `acao` (▸ laranja) — o que precisa ser feito
+
+---
+
+## Ponto de Alavancagem (hero block)
+
+Toda skill deve identificar **UM bloco que merece destaque visual especial** — o ponto onde a conversa estratégica precisa acontecer. O nome do campo varia por skill, mas a estrutura é consistente:
+
+```json
+{
+  "key_leverage_point": {
+    "headline": "Frase-manchete do ponto (pode ir como quote)",
+    "context": "Contexto em 2-3 linhas explicando o cenário",
+    "numbered_reasons": [
+      "Razão 1 (parse-friendly, pode começar com texto direto)",
+      "Razão 2",
+      "Razão 3"
+    ],
+    "discussion_anchor": "Frase curta sobre POR QUE este é o ponto de conversa com o stakeholder"
+  }
+}
+```
+
+Exemplos por skill:
+- `pesquisa-mercado` → `unexploited_opportunity` (whitespace estratégico)
+- `persona-icp` → persona principal + dor mais ignorada
+- `swot` → combinação força × oportunidade mais assimétrica
+- `posicionamento` → PUV vs alternativas descartadas
+- `diagnostico-midia` → canal mais subotimizado + upside estimado
+- `diagnostico-maturidade` → pilar mais fraco com maior impacto
+
+O renderer aplica:
+- Border verde 2px + gradient sutil
+- Selo "Whitespace Estratégico · Discussão com Stakeholder" no topo
+- Pill de viabilidade/urgência à direita
+- Quote/headline em card branco isolado
+- Razões numeradas em 3 círculos
+- Footer "💬 Momento de validar com a stakeholder"
+
+---
+
+## Alerta de honestidade
+
+Se a pesquisa/análise revelou fragilidade do cliente (não há diferencial real, ICP mal definido, mercado saturado, etc.), inclua:
+
+```json
+{
+  "honesty_alert": "Texto explicando a fragilidade encontrada e o que precisa ser feito antes de seguir."
+}
+```
+
+Esse campo renderiza em box amarelo/vermelho após os achados. **Nunca omita** se a realidade justifica. O valor do sistema depende de não vender aspiracional como real.
+
+---
+
+## Instrução para a IA da skill
+
+Em cada `SKILL.md`, incluir esta seção na geração:
+
+> ### Estrutura visual (obrigatória)
+>
+> Além dos campos específicos desta skill, gere SEMPRE:
+>
+> - `summary_headline` — manchete em 1 linha com o veredito
+> - `summary_highlights` — 4-6 KPIs categorizados (`posicao|competicao|janela|maturidade|oportunidade|risco`) com `{label, value, subtext, tone}`
+> - `summary_key_findings` — 3-5 achados categorizados (`vantagem|contexto|ameaca|acao`)
+> - `honesty_alert` se houver fragilidade
+>
+> Identifique o **ponto de alavancagem** desta skill (o bloco que merece hero visual) e estruture-o com headline + contexto + razões numeradas + discussion anchor.
+>
+> Consulte `references/padrao-output.md` para especificação completa.
+
+E na auto-validação:
+
+> - [ ] Tem `summary_headline` específico (não "análise concluída")?
+> - [ ] `summary_highlights` tem 4-6 itens com categorias válidas?
+> - [ ] `summary_key_findings` cobre pelo menos 3 dos 4 tipos (vantagem/contexto/ameaça/ação)?
+> - [ ] Identificou o ponto de alavancagem para discussão com stakeholder?
+> - [ ] Se há fragilidade, incluiu `honesty_alert`?
+
+---
+
+## Completude (regra crítica)
+
+**Todo campo definido no schema da skill é obrigatório no output.** Não omitir campos — o renderer assume que os campos do schema existem e quebra/fica vazio silenciosamente quando faltam.
+
+Se um dado **não pode ser obtido** (GA4 não instalado, conector não conectado, cliente não sabe, etc.), preencher com `null` E adicionar `unavailable_reason` no objeto pai:
+
+```json
+{
+  "current_conversion_rate": null,
+  "current_bounce_rate": null,
+  "avg_time_on_page": null,
+  "unavailable_reason": "GA4 não instalado no site — métricas de analytics não coletadas nesta auditoria"
+}
+```
+
+Para arrays vazios legitimamente (ex: nenhum competidor identificado), preencher com `[]` e adicionar uma nota no campo irmão `{campo}_note`:
+
+```json
+{
+  "competitors": [],
+  "competitors_note": "Nenhum concorrente direto identificado na microrregião após busca em Google Maps + Instagram."
+}
+```
+
+Para valores **estimados** (sem fonte pública), adicionar flag `[E]` no texto OU campo `estimated: true` no objeto:
+
+```json
+{ "tam_brl": 450000000, "estimated": true, "estimation_basis": "IBGE população × SEBRAE ticket médio" }
+```
+
+**Nunca** deixar string vazia (`""`), zero falso (`0` quando não é zero real), ou omitir o campo. Essas três formas são invisíveis para o renderer e geram o bug "coluna vazia".
+
+Valide o JSON contra o `schema.json` empacotado na skill e corrija campos ausentes ou `null` sem `unavailable_reason`.
+
+### Checklist adicional de auto-validação
+
+> - [ ] Todos os campos do schema estão presentes (preenchidos ou com `null` + `unavailable_reason`)?
+> - [ ] Nenhuma string vazia (`""`) — substituí por `null` + reason quando o dado não existe?
+> - [ ] Arrays vazios legítimos têm `{campo}_note` explicando por quê?
+> - [ ] Estimativas marcadas com `estimated: true` ou `[E]`?
+
+---
+
+## Tons de voz
+
+- `green` — oportunidade/vantagem/confirmado
+- `yellow` — atenção/potencial/médio
+- `red` — risco/ameaça/fraco
+- `blue` — contexto/informativo/neutro
+- `gray` — desativado/aspiracional/ausente
+
+Usar tons consistentemente: nunca pintar ameaça de verde ou vantagem de vermelho para "chamar atenção". O tom é semântico.
+
+---

--- a/.agents/skills/account-auditoria-comunicacao/schema.json
+++ b/.agents/skills/account-auditoria-comunicacao/schema.json
@@ -1,0 +1,800 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "AuditoriaComunicacao",
+  "description": "Output estruturado da skill auditoria-comunicacao: auditoria por canal, matriz de gaps e quick wins.",
+  "type": "object",
+  "required": [
+    "summary",
+    "channels_audited",
+    "gap_matrix",
+    "executive_summary",
+    "quick_wins",
+    "client_name",
+    "summary_headline",
+    "summary_highlights",
+    "summary_key_findings"
+  ],
+  "properties": {
+    "client_name": {
+      "type": "string",
+      "description": "Nome do cliente — sempre presente em todo output."
+    },
+    "summary": {
+      "type": "string",
+      "description": "Resumo de 1-2 frases da auditoria. Usado como referência rápida por outras skills."
+    },
+    "summary_headline": {
+      "type": "string",
+      "maxLength": 200,
+      "description": "Manchete em 1 linha com o veredito desta skill (hero do resumo executivo no portal). Ver references/padrao-output.md"
+    },
+    "summary_highlights": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 8,
+      "description": "KPIs visuais categorizados para o resumo executivo. Cada item: {category, label, value, subtext, tone}.",
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "label",
+          "value"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "posicao",
+              "competicao",
+              "janela",
+              "maturidade",
+              "oportunidade",
+              "risco"
+            ]
+          },
+          "label": {
+            "type": "string",
+            "maxLength": 40
+          },
+          "value": {
+            "type": "string"
+          },
+          "subtext": {
+            "type": "string",
+            "maxLength": 80
+          },
+          "tone": {
+            "type": "string",
+            "enum": [
+              "green",
+              "yellow",
+              "red",
+              "blue",
+              "gray"
+            ]
+          }
+        }
+      }
+    },
+    "summary_key_findings": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 6,
+      "description": "Achados categorizados por intenção (vantagem/contexto/ameaça/ação). Pelo menos 3 dos 4 tipos cobertos.",
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "text"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "vantagem",
+              "contexto",
+              "ameaca",
+              "acao"
+            ]
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "icp_reference": {
+      "type": "string",
+      "description": "Resumo do ICP usado como referência para avaliar alinhamento da comunicação."
+    },
+    "channels_audited": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "score",
+          "gaps",
+          "recommendations"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Nome do canal auditado (ex: 'site', 'instagram', 'google_meu_negocio', 'whatsapp', 'anuncios')."
+          },
+          "url_or_handle": {
+            "type": "string",
+            "description": "URL ou handle do canal auditado."
+          },
+          "score": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 100,
+            "description": "Score do canal (0-100)."
+          },
+          "classification": {
+            "type": "string",
+            "enum": [
+              "critical",
+              "low",
+              "medium",
+              "good",
+              "excellent"
+            ],
+            "description": "Classificação do canal."
+          },
+          "screenshots_analyzed": {
+            "type": "boolean",
+            "description": "Se screenshots foram fornecidos e analisados para este canal."
+          },
+          "audit_details": {
+            "type": "object",
+            "description": "Detalhes da auditoria específicos por canal.",
+            "properties": {
+              "value_proposition": {
+                "type": "object",
+                "properties": {
+                  "present": {
+                    "type": "boolean"
+                  },
+                  "clear": {
+                    "type": "boolean"
+                  },
+                  "aligned_with_icp": {
+                    "type": "boolean"
+                  },
+                  "notes": {
+                    "type": "string"
+                  }
+                }
+              },
+              "social_proof": {
+                "type": "object",
+                "properties": {
+                  "present": {
+                    "type": "boolean"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "quality": {
+                    "type": "string",
+                    "enum": [
+                      "none",
+                      "weak",
+                      "moderate",
+                      "strong"
+                    ]
+                  },
+                  "notes": {
+                    "type": "string"
+                  }
+                }
+              },
+              "cta": {
+                "type": "object",
+                "properties": {
+                  "present": {
+                    "type": "boolean"
+                  },
+                  "visible": {
+                    "type": "boolean"
+                  },
+                  "action_oriented": {
+                    "type": "boolean"
+                  },
+                  "notes": {
+                    "type": "string"
+                  }
+                }
+              },
+              "visual_consistency": {
+                "type": "object",
+                "properties": {
+                  "consistent": {
+                    "type": "boolean"
+                  },
+                  "professional": {
+                    "type": "boolean"
+                  },
+                  "notes": {
+                    "type": "string"
+                  }
+                }
+              },
+              "mobile_experience": {
+                "type": "object",
+                "properties": {
+                  "responsive": {
+                    "type": "boolean"
+                  },
+                  "speed": {
+                    "type": "string"
+                  },
+                  "notes": {
+                    "type": "string"
+                  }
+                }
+              },
+              "content_quality": {
+                "type": "object",
+                "properties": {
+                  "speaks_to_icp": {
+                    "type": "boolean"
+                  },
+                  "frequency": {
+                    "type": "string"
+                  },
+                  "engagement_level": {
+                    "type": "string"
+                  },
+                  "notes": {
+                    "type": "string"
+                  }
+                }
+              },
+              "additional_notes": {
+                "type": "string",
+                "description": "Observações adicionais específicas do canal."
+              }
+            }
+          },
+          "gaps": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "gap",
+                "impact"
+              ],
+              "properties": {
+                "gap": {
+                  "type": "string",
+                  "description": "Descrição específica do gap encontrado."
+                },
+                "evidence": {
+                  "type": "string",
+                  "description": "Evidência concreta do gap (o que foi observado)."
+                },
+                "impact": {
+                  "type": "string",
+                  "enum": [
+                    "high",
+                    "medium",
+                    "low"
+                  ],
+                  "description": "Impacto na conversão/resultado."
+                }
+              }
+            },
+            "description": "Gaps identificados neste canal."
+          },
+          "recommendations": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "action",
+                "priority"
+              ],
+              "properties": {
+                "action": {
+                  "type": "string",
+                  "description": "Ação recomendada para corrigir o gap."
+                },
+                "priority": {
+                  "type": "string",
+                  "enum": [
+                    "immediate",
+                    "short_term",
+                    "medium_term"
+                  ],
+                  "description": "Quando implementar."
+                },
+                "effort": {
+                  "type": "string",
+                  "enum": [
+                    "low",
+                    "medium",
+                    "high"
+                  ],
+                  "description": "Esforço para implementar."
+                }
+              }
+            },
+            "description": "Recomendações para este canal."
+          }
+        }
+      },
+      "description": "Auditoria detalhada de cada canal digital."
+    },
+    "gap_matrix": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "rank",
+          "channel",
+          "gap",
+          "impact",
+          "effort",
+          "recommended_action"
+        ],
+        "properties": {
+          "rank": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Posição na prioridade."
+          },
+          "channel": {
+            "type": "string",
+            "description": "Canal onde o gap foi encontrado."
+          },
+          "gap": {
+            "type": "string",
+            "description": "Descrição do gap."
+          },
+          "impact": {
+            "type": "string",
+            "enum": [
+              "high",
+              "medium",
+              "low"
+            ],
+            "description": "Impacto na conversão."
+          },
+          "effort": {
+            "type": "string",
+            "enum": [
+              "low",
+              "medium",
+              "high"
+            ],
+            "description": "Esforço para resolver."
+          },
+          "recommended_action": {
+            "type": "string",
+            "description": "Ação recomendada."
+          },
+          "quadrant": {
+            "type": "string",
+            "enum": [
+              "quick_win",
+              "strategic_project",
+              "fill_time",
+              "deprioritize"
+            ],
+            "description": "Classificação na matriz impacto x esforço."
+          }
+        }
+      },
+      "description": "Matriz consolidada de todos os gaps, priorizada por impacto x esforço."
+    },
+    "executive_summary": {
+      "type": "object",
+      "required": [
+        "top_problems",
+        "overall_assessment"
+      ],
+      "properties": {
+        "overall_assessment": {
+          "type": "string",
+          "description": "Avaliação geral da comunicação digital do cliente (1-2 parágrafos)."
+        },
+        "top_problems": {
+          "type": "array",
+          "minItems": 3,
+          "maxItems": 3,
+          "items": {
+            "type": "object",
+            "required": [
+              "problem",
+              "evidence",
+              "impact",
+              "action"
+            ],
+            "properties": {
+              "problem": {
+                "type": "string",
+                "description": "Descrição do problema."
+              },
+              "evidence": {
+                "type": "string",
+                "description": "Evidência concreta."
+              },
+              "impact": {
+                "type": "string",
+                "description": "Impacto estimado na conversão/resultado."
+              },
+              "action": {
+                "type": "string",
+                "description": "Ação para resolver."
+              }
+            }
+          },
+          "description": "Top 3 problemas de comunicação que mais custam conversão."
+        },
+        "communication_score": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100,
+          "description": "Score geral de comunicação (média dos canais auditados)."
+        }
+      }
+    },
+    "competitor_benchmark": {
+      "type": "object",
+      "description": "Benchmark canal-a-canal contra grupos de concorrentes.",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "groups": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "name"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "members": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "positioning": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "benchmark_by_channel": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "channel"
+            ],
+            "properties": {
+              "channel": {
+                "type": "string"
+              },
+              "client_score": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 100,
+                "description": "Score do cliente (0-100). Nome preferido."
+              },
+              "best_in_class_score": {
+                "type": "number",
+                "description": "Score do melhor concorrente do grupo."
+              },
+              "competitor_avg_score": {
+                "type": "number",
+                "description": "Alternativa: média dos concorrentes. O renderer aceita best_in_class_score OU competitor_avg_score."
+              },
+              "gap": {
+                "type": "number",
+                "description": "Diferença entre best_in_class e client_score."
+              },
+              "best_practice_observed": {
+                "type": "string",
+                "description": "O que o melhor concorrente faz (específico). Nome preferido."
+              },
+              "evidence": {
+                "type": "string",
+                "description": "Alternativa a best_practice_observed — evidência concreta observada."
+              },
+              "opportunity_for_client": {
+                "type": "string",
+                "description": "Como o cliente pode fechar o gap (específico, não genérico). Nome preferido."
+              },
+              "immediate_win": {
+                "type": "string",
+                "description": "Alternativa a opportunity_for_client — ganho imediato possível."
+              }
+            }
+          }
+        },
+        "strategic_read": {
+          "type": "string"
+        }
+      }
+    },
+    "journey_friction_map": {
+      "type": "object",
+      "description": "Mapa de fricção do funil real da persona, estágio a estágio.",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "stages": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "stage"
+            ],
+            "properties": {
+              "stage": {
+                "type": "string"
+              },
+              "current_volume": {
+                "type": [
+                  "number",
+                  "string"
+                ]
+              },
+              "leakage_pct": {
+                "type": "number",
+                "description": "% que vaza para o próximo estágio."
+              },
+              "root_cause": {
+                "type": "string"
+              },
+              "fix_effort": {
+                "type": "string",
+                "enum": [
+                  "low",
+                  "medium",
+                  "high"
+                ]
+              },
+              "fix_impact_estimate": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "biggest_leakage_summary": {
+          "type": "string"
+        },
+        "projected_funnel_90d_realistic": {
+          "type": "string"
+        }
+      }
+    },
+    "tone_of_voice_analysis": {
+      "type": "object",
+      "description": "Auditoria de coerência do tom de voz entre canais.",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "brand_voice_target": {
+          "type": "object",
+          "properties": {
+            "pillars": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "avoid": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "channel_drift": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "channel"
+            ],
+            "properties": {
+              "channel": {
+                "type": "string"
+              },
+              "actual_tone": {
+                "type": "string",
+                "description": "Como soa hoje (com exemplo citado). Nome preferido."
+              },
+              "current_tone": {
+                "type": "string",
+                "description": "Alternativa a actual_tone."
+              },
+              "alignment_score": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 100,
+                "description": "Score numérico 0-100. Opcional se target_alignment for usado."
+              },
+              "target_alignment": {
+                "type": "string",
+                "enum": [
+                  "alinhado",
+                  "aligned",
+                  "bom",
+                  "boa",
+                  "good",
+                  "parcial",
+                  "partial",
+                  "media",
+                  "média",
+                  "medium",
+                  "baixa",
+                  "baixo",
+                  "low",
+                  "desalinhado",
+                  "misaligned",
+                  "critico",
+                  "crítico",
+                  "nenhum",
+                  "none",
+                  "nao",
+                  "não"
+                ],
+                "description": "Alinhamento qualitativo com a brand voice. O renderer do portal mapeia para score (alinhado=100, bom=80, parcial/média=55, baixa=25, desalinhado=20, crítico=10, nenhum=0). Preferido sobre alignment_score numérico por ser mais legível."
+              },
+              "drift_notes": {
+                "type": "string",
+                "description": "Onde desalinhou. Nome preferido."
+              },
+              "gap": {
+                "type": "string",
+                "description": "Alternativa a drift_notes — descrição do gap observado."
+              },
+              "fix": {
+                "type": "string",
+                "description": "Correção sugerida. Se presente, o renderer exibe como ação complementar ao drift_notes."
+              },
+              "example": {
+                "type": "string",
+                "description": "Citação textual do canal que ilustra o drift."
+              }
+            }
+          }
+        },
+        "coherence_score": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100
+        }
+      }
+    },
+    "url_audit": {
+      "type": "object",
+      "description": "Lista de URLs críticas a verificar pelo operador.",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "urls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "url",
+              "purpose"
+            ],
+            "properties": {
+              "url": {
+                "type": "string"
+              },
+              "purpose": {
+                "type": "string"
+              },
+              "status_expected": {
+                "type": "string"
+              },
+              "verify_checklist": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "quick_wins": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 5,
+      "items": {
+        "type": "object",
+        "required": [
+          "action",
+          "channel",
+          "time_estimate",
+          "expected_impact"
+        ],
+        "properties": {
+          "action": {
+            "type": "string",
+            "description": "Ação concreta passo a passo."
+          },
+          "channel": {
+            "type": "string",
+            "description": "Canal onde implementar."
+          },
+          "time_estimate": {
+            "type": "string",
+            "description": "Tempo estimado para implementar (ex: '1h', '30min', '2h')."
+          },
+          "expected_impact": {
+            "type": "string",
+            "description": "O que melhora com essa ação."
+          },
+          "who_does_it": {
+            "type": "string",
+            "enum": [
+              "operator",
+              "client",
+              "client_team",
+              "designer"
+            ],
+            "description": "Quem implementa."
+          },
+          "steps": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Passos detalhados para implementar."
+          }
+        }
+      },
+      "description": "Ações implementáveis em menos de 1 semana sem custo adicional."
+    },
+    "key_insight": {
+      "type": "object",
+      "description": "Ponto de alavancagem desta skill — o bloco que merece destaque visual para conversa com o stakeholder. Ver PADRAO-OUTPUT.md.",
+      "properties": {
+        "headline": {
+          "type": "string",
+          "description": "Frase-manchete do ponto (pode virar quote destacada no renderer)"
+        },
+        "context": {
+          "type": "string",
+          "description": "Contexto em 2-3 linhas explicando o cenário"
+        },
+        "numbered_reasons": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Razões numeradas (o renderer vira 3 cards numerados)"
+        },
+        "discussion_anchor": {
+          "type": "string",
+          "description": "Por que este é o ponto para stakeholder decidir/validar"
+        }
+      }
+    },
+    "honesty_alert": {
+      "type": "string",
+      "description": "Alerta se a análise revelou fragilidade real do cliente (não há diferencial claro, premissa contraditória, etc.). Nunca omitir se justificado."
+    }
+  }
+}

--- a/.agents/skills/account-cliente-oculto/SKILL.md
+++ b/.agents/skills/account-cliente-oculto/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: account-cliente-oculto
+description: "Simulacao de cliente oculto: cria perfil de comprador ficticio, operador executa no canal real, IA analisa a conversa e gera relatorio com nota 0-10. Use quando o operador disser 'cliente oculto', 'mystery shopping', 'testar atendimento', 'simular compra', ou na Semana 3 do modelo Inside Sales (POP 3.2)."
+area: account
+author: luizfreitasv4
+version: 1.0.0
+dependencies:
+  - geral-persona-icp
+outputs: ["account-cliente-oculto.json"]
+week: 3
+modelo_venda: inside-sales
+estimated_time: "1.5h"
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta versao foi portada do sistema de Estruturacao Estrategica. As regras abaixo tem precedencia sobre caminhos e persistencia citados no fluxo original:
+
+- Trabalhe somente em `squads/{squad}/clientes/{cliente}/`, nunca em um diretorio `clientes/` solto na raiz.
+- Leia primeiro o `CLAUDE.md` ou `AGENTS.md` da KB, `mission-control/`, `calls/`, `docs/` e `campanhas/`.
+- Se `client.json` existir, use-o como fonte complementar. Se nao existir, derive o contexto da KB e do Mission Control; nao exija nem invente esse arquivo.
+- Salve entregaveis em `squads/{squad}/clientes/{cliente}/outputs/`, em JSON e Markdown quando o fluxo pedir ambos.
+- Registre decisoes e progresso no `mission-control/historico-checkins.md` ou no arquivo de historico equivalente encontrado na KB.
+- Resolva recursos empacotados a partir do proprio diretorio desta skill. Se uma integracao externa nao estiver configurada, declare o gap e continue apenas com os dados reais disponiveis.
+
+
+# Cliente Oculto (POP 3.2 — Inside Sales)
+
+Voce e um especialista em avaliacao de experiencia de compra e mystery shopping. Vai criar um cenario de simulacao realista para testar o atendimento comercial do cliente e, apos a execucao pelo operador, analisar a conversa gerando um relatorio detalhado com nota e recomendacoes.
+
+> **Posição no fluxo:** Semana 3, cabeça do modelo **Inside Sales** (POP 3.2). Roda **antes** do Diagnóstico Comercial (3.3) — é um input independente que mede a realidade do atendimento; o comercial usa esses achados. Mínimo 3-5 simulações em horários variados.
+
+## Dados necessários
+
+1. `client.json` (seção `briefing`) — NOME_CLIENTE, PRODUTO_SERVICO, CANAL_CONTATO
+2. `outputs/geral-persona-icp.json` — RESUMO_ICP, perfil demografico, comportamento
+3. `outputs/account-diagnostico-comercial.json` — **se já existir** (opcional; normalmente o cliente oculto roda antes do comercial)
+4. `client.json` (seção `connectors`) — dados adicionais de canais
+
+Confirme com o operador:
+
+> Vamos criar e executar um cliente oculto para {NOME_CLIENTE}.
+> Canal principal: {CANAL — WhatsApp / formulario / email / Instagram DM}
+> Correto? IMPORTANTE: voce (operador) vai executar a simulacao manualmente. Eu crio o roteiro e depois analiso.
+
+---
+
+## Geração
+
+Gere o output COMPLETO de uma vez: perfil do comprador + script da simulação. Use os dados de `client.json` (briefing) e outputs de skills dependentes em `outputs/`.
+
+Consulte `references/criterios-avaliacao-cliente-oculto.md` para os criterios de avaliação.
+
+### Perfil do comprador simulado
+
+- Nome fictício, contexto plausível e específico
+- Urgência (alta/média/baixa) com motivo
+- Budget declarado (como/quando mencionar)
+- Objeção principal (alinhada ao diagnóstico)
+- Nível de conhecimento do produto
+
+### Script da simulação
+
+**Mensagem de abertura:** como o ICP real enviaria
+**Mensagens de acompanhamento:** se não houver resposta (30min, 2h)
+**4 perguntas para fazer ao longo da conversa:** cada uma testando uma dimensão (conhecimento do produto, objeção de preço, urgência/follow-up, personalização)
+**Comportamento do comprador:** atraso de resposta, cautela, objeção de preço na proposta, "vou pensar" para testar follow-up
+
+Apresente ao operador e peça validação de que é realista.
+
+### Execução (MANUAL pelo operador)
+
+> **ATENCAO: Esta etapa e MANUAL.** Voce (operador) executa a simulação seguindo o roteiro.
+>
+> **Instrucoes:**
+> 1. Use numero/conta que NÃO esteja associado a V4 ou ao seu nome
+> 2. Siga o roteiro mas adapte naturalmente
+> 3. Anote tempos exatos de cada resposta
+> 4. Documente TODA a conversa (print ou cópia)
+> 5. NÃO revele que é teste
+> 6. Se pedirem dados sensíveis, invente dados fictícios
+>
+> Cole aqui o histórico completo com horários quando terminar.
+
+Aguarde o operador executar e colar o histórico.
+
+### Análise da conversa e relatório
+
+Após receber o histórico, analise e gere o relatório:
+
+**Nota geral: X/10** (EXCELENTE 9-10 / BOM 7-8 / REGULAR 5-6 / RUIM 3-4 / CRITICO 0-2)
+
+**7 critérios avaliados:**
+1. Tempo de primeira resposta (meta: < 5 min)
+2. Qualidade da abordagem inicial
+3. Identificação de necessidade
+4. Conhecimento do produto
+5. Tratamento de objeção de preço
+6. CTA e tentativa de avançar o funil
+7. Follow-up após conversa
+
+Para cada: nota 0-10 + observação + evidência (trecho da conversa).
+
+**Pontos fortes** (com evidência)
+**Pontos críticos** (em ordem de impacto, com: problema, impacto estimado, como o SDR IA vai resolver)
+
+**Impacto estimado do SDR IA:**
+- Tempo de resposta: de {atual} para < 5 segundos
+- Taxa de contato: de {atual}% para {projeção}%
+- Taxa de qualificação: de {atual}% para {projeção}%
+- Impacto financeiro: +R${valor}/mês
+
+## Auto-validação
+
+Antes de mostrar ao operador, verifique:
+
+- [ ] Mencionou o cliente pelo nome?
+- [ ] Usou dados reais (não inventou)?
+- [ ] Perfil é realista (time não perceberá que é teste)?
+- [ ] Critérios de avaliação são justos e baseados em evidência?
+- [ ] Impacto do SDR IA é realista (não exagerado)?
+
+Se falhou → regenere silenciosamente. Não avise o operador.
+
+## Apresentação e decisões
+
+Apresente o relatório COMPLETO ao operador.
+
+Revise o output. O que está errado, exagerado ou faltando?
+
+- "O relatorio reflete fielmente o que voce observou?"
+- "Algum detalhe que interpretei errado?"
+- "Os pontos criticos estao na ordem certa de impacto?"
+
+## Finalização
+
+Operador aprova (com ou sem ajustes).
+1. Salve em `squads/{squad}/clientes/{cliente}/outputs/account-cliente-oculto.json` (com campo `summary` no topo)
+2. Atualize `client.json`: progress.skills → completed, version++, append em history[]
+3. Salve também uma versão Markdown do entregável na mesma pasta de outputs.
+4. Sugira a próxima skill com base nas dependências do frontmatter e no estado da KB
+   - "Cliente oculto concluido. Nota: {X}/10. Pontos criticos: {lista}."
+   - Sugira: `/account-diagnostico-comercial` (3.3) — usa estes achados para cravar o gargalo e calibrar a qualificação.
+
+**NOTA:** O relatório pode ser compartilhado com o cliente como evidência do valor do SDR IA. O contraste "antes vs depois" é poderoso.

--- a/.agents/skills/account-cliente-oculto/references/criterios-avaliacao-cliente-oculto.md
+++ b/.agents/skills/account-cliente-oculto/references/criterios-avaliacao-cliente-oculto.md
@@ -1,0 +1,205 @@
+# Criterios de Avaliacao — Cliente Oculto
+
+Framework completo para avaliacao de mystery shopping em PMEs brasileiras. Cada criterio tem peso, escala de nota, e exemplos concretos de cada faixa de avaliacao.
+
+---
+
+## Criterio 1: Tempo de Primeira Resposta
+
+**Peso:** 20% da nota final
+**Meta:** < 5 minutos
+
+| Nota | Tempo | Descricao |
+|------|-------|-----------|
+| 10 | < 1 minuto | Resposta quase instantanea. Impressiona o lead. |
+| 9 | 1-3 minutos | Muito rapido. Lead ainda esta quente e engajado. |
+| 8 | 3-5 minutos | Dentro da meta. Aceitavel para a maioria dos segmentos. |
+| 7 | 5-10 minutos | Ligeiramente acima da meta. Lead ainda esta no celular. |
+| 6 | 10-15 minutos | Comeca a perder atencao. Lead pode estar vendo concorrente. |
+| 5 | 15-30 minutos | Problematico. Lead provavelmente ja enviou mensagem para outro. |
+| 4 | 30-60 minutos | Ruim. Lead ja esta em outra atividade. |
+| 3 | 1-2 horas | Muito ruim. Lead precisa ser re-engajado. |
+| 2 | 2-4 horas | Critico. Lead provavelmente ja comprou do concorrente. |
+| 1 | 4-24 horas | Inaceitavel. Demonstra total falta de processo. |
+| 0 | > 24 horas ou sem resposta | O lead foi perdido. |
+
+**O que observar:**
+- A resposta foi automatica (chatbot) ou humana?
+- Se automatica, era util ou so "aguarde que ja iremos atende-lo"?
+- O lead precisou mandar mais de uma mensagem para ser atendido?
+
+**Impacto real:** Pesquisas mostram que a chance de qualificar um lead cai 10x se o contato for feito apos 5 minutos vs nos primeiros 5 minutos (estudo InsideSales/Harvard Business Review). Em WhatsApp, o efeito e ainda mais dramatico porque o lead espera resposta imediata.
+
+---
+
+## Criterio 2: Qualidade da Abordagem Inicial
+
+**Peso:** 15% da nota final
+
+| Nota | Descricao | Exemplo |
+|------|-----------|---------|
+| 9-10 | Personalizada, calorosa, com pergunta de contexto. Se apresentou pelo nome. | "Oi, Marcos! Sou a Ana da [empresa]. Vi que voce tem interesse em [produto]. Me conta um pouco da sua situacao — em que posso te ajudar?" |
+| 7-8 | Boa abordagem, se apresentou, mas poderia ser mais personalizada. | "Ola, tudo bem? Sou o Pedro da [empresa]. Como posso te ajudar?" |
+| 5-6 | Generica mas educada. Nao se apresentou ou nao fez pergunta. | "Ola, obrigado pelo contato! Segue nosso catalogo." |
+| 3-4 | Fria ou mecanica. Parece copiar e colar. | "Boa tarde. Qual servico deseja?" |
+| 1-2 | Rude, confusa ou incoerente. | "Oi" (e espera o lead puxar a conversa) |
+| 0 | Nao houve abordagem. Lead nao foi respondido. | — |
+
+**O que observar:**
+- O atendente se apresentou pelo nome?
+- Usou o nome do lead (se disponivel)?
+- Fez alguma pergunta para entender o contexto?
+- A mensagem era personalizada ou copy-paste?
+- O tom era coerente com o tipo de negocio?
+- Enviou audio, texto, ou figurinha? (audio sem contexto e negativo)
+
+---
+
+## Criterio 3: Identificacao de Necessidade
+
+**Peso:** 15% da nota final
+
+| Nota | Descricao | Sinais |
+|------|-----------|--------|
+| 9-10 | Fez perguntas abertas e especificas para entender a real necessidade. Escutou antes de vender. | Perguntas como "qual seu objetivo principal?", "o que te motivou a procurar isso agora?", "ja tentou resolver de outra forma?" |
+| 7-8 | Fez perguntas, mas poderiam ser mais profundas. | Perguntas genericas como "o que voce precisa?" sem aprofundar |
+| 5-6 | Fez 1-2 perguntas basicas e ja partiu para a apresentacao. | "Voce quer o servico X ou Y?" e ja enviou proposta |
+| 3-4 | Nao perguntou nada. Apresentou o produto direto. | Mandou catalogo/precos sem perguntar o que o lead precisa |
+| 1-2 | Ignorou o que o lead disse e falou de outra coisa. | Lead fala do problema, atendente responde com promocao |
+| 0 | Nao houve interacao suficiente para avaliar. | — |
+
+**O que observar:**
+- Quantas perguntas foram feitas antes de apresentar o produto?
+- As perguntas eram abertas ou fechadas?
+- O atendente ouviu as respostas e adaptou a abordagem?
+- Houve empatia com a situacao do lead?
+- O atendente tentou entender o "por que agora?" (timing da necessidade)
+
+---
+
+## Criterio 4: Conhecimento do Produto
+
+**Peso:** 10% da nota final
+
+| Nota | Descricao | Sinais |
+|------|-----------|--------|
+| 9-10 | Domina o produto, responde com seguranca, usa exemplos e casos. | "No caso de academias, o que funciona melhor e [X] porque [motivo com exemplo real]." |
+| 7-8 | Conhece bem, responde sem hesitar, mas sem exemplos. | Respostas corretas e seguras, porem teoricas |
+| 5-6 | Conhece o basico, hesita em detalhes. | "Acho que sim... vou confirmar com a equipe." |
+| 3-4 | Pouco conhecimento, da respostas vagas. | "Temos varios pacotes, vou te mandar o material." |
+| 1-2 | Nao sabe sobre o produto, da informacao errada. | Respostas confusas ou contraditorias |
+| 0 | Nao demonstrou nenhum conhecimento. | Nao respondeu perguntas sobre o produto |
+
+**O que observar:**
+- O atendente sabia responder sem precisar "verificar"?
+- Usou termos tecnicos de forma acessivel ou confundiu o lead?
+- Conseguiu comparar opcoes/pacotes com clareza?
+- Usou exemplos ou casos de sucesso para ilustrar?
+- As informacoes dadas sao consistentes (nao se contradizem)?
+
+---
+
+## Criterio 5: Tratamento de Objecao de Preco
+
+**Peso:** 15% da nota final
+
+| Nota | Descricao | Sinais |
+|------|-----------|--------|
+| 9-10 | Reconheceu a objecao, demonstrou valor antes de falar em preco, usou ROI ou comparacao. | "Entendo a preocupacao. Olha, o Joao tinha a mesma dúvida e em 2 meses recuperou o investimento porque [resultado]." |
+| 7-8 | Boa resposta, demonstrou valor, mas poderia ser mais especifica. | "O valor reflete [beneficio], e a maioria dos clientes veem retorno em [prazo]." |
+| 5-6 | Tentou justificar, mas ficou na superficie. Ou foi direto para desconto. | "O preco e justo pelo que oferecemos" ou "posso ver um desconto" |
+| 3-4 | Ficou defensivo ou desconfortavel com a objecao. | "E esse o preco, nao tem como mudar" ou silencio constrangedor |
+| 1-2 | Deu desconto imediatamente sem justificar. Ou ignorou a objecao. | "Te faco por X, pode ser?" (sem perguntar por que achou caro) |
+| 0 | Nao houve objecao de preco (lead nao chegou a esse ponto) ou atendente sumiu. | — |
+
+**O que observar:**
+- O atendente perguntou POR QUE achou caro? (comparando com o que?)
+- Tentou entender se e falta de budget ou falta de valor percebido?
+- Usou prova social (outros clientes, resultados)?
+- Fez ancoragem de preco (mostrou o custo da inacao)?
+- Ofereceu alternativas antes de desconto (plano menor, parcelamento)?
+- Se deu desconto, condicionou a algo (fechar agora, contrato maior)?
+
+---
+
+## Criterio 6: CTA e Tentativa de Avancar o Funil
+
+**Peso:** 15% da nota final
+
+| Nota | Descricao | Sinais |
+|------|-----------|--------|
+| 9-10 | Propoe proximo passo claro e especifico, com data/horario. | "Que tal a gente marcar uma conversa de 15 minutos amanha as 14h pra eu entender melhor e montar uma proposta personalizada?" |
+| 7-8 | Propoe proximo passo, mas sem data especifica. | "Vou te mandar uma proposta, pode ser?" |
+| 5-6 | Tentativa timida de avancar. | "Se quiser, posso te mandar mais informacoes." |
+| 3-4 | Nao propoe proximo passo. Deixa na mao do lead. | "Qualquer dúvida, estou a disposicao." |
+| 1-2 | Encerra a conversa sem CTA. | "Ok, obrigado pelo contato." |
+| 0 | Conversa morreu sem conclusao. | Atendente parou de responder |
+
+**O que observar:**
+- Houve tentativa de agendar proxima interacao?
+- O CTA era especifico (data, horario, canal)?
+- O atendente usou senso de urgencia apropriado?
+- Houve alguma oferta ou condicao para incentivar acao?
+- O lead saiu sabendo o que acontece a seguir?
+
+---
+
+## Criterio 7: Follow-up Apos Conversa
+
+**Peso:** 10% da nota final
+
+| Nota | Descricao | Tempo |
+|------|-----------|-------|
+| 9-10 | Follow-up proativo com valor agregado em 1-2 horas. | "Oi Marcos, lembrei que voce perguntou sobre [X]. Separei esse caso aqui que e parecido com o seu." |
+| 7-8 | Follow-up em ate 24 horas com conteudo relevante. | "Oi, continuando nossa conversa de ontem, montei uma proposta personalizada pra voce." |
+| 5-6 | Follow-up generico em 24-48 horas. | "Oi, tudo bem? Pensou na proposta?" |
+| 3-4 | Follow-up apenas apos 3+ dias. | "Ola, ainda tem interesse?" (4 dias depois) |
+| 1-2 | Nenhum follow-up em 1 semana. | — |
+| 0 | Nenhum follow-up em 2+ semanas. Lead esquecido. | — |
+
+**O que observar:**
+- Houve follow-up sem o lead pedir?
+- O follow-up tinha valor (conteudo, proposta) ou era so cobranca?
+- O tom era natural ou robótico/automatizado?
+- Usou alguma informacao da conversa anterior?
+- Quantas tentativas de follow-up foram feitas?
+
+---
+
+## Formula de Calculo da Nota Final
+
+```
+Nota final = (C1 x 0.20) + (C2 x 0.15) + (C3 x 0.15) + (C4 x 0.10) + (C5 x 0.15) + (C6 x 0.15) + (C7 x 0.10)
+```
+
+### Classificacao
+
+| Nota | Classificacao | Descricao |
+|------|---------------|-----------|
+| 9.0 - 10.0 | Excelente | Atendimento de referencia. Poucas melhorias necessarias. |
+| 7.0 - 8.9 | Bom | Atendimento competente. Melhorias pontuais. |
+| 5.0 - 6.9 | Regular | Funciona, mas perde vendas por falta de processo. SDR IA tera alto impacto. |
+| 3.0 - 4.9 | Ruim | Processo quebrado. Leads estao sendo desperdicados. SDR IA e urgente. |
+| 0.0 - 2.9 | Critico | Atendimento inexistente ou prejudicial. Cada dia sem SDR IA e dinheiro perdido. |
+
+---
+
+## Erros Comuns que Invalidam a Simulacao
+
+1. **Usar numero/conta associado a V4:** O time pode reconhecer e dar tratamento VIP
+2. **Perfil muito diferente do ICP:** O atendimento pode ser diferente para um perfil que nao e o publico-alvo
+3. **Revelar que e teste antes de terminar:** Invalida completamente os dados
+4. **Nao registrar horarios:** Sem horarios, nao da para avaliar tempo de resposta
+5. **Simular apenas em horario comercial pico:** Teste em horarios variados revela realidade
+6. **Desistir cedo demais:** A simulacao deve ir ate o ponto de proposta de valor/preco
+
+---
+
+## Dicas para Simulacao Realista
+
+1. **Use linguagem natural do ICP:** Se o ICP e informal, escreva com gíria/abreviacao. Se e formal, escreva formalmente.
+2. **Responda com atraso realista:** Um lead real nao responde instantaneamente a cada mensagem.
+3. **Demonstre hesitacao real:** Faca perguntas que um comprador cauteloso faria.
+4. **Nao facilite:** Se o atendente nao perguntar algo, nao ofereça a informacao espontaneamente.
+5. **Teste o "vou pensar":** Essa frase e o teste definitivo — o follow-up (ou falta dele) revela muito.
+6. **Documente tudo:** Print de tela com horarios visíveis e a melhor evidencia.

--- a/.agents/skills/account-cliente-oculto/schema.json
+++ b/.agents/skills/account-cliente-oculto/schema.json
@@ -1,0 +1,352 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ClienteOculto",
+  "description": "Output estruturado da skill cliente-oculto: simulacao de mystery shopping com perfil do comprador, script de simulacao e avaliacao detalhada.",
+  "type": "object",
+  "required": [
+    "summary",
+    "buyer_profile",
+    "simulation_script",
+    "evaluation",
+    "client_name",
+    "summary_headline",
+    "summary_highlights",
+    "summary_key_findings"
+  ],
+  "properties": {
+    "client_name": {
+      "type": "string",
+      "description": "Nome do cliente — sempre presente em todo output."
+    },
+    "summary": {
+      "type": "string",
+      "description": "Resumo executivo de 2-3 frases: nota geral, principal ponto forte, principal ponto critico e impacto estimado do SDR IA."
+    },
+    "summary_headline": {
+      "type": "string",
+      "description": "Manchete em 1 linha (~120 caracteres) com o veredito da skill."
+    },
+    "summary_highlights": {
+      "type": "array",
+      "description": "KPIs em destaque (4-6 itens). Categorias: posicao | competicao | janela | maturidade | oportunidade | risco.",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "label",
+          "value",
+          "tone"
+        ],
+        "properties": {
+          "category": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "subtext": {
+            "type": "string"
+          },
+          "tone": {
+            "type": "string",
+            "enum": [
+              "green",
+              "yellow",
+              "red",
+              "blue",
+              "gray"
+            ]
+          }
+        }
+      }
+    },
+    "summary_key_findings": {
+      "type": "array",
+      "description": "3-5 achados categorizados (vantagem | contexto | ameaca | acao).",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "text"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "vantagem",
+              "contexto",
+              "ameaca",
+              "acao"
+            ]
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "buyer_profile": {
+      "type": "object",
+      "required": [
+        "name",
+        "situation",
+        "urgency",
+        "budget",
+        "main_objection"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Nome ficticio do comprador simulado."
+        },
+        "situation": {
+          "type": "string",
+          "description": "Contexto plausivel que justifica o interesse no produto/servico."
+        },
+        "urgency": {
+          "type": "string",
+          "enum": [
+            "high",
+            "medium",
+            "low"
+          ],
+          "description": "Nivel de urgencia do comprador simulado."
+        },
+        "urgency_reason": {
+          "type": "string",
+          "description": "Motivo concreto da urgencia (ou falta dela)."
+        },
+        "budget": {
+          "type": "string",
+          "description": "Budget declarado ou implicito do comprador simulado."
+        },
+        "main_objection": {
+          "type": "string",
+          "description": "Objecao principal que sera levantada durante a simulacao."
+        },
+        "knowledge_level": {
+          "type": "string",
+          "enum": [
+            "low",
+            "medium",
+            "high"
+          ],
+          "description": "Nivel de conhecimento do comprador sobre o produto/servico."
+        }
+      }
+    },
+    "simulation_script": {
+      "type": "object",
+      "required": [
+        "opening_message",
+        "followup_30min",
+        "followup_2h",
+        "questions"
+      ],
+      "properties": {
+        "opening_message": {
+          "type": "string",
+          "description": "Mensagem de abertura natural que o ICP real enviaria."
+        },
+        "followup_30min": {
+          "type": "string",
+          "description": "Mensagem de follow-up caso nao haja resposta em 30 minutos."
+        },
+        "followup_2h": {
+          "type": "string",
+          "description": "Mensagem de follow-up caso nao haja resposta em 2 horas."
+        },
+        "questions": {
+          "type": "array",
+          "minItems": 3,
+          "items": {
+            "type": "object",
+            "required": [
+              "question",
+              "objective"
+            ],
+            "properties": {
+              "question": {
+                "type": "string",
+                "description": "Pergunta que o comprador simulado fara."
+              },
+              "objective": {
+                "type": "string",
+                "description": "O que essa pergunta testa (conhecimento do produto, objecao de preco, follow-up, etc.)."
+              }
+            }
+          },
+          "description": "Perguntas estrategicas para testar diferentes aspectos do atendimento."
+        },
+        "buyer_behavior_rules": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Regras de comportamento do comprador simulado (atraso de resposta, cautela, etc.)."
+        }
+      }
+    },
+    "simulation_metadata": {
+      "type": "object",
+      "properties": {
+        "date": {
+          "type": "string",
+          "format": "date",
+          "description": "Data da simulacao (ISO 8601)."
+        },
+        "channel": {
+          "type": "string",
+          "description": "Canal onde a simulacao foi executada (WhatsApp, formulario, email, Instagram DM)."
+        },
+        "attendant_name": {
+          "type": "string",
+          "description": "Nome do atendente que respondeu (ou 'nao se identificou')."
+        },
+        "total_duration_minutes": {
+          "type": "integer",
+          "description": "Duracao total da conversa em minutos."
+        },
+        "conversation_transcript": {
+          "type": "string",
+          "description": "Transcricao completa da conversa com horarios."
+        }
+      }
+    },
+    "evaluation": {
+      "type": "object",
+      "required": [
+        "overall_score",
+        "strengths",
+        "critical_improvements",
+        "sdr_impact_per_improvement"
+      ],
+      "properties": {
+        "overall_score": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 10,
+          "description": "Nota geral de 0 a 10."
+        },
+        "classification": {
+          "type": "string",
+          "enum": [
+            "excellent",
+            "good",
+            "regular",
+            "poor",
+            "critical"
+          ],
+          "description": "Classificacao textual baseada na nota."
+        },
+        "criteria_scores": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "criterion",
+              "score",
+              "observation"
+            ],
+            "properties": {
+              "criterion": {
+                "type": "string",
+                "description": "Nome do criterio avaliado."
+              },
+              "score": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 10,
+                "description": "Nota de 0 a 10 para este criterio."
+              },
+              "observation": {
+                "type": "string",
+                "description": "Observacao detalhada sobre o desempenho neste criterio."
+              },
+              "evidence": {
+                "type": "string",
+                "description": "Trecho da conversa que evidencia a avaliacao."
+              }
+            }
+          },
+          "description": "Notas individuais por criterio de avaliacao."
+        },
+        "strengths": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "description": "Ponto forte observado com evidencia da conversa."
+          },
+          "description": "Lista de pontos fortes identificados no atendimento."
+        },
+        "critical_improvements": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "description": "Ponto critico de melhoria em ordem de impacto."
+          },
+          "description": "Lista de pontos criticos de melhoria ordenados por impacto."
+        },
+        "sdr_impact_per_improvement": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": [
+              "improvement",
+              "sdr_solution",
+              "estimated_impact"
+            ],
+            "properties": {
+              "improvement": {
+                "type": "string",
+                "description": "Ponto critico que o SDR IA vai resolver."
+              },
+              "sdr_solution": {
+                "type": "string",
+                "description": "Como especificamente o SDR IA vai resolver este ponto."
+              },
+              "estimated_impact": {
+                "type": "string",
+                "description": "Impacto estimado da melhoria (ex: '+20% na taxa de contato')."
+              }
+            }
+          },
+          "description": "Mapeamento de como o SDR IA vai resolver cada ponto critico."
+        },
+        "overall_sdr_impact": {
+          "type": "object",
+          "properties": {
+            "response_time_before": {
+              "type": "string",
+              "description": "Tempo de resposta observado na simulacao."
+            },
+            "response_time_after": {
+              "type": "string",
+              "description": "Tempo de resposta projetado com SDR IA (< 5 segundos)."
+            },
+            "contact_rate_before": {
+              "type": "number",
+              "description": "Taxa de contato estimada atual (%)."
+            },
+            "contact_rate_after": {
+              "type": "number",
+              "description": "Taxa de contato projetada com SDR IA (%)."
+            },
+            "financial_impact_monthly": {
+              "type": "number",
+              "description": "Impacto financeiro mensal estimado em reais."
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/.agents/skills/account-crm-setup/SKILL.md
+++ b/.agents/skills/account-crm-setup/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: account-crm-setup
+description: "Configura o CRM Kommo com pipeline personalizado, réguas de boas-vindas e nutrição, e testa com lead fictício. Semi-manual — operador executa no Kommo. Use quando disser /account-crm-setup ou 'configurar CRM' ou 'setup Kommo' ou 'automação de leads'."
+area: account
+author: luizfreitasv4
+version: 1.0.0
+dependencies:
+  - geral-persona-icp
+inputs:
+  - client.json (briefing)
+  - geral-persona-icp.json
+  - designer-manual-marca.json
+output: account-crm-setup.json
+week: 4
+type: semi-manual
+estimated_time: "4h"
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta versao foi portada do sistema de Estruturacao Estrategica. As regras abaixo tem precedencia sobre caminhos e persistencia citados no fluxo original:
+
+- Trabalhe somente em `squads/{squad}/clientes/{cliente}/`, nunca em um diretorio `clientes/` solto na raiz.
+- Leia primeiro o `CLAUDE.md` ou `AGENTS.md` da KB, `mission-control/`, `calls/`, `docs/` e `campanhas/`.
+- Se `client.json` existir, use-o como fonte complementar. Se nao existir, derive o contexto da KB e do Mission Control; nao exija nem invente esse arquivo.
+- Salve entregaveis em `squads/{squad}/clientes/{cliente}/outputs/`, em JSON e Markdown quando o fluxo pedir ambos.
+- Registre decisoes e progresso no `mission-control/historico-checkins.md` ou no arquivo de historico equivalente encontrado na KB.
+- Resolva recursos empacotados a partir do proprio diretorio desta skill. Se uma integracao externa nao estiver configurada, declare o gap e continue apenas com os dados reais disponiveis.
+
+
+# CRM Setup — Pipeline + Réguas de Automação (POP 3.6)
+
+> **Posição no fluxo:** Semana 4 — Identidade de Comunicação e Plano de Mídia (**comum** a todos os modelos) (e-commerce / inside-sales / pdv). É "Implementação **ou** Otimização" — comece classificando o cenário de partida. O pipeline reflete o processo definido nos diagnósticos do modelo; o CRM **espelha** o processo (não o contrário).
+
+Você é um consultor especializado em automação comercial para PMEs brasileiras, com experiência em Kommo CRM. Vai classificar o cenário do cliente, criar/otimizar o pipeline personalizado, templates de mensagem para as réguas de automação (boas-vindas e nutrição), e guiar o operador na configuração — incluindo migração/limpeza de base e governança.
+
+### Cenário de partida (classifique primeiro)
+- **Cenário A — do zero:** sem CRM. Implementar do zero.
+- **Cenário B — subutilizado:** CRM existe mas mal usado. Reconfigurar + adotar.
+- **Cenário C — otimização:** CRM em uso. Otimizar sem ruptura (esgotar otimização antes de propor troca de ferramenta).
+
+## Dados necessários
+
+1. `client.json` (seção `briefing`) — nome, segmento, produto/serviço, processo comercial atual, WhatsApp, CRM atual (se houver)
+2. `outputs/geral-persona-icp.json` — ICP, dores, objeções, linguagem
+3. `outputs/designer-manual-marca.json` — tom de voz, vocabulário (se existir — melhora qualidade)
+4. `client.json` (seção `history`) — decisões anteriores
+
+---
+
+## Geração
+
+Gere o output COMPLETO de uma vez: pipeline + réguas + guia de configuração + checklist de teste. Use os dados de `client.json` (briefing) e outputs de skills dependentes em `outputs/`.
+
+Consulte `references/guia-kommo-setup.md` para referência de configuração.
+
+### Pipeline de vendas (personalizado)
+
+Etapas baseadas no processo comercial do cliente:
+```
+[Etapa 1] → [Etapa 2] → ... → [Fechado-Ganho / Fechado-Perdido]
+```
+Personalize nomes conforme o processo real (ex: "Orçamento Solicitado" em vez de "Proposta Enviada").
+
+### Tags e propriedades
+
+- Origem: Meta Ads | Google Ads | Indicação | Orgânico | Site | WhatsApp
+- Score SDR: 1-5 estrelas
+- Produto de interesse: [do briefing]
+- Temperatura: Frio | Morno | Quente
+
+### Régua 1 — Boas-vindas (3 mensagens automáticas)
+
+*Mensagem 1 (imediata):* Boas-vindas + confirmação + próximo passo. Máx 3 frases.
+*Mensagem 2 (24h sem resposta):* Follow-up leve + conteúdo de valor + CTA suave. Máx 3 frases.
+*Mensagem 3 (48h sem resposta):* Última tentativa + pergunta direta + abertura de saída. Máx 3 frases.
+
+### Régua 2 — Nutrição (4 touchpoints em 30 dias)
+
+Para leads score 1-3 estrelas:
+*Semana 1:* Conteúdo de valor (WhatsApp + Email) — educativo
+*Semana 2:* Caso de sucesso / prova social (WhatsApp + Email) — inspiracional
+*Semana 3:* Diferencial do produto (WhatsApp) — educativo + pitch leve
+*Semana 4:* Oferta / CTA direto (WhatsApp + Email) — direto, urgência real
+
+### Guia de configuração Kommo (passo a passo)
+
+**PASSO 1:** Criar pipeline (Settings > Pipeline). Renomear etapas.
+**PASSO 2:** Configurar tags e campos customizados.
+**PASSO 3:** Configurar Salesbot (boas-vindas) — trigger, condições, mensagens com delays.
+**PASSO 4:** Configurar Salesbot (nutrição) — trigger por score, 4 ações com delays de 7 dias.
+**PASSO 5:** Conectar WhatsApp Business. Testar envio.
+
+### Migração e limpeza de base (Cenários B e C)
+
+Se já existe base/CRM:
+- **Migrar base ativa primeiro**, histórico depois — nunca tudo de uma vez.
+- **Deduplicar, padronizar e enriquecer** antes de importar (sem lixo).
+- Mapear campos antigos → novos; registrar o que não migra e por quê.
+
+### Governança e adoção
+
+- **Campos obrigatórios** por etapa (origem, score, motivo de perda como lista fechada, próximo follow-up).
+- **Dashboards operacionais** (funil, SLA, motivos de perda).
+- **Treinamento + documento de governança** + plano de adoção (o CRM só vale se o time usar).
+
+### Checklist de teste
+
+**TESTE 1: PIPELINE** — criar lead manual, mover por etapas, verificar tags
+**TESTE 2: RÉGUA DE BOAS-VINDAS** — criar lead, verificar 3 mensagens com timings
+**TESTE 3: RÉGUA DE NUTRIÇÃO** — criar lead score baixo, verificar sequência
+**TESTE 4: INTEGRAÇÃO WHATSAPP** — enviar teste, verificar formatação e histórico
+**TESTE 5: CENÁRIO REAL** — submeter formulário, verificar pipeline + tags + salesbot
+
+## Auto-validação
+
+Antes de mostrar ao operador, verifique:
+
+- [ ] Mencionou o cliente pelo nome?
+- [ ] Usou dados reais do client.json (não inventou)?
+- [ ] Nenhum item genérico (ex: "quer crescer", "qualidade e compromisso")?
+- [ ] Schema da skill validou?
+- [ ] Todos os campos do schema preenchidos (ou com `null` + `unavailable_reason` no pai)?
+- [ ] Nenhuma string vazia (`""`) — substituí por `null` + reason quando o dado não existe?
+- [ ] Estimativas marcadas com `estimated: true` ou `[E]`?
+- [ ] Consistente com outputs anteriores (ICP)?
+- [ ] Mensagens de boas-vindas têm máximo 3 frases cada (WhatsApp)?
+- [ ] Régua de nutrição endereça a objeção principal do ICP?
+- [ ] Pipeline reflete o processo real (não genérico)?
+
+Se falhou → regenere silenciosamente. Não avise o operador.
+
+## Apresentação e decisões
+
+Apresente o output COMPLETO ao operador — pipeline, réguas, guia e checklist.
+
+Revise o output. O que está errado, exagerado ou faltando?
+
+- "O pipeline reflete o processo real de vendas? Nomes das etapas fazem sentido?"
+- "As tags cobrem todas as origens de leads?"
+- "O tom das mensagens está natural e alinhado com a marca?"
+- "As mensagens de boas-vindas são curtas o suficiente para WhatsApp?"
+- "A régua de nutrição endereça a objeção principal do ICP?"
+
+**Próximo passo (semi-manual):**
+O operador executa a configuração no Kommo seguindo o guia passo a passo. Após configurar, executa o checklist de teste. Se algum teste falhar, ajude a debugar.
+
+## Finalização
+
+Operador aprova (com ou sem ajustes, após testes passarem).
+1. Salve em `squads/{squad}/clientes/{cliente}/outputs/account-crm-setup.json` (com campo `summary` no topo)
+2. Atualize `client.json`: progress.skills → completed, version++, append em history[]
+3. Salve também uma versão Markdown do entregável na mesma pasta de outputs.
+4. Sugira próxima skill do dependency_graph
+
+## Formato do output (account-crm-setup.json)
+
+```json
+{
+  "pipeline_stages": [{ "order": 1, "name": "Lead", "description": "string", "auto_actions": ["string"] }],
+  "tags": { "origin": ["string"], "score": ["string"], "products": ["string"], "temperature": ["string"] },
+  "welcome_sequence": [{ "order": 1, "timing": "imediata", "channel": "whatsapp", "message": "string" }],
+  "nurture_sequence": [{ "week": 1, "channel": "whatsapp + email", "message_type": "string", "whatsapp_message": "string", "email_subject": "string", "email_body": "string" }],
+  "test_checklist": [{ "test": "Pipeline", "steps": ["string"], "passed": null }]
+}
+```
+
+
+## Campo obrigatório: summary
+
+Sempre inclua no JSON de saída:
+```json
+"summary": "Resumo de 1-2 frases do setup do CRM: número de etapas do pipeline e réguas configuradas. Seja específico — mencione o cliente, números reais e a conclusão principal."
+```
+
+Este campo alimenta o Resumo Executivo do portal de entregas. Deve ser objetivo, com dados reais, sem genéricos.

--- a/.agents/skills/account-crm-setup/references/guia-kommo-setup.md
+++ b/.agents/skills/account-crm-setup/references/guia-kommo-setup.md
@@ -1,0 +1,290 @@
+# Guia de Setup Kommo CRM — Pipeline + Automações para PMEs
+
+Referência técnica para configurar o Kommo CRM como padrão V4 Company. Cobre pipeline, campos customizados, Salesbot e integrações.
+
+---
+
+## 1. Visão Geral do Kommo
+
+O Kommo (ex-amoCRM) é o CRM padrão da V4 Company para clientes PME. Pontos fortes:
+- Integração nativa com WhatsApp Business
+- Salesbot visual (automação sem código)
+- Pipeline visual estilo Kanban
+- Integração com Meta Lead Ads e Google Ads
+
+### Acesso e contas
+- URL: https://www.kommo.com
+- Plano recomendado: Avançado (Salesbot ilimitados)
+- 1 conta por cliente, gerenciada pelo consultor V4
+- WhatsApp Business conectado via integração oficial
+
+---
+
+## 2. Configuração do Pipeline
+
+### Pipeline padrão V4 (adaptar por cliente)
+
+```
+Lead Novo → Em Qualificação → Qualificado → Proposta Enviada → Em Negociação → Fechado-Ganho
+                                                                                → Fechado-Perdido
+```
+
+### Variações comuns por segmento
+
+**Serviços (clínica, escritório, consultoria):**
+```
+Agendamento Solicitado → Consulta Marcada → Proposta Apresentada → Em Decisão → Fechado
+```
+
+**E-commerce com vendedor (high-ticket):**
+```
+Lead → Contato Inicial → Demonstração → Proposta → Negociação → Venda
+```
+
+**Restaurante/Delivery:**
+```
+Contato → Primeiro Pedido → Cliente Recorrente → VIP
+```
+
+### Como criar no Kommo
+
+1. Acesse **Leads** no menu lateral
+2. Clique no ícone de engrenagem do pipeline
+3. Renomeie as etapas existentes clicando no nome
+4. Para adicionar etapa: clique em "+" entre etapas
+5. Para remover: arraste a etapa para a lixeira
+6. **Importante:** Configure "Fechado-Perdido" com campo obrigatório de motivo
+
+---
+
+## 3. Campos Customizados
+
+### Campos obrigatórios para todos os clientes
+
+| Campo | Tipo | Opções | Onde |
+|-------|------|--------|------|
+| Origem | Lista | Meta Ads, Google Ads, Indicação, Orgânico, Site, WhatsApp, Outro | Lead |
+| Score SDR | Lista | 1★, 2★, 3★, 4★, 5★ | Lead |
+| Produto de interesse | Lista | [do briefing] | Lead |
+| Temperatura | Lista | Frio, Morno, Quente | Lead |
+| Motivo de perda | Texto | — | Lead (obrigatório em Fechado-Perdido) |
+
+### Como criar campos customizados
+
+1. Acesse **Configurações** > **Campos**
+2. Clique em **Criar campo**
+3. Selecione tipo (lista, texto, número, etc.)
+4. Preencha as opções
+5. Marque "Obrigatório" se necessário (ex: Motivo de perda)
+
+### Critérios de Score SDR
+
+| Score | Critério | Ação recomendada |
+|-------|----------|------------------|
+| 1★ | Curiosidade passiva, sem urgência, budget baixo | Régua de nutrição |
+| 2★ | Interesse demonstrado, mas sem urgência clara | Régua de nutrição |
+| 3★ | Tem o problema, budget indefinido, prazo indefinido | Follow-up manual em 7 dias |
+| 4★ | Tem problema + budget + prazo definido | Contato imediato do vendedor |
+| 5★ | Pronto para comprar, budget confirmado, urgência alta | Prioridade máxima, atender em minutos |
+
+---
+
+## 4. Salesbot — Régua de Boas-Vindas
+
+### Anatomia do Salesbot
+
+```
+TRIGGER (quando dispara)
+  └── CONDIÇÃO (se X, então)
+       └── AÇÃO (enviar mensagem, mover lead, etc.)
+            └── WAIT (esperar X tempo)
+                 └── CONDIÇÃO (verificar resposta)
+                      └── AÇÃO (próximo passo)
+```
+
+### Configuração passo a passo
+
+**1. Criar novo Salesbot:**
+- Acesse **Salesbot** no menu lateral
+- Clique **Criar novo bot**
+- Nomeie: "Boas-Vindas - [Nome do Cliente]"
+
+**2. Configurar trigger:**
+- Tipo: "Quando um novo lead é criado"
+- Condição adicional: Origem = Meta Ads OU Google Ads OU Site
+- (Isso evita disparar para leads de indicação/orgânico que já estão em contato)
+
+**3. Fluxo do Salesbot:**
+
+```
+[Trigger: Novo lead criado]
+  │
+  ├── [Enviar Mensagem 1 via WhatsApp]
+  │     "Olá {nome}! Recebi seu interesse em [produto].
+  │      Sou [nome], consultor(a) da [empresa].
+  │      Em até 2h vou te enviar mais detalhes. 😊"
+  │
+  ├── [Wait: 24 horas]
+  │
+  ├── [Condição: Lead respondeu?]
+  │     ├── SIM → [Mover para "Em Qualificação"] → [Notificar vendedor]
+  │     └── NÃO → [Enviar Mensagem 2]
+  │                  "Oi {nome}! Passando pra compartilhar algo
+  │                   que pode te ajudar: [conteúdo de valor].
+  │                   Quer que eu explique como funciona?"
+  │
+  ├── [Wait: 48 horas]
+  │
+  ├── [Condição: Lead respondeu?]
+  │     ├── SIM → [Mover para "Em Qualificação"]
+  │     └── NÃO → [Enviar Mensagem 3]
+  │                  "Oi {nome}, última mensagem!
+  │                   Se [resultado] é algo que te interessa,
+  │                   é só responder aqui. Se não for o momento,
+  │                   sem problema — fico por aqui se precisar. 👋"
+  │
+  └── [Após Mensagem 3: Mover para "Lead Frio"] → [Entrar na régua de nutrição]
+```
+
+**4. Variáveis disponíveis no Salesbot:**
+- `{nome}` — nome do lead
+- `{empresa}` — empresa do lead (se preenchido)
+- `{email}` — email do lead
+- `{telefone}` — telefone do lead
+- Campos customizados via `{campo_customizado}`
+
+---
+
+## 5. Salesbot — Régua de Nutrição
+
+### Trigger
+- Lead com score 1-3★
+- Parado na mesma etapa há 7+ dias
+- Não respondeu régua de boas-vindas
+
+### Fluxo
+
+```
+[Trigger: Lead frio parado 7+ dias]
+  │
+  ├── [Semana 1: Conteúdo de Valor]
+  │     WhatsApp: dica prática, dado de mercado
+  │     Email: mini-guia ou artigo
+  │
+  ├── [Wait: 7 dias]
+  │
+  ├── [Semana 2: Caso de Sucesso]
+  │     WhatsApp: história curta de resultado
+  │     Email: case study resumido
+  │
+  ├── [Wait: 7 dias]
+  │
+  ├── [Semana 3: Diferencial]
+  │     WhatsApp: o que diferencia o produto/serviço
+  │
+  ├── [Wait: 7 dias]
+  │
+  ├── [Semana 4: Oferta/CTA]
+  │     WhatsApp: oferta direta ou convite
+  │     Email: oferta com CTA claro
+  │
+  └── [Condição: Respondeu em algum momento?]
+        ├── SIM → [Mover para "Em Qualificação"]
+        └── NÃO → [Mover para "Descartado"] + [Tag: "Nutrição concluída sem resposta"]
+```
+
+---
+
+## 6. Integrações Essenciais
+
+### WhatsApp Business
+
+1. Acesse **Integrações** > procure "WhatsApp"
+2. Existem 2 opções:
+   - **WhatsApp Business API** (via provedor como Gupshup, 360dialog): melhor para volume alto, custa mensalidade
+   - **WhatsApp Web** (via extensão): gratuito, funciona para volume baixo
+3. Para maioria dos clientes PME: WhatsApp Web é suficiente no início
+4. Configure para que mensagens recebidas criem leads automaticamente
+
+### Meta Lead Ads
+
+1. Acesse **Integrações** > procure "Facebook"
+2. Conecte a conta de anúncios do cliente
+3. Mapeie os campos do formulário de lead para os campos do Kommo:
+   - Nome → Nome do lead
+   - Email → Email
+   - Telefone → Telefone
+   - Campo customizado → Tag de produto de interesse
+4. Configure para criar lead automaticamente na etapa "Lead Novo"
+5. Tag automática: "Origem: Meta Ads"
+
+### Google Ads
+
+1. Use integração via Make/Zapier (não há integração nativa direta)
+2. Trigger: Google Ads Lead Form submission
+3. Ação: Criar lead no Kommo
+4. Mapeamento de campos similar ao Meta
+
+---
+
+## 7. Boas Práticas para Mensagens de WhatsApp
+
+### Formatação Kommo WhatsApp
+- **Negrito:** `*texto*`
+- **Itálico:** `_texto_`
+- **Riscado:** `~texto~`
+- **Monoespaçado:** `` ```texto``` ``
+- **Links:** Cole direto (WhatsApp gera preview)
+- **Emojis:** Funcionam normalmente
+
+### Regras de mensagem
+- Máximo 3 frases por mensagem (WhatsApp não é email)
+- Sempre personalize com nome: `{nome}`
+- Horário de envio: 9h-18h dias úteis (respeitar horário comercial)
+- Não enviar mais de 1 mensagem por dia (exceto se o lead responder)
+- Linguagem coloquial-profissional (WhatsApp é informal)
+- CTA claro em cada mensagem (o que a pessoa deve fazer)
+
+### Templates que funcionam
+
+**Boas-vindas:**
+```
+Oi {nome}! 😊
+
+Recebi seu contato sobre [produto/serviço]. Que bom que nos procurou!
+
+Nos próximos minutos, [vendedor] vai entrar em contato pra entender melhor o que você precisa. Até já!
+```
+
+**Follow-up leve:**
+```
+Oi {nome}! Passando pra compartilhar algo rápido:
+
+[Dica/dado relevante em 1-2 frases]
+
+Se quiser saber como aplicar isso no seu [negócio/caso], é só responder aqui. 👇
+```
+
+**Última tentativa:**
+```
+Oi {nome}! Última mensagem, prometo 😄
+
+Se [resultado/benefício] é algo que te interessa, me responde "quero" que eu explico como funciona.
+
+Se não for o momento, sem problema — fico por aqui se precisar!
+```
+
+---
+
+## 8. Checklist de Configuração Completa
+
+- [ ] Pipeline criado com etapas personalizadas
+- [ ] Fechado-Perdido com motivo obrigatório
+- [ ] Campos customizados criados (Origem, Score, Produto, Temperatura)
+- [ ] WhatsApp conectado e testado
+- [ ] Salesbot de boas-vindas configurado e ativo
+- [ ] Salesbot de nutrição configurado e ativo
+- [ ] Integração Meta Lead Ads (se usar Meta)
+- [ ] Integração Google Ads via Make/Zapier (se usar Google)
+- [ ] Teste completo com lead fictício
+- [ ] Vendedor treinado no uso do pipeline

--- a/.agents/skills/account-crm-setup/schema.json
+++ b/.agents/skills/account-crm-setup/schema.json
@@ -1,0 +1,290 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "CRM Setup",
+  "description": "Output estruturado da configuração de CRM Kommo: pipeline, tags, réguas de automação e checklist de teste.",
+  "type": "object",
+  "required": [
+    "summary",
+    "pipeline_stages",
+    "tags",
+    "welcome_sequence",
+    "nurture_sequence",
+    "test_checklist",
+    "client_name",
+    "summary_headline",
+    "summary_highlights",
+    "summary_key_findings"
+  ],
+  "properties": {
+    "client_name": {
+      "type": "string",
+      "description": "Nome do cliente — sempre presente em todo output."
+    },
+    "summary": {
+      "type": "string",
+      "description": "Resumo de 1-2 frases do setup do CRM. Inclui número de etapas do pipeline e réguas configuradas."
+    },
+    "summary_headline": {
+      "type": "string",
+      "description": "Manchete em 1 linha (~120 caracteres) com o veredito da skill."
+    },
+    "summary_highlights": {
+      "type": "array",
+      "description": "KPIs em destaque (4-6 itens). Categorias: posicao | competicao | janela | maturidade | oportunidade | risco.",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "label",
+          "value",
+          "tone"
+        ],
+        "properties": {
+          "category": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "subtext": {
+            "type": "string"
+          },
+          "tone": {
+            "type": "string",
+            "enum": [
+              "green",
+              "yellow",
+              "red",
+              "blue",
+              "gray"
+            ]
+          }
+        }
+      }
+    },
+    "summary_key_findings": {
+      "type": "array",
+      "description": "3-5 achados categorizados (vantagem | contexto | ameaca | acao).",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "text"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "vantagem",
+              "contexto",
+              "ameaca",
+              "acao"
+            ]
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "pipeline_stages": {
+      "type": "array",
+      "description": "Etapas do pipeline de vendas no Kommo.",
+      "minItems": 4,
+      "items": {
+        "type": "object",
+        "required": [
+          "order",
+          "name",
+          "description"
+        ],
+        "properties": {
+          "order": {
+            "type": "integer",
+            "description": "Ordem da etapa no pipeline"
+          },
+          "name": {
+            "type": "string",
+            "description": "Nome da etapa (ex: 'Lead', 'Qualificado')"
+          },
+          "description": {
+            "type": "string",
+            "description": "O que significa estar nesta etapa"
+          },
+          "auto_actions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Ações automáticas disparadas nesta etapa"
+          }
+        }
+      }
+    },
+    "tags": {
+      "type": "object",
+      "required": [
+        "origin",
+        "score",
+        "products",
+        "temperature"
+      ],
+      "properties": {
+        "origin": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Tags de origem do lead"
+        },
+        "score": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Níveis de score SDR"
+        },
+        "products": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Produtos/serviços de interesse"
+        },
+        "temperature": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Temperatura do lead"
+        }
+      }
+    },
+    "welcome_sequence": {
+      "type": "array",
+      "description": "Régua de boas-vindas com 3 mensagens automáticas.",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "order",
+          "timing",
+          "channel",
+          "message"
+        ],
+        "properties": {
+          "order": {
+            "type": "integer",
+            "description": "Ordem da mensagem na sequência"
+          },
+          "timing": {
+            "type": "string",
+            "description": "Quando disparar (ex: 'imediata', '24h_sem_resposta')"
+          },
+          "channel": {
+            "type": "string",
+            "enum": [
+              "whatsapp",
+              "email",
+              "whatsapp + email"
+            ],
+            "description": "Canal de envio"
+          },
+          "message": {
+            "type": "string",
+            "description": "Texto completo da mensagem"
+          }
+        }
+      }
+    },
+    "nurture_sequence": {
+      "type": "array",
+      "description": "Régua de nutrição de 30 dias com 4 touchpoints.",
+      "minItems": 4,
+      "maxItems": 4,
+      "items": {
+        "type": "object",
+        "required": [
+          "week",
+          "channel",
+          "message_type"
+        ],
+        "properties": {
+          "week": {
+            "type": "integer",
+            "description": "Semana do touchpoint (1-4)"
+          },
+          "channel": {
+            "type": "string",
+            "enum": [
+              "whatsapp",
+              "email",
+              "whatsapp + email"
+            ],
+            "description": "Canal de envio"
+          },
+          "message_type": {
+            "type": "string",
+            "enum": [
+              "conteudo_de_valor",
+              "caso_de_sucesso",
+              "diferencial_produto",
+              "oferta_cta"
+            ],
+            "description": "Tipo de conteúdo do touchpoint"
+          },
+          "whatsapp_message": {
+            "type": "string",
+            "description": "Texto da mensagem WhatsApp"
+          },
+          "email_subject": {
+            "type": "string",
+            "description": "Assunto do email (quando aplicável)"
+          },
+          "email_body": {
+            "type": "string",
+            "description": "Corpo do email (quando aplicável)"
+          }
+        }
+      }
+    },
+    "test_checklist": {
+      "type": "array",
+      "description": "Checklist de testes para validar a configuração.",
+      "minItems": 5,
+      "items": {
+        "type": "object",
+        "required": [
+          "test",
+          "steps"
+        ],
+        "properties": {
+          "test": {
+            "type": "string",
+            "description": "Nome do teste"
+          },
+          "steps": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Passos do teste"
+          },
+          "passed": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "Se o teste passou (preenchido pelo operador)"
+          }
+        }
+      }
+    }
+  }
+}

--- a/.agents/skills/account-diagnostico-comercial/SKILL.md
+++ b/.agents/skills/account-diagnostico-comercial/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: account-diagnostico-comercial
+description: "Diagnostico comercial e etapas do funil (Inside Sales): funil mensal + funil estendido, estrutura do time, gargalo primario, mapa de objecoes, criterios de qualificacao 1-5 estrelas e SLA por score. Use quando o operador disser 'diagnostico comercial', 'funil de vendas', 'analise comercial', 'gargalo de vendas', ou na Semana 3 do modelo Inside Sales (POP 3.3)."
+area: account
+author: luizfreitasv4
+version: 1.0.0
+dependencies:
+  - geral-persona-icp
+outputs: ["account-diagnostico-comercial.json"]
+week: 3
+modelo_venda: inside-sales
+estimated_time: "2h"
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta versao foi portada do sistema de Estruturacao Estrategica. As regras abaixo tem precedencia sobre caminhos e persistencia citados no fluxo original:
+
+- Trabalhe somente em `squads/{squad}/clientes/{cliente}/`, nunca em um diretorio `clientes/` solto na raiz.
+- Leia primeiro o `CLAUDE.md` ou `AGENTS.md` da KB, `mission-control/`, `calls/`, `docs/` e `campanhas/`.
+- Se `client.json` existir, use-o como fonte complementar. Se nao existir, derive o contexto da KB e do Mission Control; nao exija nem invente esse arquivo.
+- Salve entregaveis em `squads/{squad}/clientes/{cliente}/outputs/`, em JSON e Markdown quando o fluxo pedir ambos.
+- Registre decisoes e progresso no `mission-control/historico-checkins.md` ou no arquivo de historico equivalente encontrado na KB.
+- Resolva recursos empacotados a partir do proprio diretorio desta skill. Se uma integracao externa nao estiver configurada, declare o gap e continue apenas com os dados reais disponiveis.
+
+
+# Diagnóstico Comercial e Etapas do Funil (POP 3.3 — Inside Sales)
+
+Voce e um consultor especializado em processos comerciais e funis de vendas para PMEs brasileiras. Vai conduzir, junto com o operador, um diagnostico completo do funil de vendas do cliente para identificar gargalos, mapear objecoes e definir os criterios de qualificacao que vao calibrar o SDR IA.
+
+> **Posição no fluxo:** Semana 3, cabeça do modelo **Inside Sales** (POP 3.3). Vem depois do CRO Site/LP (3.1) e do Cliente Oculto (3.2), e alimenta a Definição de Métricas/Critérios do Funil (3.4) e o Pipeline + Script Consultivo (3.5).
+> **IMPORTANCIA:** Os criterios de qualificacao definidos aqui sao usados diretamente nos scripts do SDR IA (cauda da Semana 3) e na configuracao do Patagon. Se os criterios estiverem errados, o SDR vai qualificar errado.
+
+## Dados necessários
+
+1. `client.json` (seção `briefing`) — NOME_CLIENTE, PRODUTO_SERVICO, TICKET_MEDIO
+2. `outputs/geral-persona-icp.json` — RESUMO_ICP, dores, comportamento de compra, objecoes
+3. `client.json` (seção `connectors`) — dados de CRM ou funil se disponíveis
+
+Antes de gerar, pergunte ao operador os dados do funil atual TUDO de uma vez:
+
+> Preciso dos dados do funil de vendas atual de {NOME_CLIENTE}. Me passe:
+> - Quantos leads/mes entram?
+> - Taxa de contato (lead → primeira conversa): X%
+> - Taxa de qualificacao (conversa → proposta): X%
+> - Taxa de fechamento (proposta → venda): X%
+> - Ticket medio real: R$
+> - Ciclo medio de venda (dias): X
+> - Quantos vendedores e perfil de cada?
+> - 5 objecoes mais comuns?
+> - Tem script ou roteiro de vendas hoje?
+>
+> Se nao tem dados exatos, estimativas servem — mas sinalize.
+
+Se o operador nao tiver algum dado, registre como "[estimativa]" ou "[nao disponivel]". NAO invente numeros.
+
+---
+
+## Geração
+
+Gere o output COMPLETO de uma vez usando os dados de `client.json` (briefing, connectors), outputs de skills dependentes, e dados do funil informados pelo operador.
+
+Consulte `references/framework-diagnostico-comercial.md` para benchmarks de conversao por segmento.
+
+### Diagnóstico do funil com taxas vs benchmarks
+
+Para cada etapa (Lead→Contato, Contato→Qualificação, Qualificação→Proposta, Proposta→Fechamento):
+- Taxa atual vs benchmark do setor
+- Gap (pontos percentuais)
+- Status: ACIMA / NO / ABAIXO / CRITICO
+- Gargalo + causa raiz + impacto financeiro estimado
+
+**Gargalo principal:** etapa, motivo, impacto se corrigido.
+
+### Funil estendido (Exposição → Retenção)
+
+Além do funil comercial clássico, mapeie o funil estendido para revelar perdas fora do "miolo" de vendas:
+
+`Exposição → Lead → Contato → Qualificação → Proposta → Fechamento → Onboarding → Retenção/Recompra`
+
+- Para cada etapa: taxa/tempo médio (quando houver dado) e onde o lead **vaza**.
+- Marque as etapas sem instrumentação (sem dado) como `null` + motivo — a ausência de medição já é um achado.
+
+### Estrutura do time comercial
+
+O pipeline tem que caber no time real. Mapeie:
+- **Papéis e quantidade** (SDR, closer, híbrido), **tenure** médio, **capacidade** (leads/vendedor/dia)
+- **Ferramentas e rituais** atuais (CRM, cadência, reuniões de pipeline)
+- **Lacunas** entre a capacidade atual e o volume de leads — isso calibra o SLA e o que dá pra automatizar com o SDR IA.
+
+Estruture em `sales_team_structure`: `{roles:[{role, count, tenure, capacity_note}], tools:[], rituals:[], gaps:[]}`.
+
+### Mapa de objeções
+
+Para CADA objeção (das informadas pelo operador + do ICP):
+- Objeção exata
+- Tipo: PRECO / URGENCIA / AUTORIDADE / CONFIANCA / NECESSIDADE / CONCORRENTE
+- Momento no funil
+- Frequência: ALTA / MEDIA / BAIXA
+- Resposta recomendada (vendedor humano)
+- Prevenção pelo SDR IA
+- Exemplo de conversa (lead + SDR)
+
+**Padrão identificado:** tipo mais frequente, momento mais crítico, objeção que mais mata vendas, recomendação principal.
+
+### Critérios de qualificação 1-5 estrelas
+
+Para cada nível:
+- **5★ (Lead Quente):** perfil + 4 sinais obrigatórios (TODOS presentes) + ação: encaminhar IMEDIATAMENTE
+- **4★ (Qualificado):** perfil + sinais (pelo menos 3/4) + ação: encaminhar em Xh
+- **3★ (Morno):** perfil + sinais (pelo menos 2/4) + ação: régua de nutrição
+- **1-2★ (Frio):** perfil + sinais de desqualificação (qualquer um) + ação: nutrição passiva ou descarte
+
+Com exemplos de lead típico para cada nível e regra de ouro para dúvidas.
+
+### SLA de atendimento por score
+
+- Lead 5★: responder em X MINUTOS, vendedor sênior, WhatsApp direto
+- Lead 4★: responder em X HORAS, vendedor designado
+- Lead 3★: régua automática em Xh, SDR IA/automático
+- Lead 1-2★: descarte gentil ou nutrição passiva
+- Alerta crítico se SLA não cumprido → escalar para responsável
+
+### Plano de ação comercial (5 ações priorizadas)
+
+Para cada: ação específica, responsável, prazo, métrica de sucesso, impacto esperado.
+
+## Auto-validação
+
+Antes de mostrar ao operador, verifique:
+
+- [ ] Mencionou o cliente pelo nome?
+- [ ] Usou dados reais do client.json (não inventou)?
+- [ ] Nenhum item genérico (ex: "quer crescer", "qualidade e compromisso")?
+- [ ] Schema da skill validou?
+- [ ] Todos os campos do schema preenchidos (ou com `null` + `unavailable_reason` no pai)?
+- [ ] Nenhuma string vazia (`""`) — substituí por `null` + reason quando o dado não existe?
+- [ ] Estimativas marcadas com `estimated: true` ou `[E]`?
+- [ ] Consistente com outputs anteriores (ICP)?
+- [ ] Benchmarks são do segmento correto?
+- [ ] Critérios de qualificação são mensuráveis (não vagos)?
+- [ ] SLA é realista para capacidade do time?
+
+Se falhou → regenere silenciosamente. Não avise o operador.
+
+## Apresentação e decisões
+
+Apresente o output COMPLETO ao operador.
+
+Revise o output. O que está errado, exagerado ou faltando?
+
+- "O diagnostico faz sentido com o que voce observa no dia a dia?"
+- "O gargalo principal confere com a percepcao do time de vendas?"
+- "As respostas para objecoes fazem sentido para o tom do cliente?"
+- "Os criterios de qualificacao refletem o que diferencia um lead bom de ruim?"
+- "O SLA e realista para a capacidade do time? O cliente consegue responder em X minutos para 5★?"
+- "As acoes do plano sao factiveis com os recursos atuais?"
+
+## Finalização
+
+Operador aprova (com ou sem ajustes).
+1. Salve em `squads/{squad}/clientes/{cliente}/outputs/account-diagnostico-comercial.json` (com campo `summary` no topo)
+2. Atualize `client.json`: progress.skills → completed, version++, append em history[]
+3. Salve também uma versão Markdown do entregável na mesma pasta de outputs.
+4. Sugira a próxima skill com base nas dependências do frontmatter e no estado da KB
+   - "Diagnostico comercial salvo. Alimenta: etapa de métricas do funil (ainda não portada) (3.4), etapa de pipeline comercial (ainda não portada) (3.5) e os scripts do SDR IA (cauda)."
+   - Sugira: `etapa de métricas do funil (ainda não portada)` (formalizar MQL/SQL/SAL + scoring determinístico).

--- a/.agents/skills/account-diagnostico-comercial/references/framework-diagnostico-comercial.md
+++ b/.agents/skills/account-diagnostico-comercial/references/framework-diagnostico-comercial.md
@@ -1,0 +1,207 @@
+# Framework de Diagnostico Comercial para PMEs Brasileiras
+
+## Benchmarks de Conversao por Segmento
+
+Os benchmarks abaixo sao baseados em dados agregados de PMEs brasileiras atendidas em programas de aceleracao comercial, pesquisas do SEBRAE, RD Station e Resultados Digitais. Use como referencia — ajuste conforme a realidade do segmento e regiao do cliente.
+
+### Servicos Profissionais (Consultorias, Contabilidade, Advocacia, TI)
+| Etapa | Benchmark (mediana) | Faixa aceitavel | Sinal de alerta |
+|-------|---------------------|-----------------|-----------------|
+| Lead → Primeiro Contato | 60-70% | 50-80% | < 45% |
+| Primeiro Contato → Qualificacao | 40-50% | 30-60% | < 25% |
+| Qualificacao → Proposta | 50-65% | 40-70% | < 35% |
+| Proposta → Fechamento | 25-35% | 20-45% | < 15% |
+| **Conversao geral (lead → venda)** | **3-8%** | **2-12%** | **< 1.5%** |
+| Ciclo medio de venda | 15-30 dias | 7-60 dias | > 90 dias |
+
+### E-commerce / Varejo Online
+| Etapa | Benchmark (mediana) | Faixa aceitavel | Sinal de alerta |
+|-------|---------------------|-----------------|-----------------|
+| Visitante → Lead (formulario/WhatsApp) | 2-5% | 1-8% | < 0.8% |
+| Lead → Primeiro Contato | 70-85% | 60-90% | < 50% |
+| Primeiro Contato → Qualificacao | 30-40% | 20-50% | < 15% |
+| Qualificacao → Venda | 15-25% | 10-35% | < 8% |
+| **Conversao geral (lead → venda)** | **3-8%** | **2-12%** | **< 1%** |
+| Ciclo medio de venda | 1-7 dias | mesmo dia-14 dias | > 21 dias |
+
+### Saude e Estetica (Clinicas, Dentistas, Personal Trainers)
+| Etapa | Benchmark (mediana) | Faixa aceitavel | Sinal de alerta |
+|-------|---------------------|-----------------|-----------------|
+| Lead → Primeiro Contato | 65-80% | 55-90% | < 50% |
+| Primeiro Contato → Agendamento | 35-50% | 25-60% | < 20% |
+| Agendamento → Comparecimento | 70-85% | 60-90% | < 55% |
+| Comparecimento → Fechamento | 40-60% | 30-70% | < 25% |
+| **Conversao geral (lead → venda)** | **6-15%** | **4-20%** | **< 3%** |
+| Ciclo medio de venda | 3-14 dias | 1-30 dias | > 45 dias |
+
+### Educacao (Cursos, Escolas, Treinamentos)
+| Etapa | Benchmark (mediana) | Faixa aceitavel | Sinal de alerta |
+|-------|---------------------|-----------------|-----------------|
+| Lead → Primeiro Contato | 55-70% | 45-80% | < 40% |
+| Primeiro Contato → Qualificacao | 35-45% | 25-55% | < 20% |
+| Qualificacao → Proposta/Matricula | 40-55% | 30-65% | < 25% |
+| Proposta → Fechamento | 30-45% | 20-55% | < 15% |
+| **Conversao geral (lead → venda)** | **2-8%** | **1.5-12%** | **< 1%** |
+| Ciclo medio de venda | 7-30 dias | 3-60 dias | > 90 dias |
+
+### Imobiliario (Construtoras, Imobiliarias, Corretores)
+| Etapa | Benchmark (mediana) | Faixa aceitavel | Sinal de alerta |
+|-------|---------------------|-----------------|-----------------|
+| Lead → Primeiro Contato | 50-65% | 40-75% | < 35% |
+| Primeiro Contato → Visita | 20-30% | 15-40% | < 10% |
+| Visita → Proposta | 30-45% | 20-55% | < 15% |
+| Proposta → Fechamento | 15-25% | 10-35% | < 8% |
+| **Conversao geral (lead → venda)** | **0.5-3%** | **0.3-5%** | **< 0.2%** |
+| Ciclo medio de venda | 30-90 dias | 15-180 dias | > 240 dias |
+
+### Alimentacao (Restaurantes, Delivery, Food Service)
+| Etapa | Benchmark (mediana) | Faixa aceitavel | Sinal de alerta |
+|-------|---------------------|-----------------|-----------------|
+| Lead → Primeiro Contato | 75-90% | 65-95% | < 60% |
+| Primeiro Contato → Pedido/Reserva | 40-55% | 30-65% | < 25% |
+| Pedido → Recompra (30 dias) | 25-40% | 15-50% | < 10% |
+| **Conversao geral (lead → primeira compra)** | **20-40%** | **15-50%** | **< 10%** |
+| Ciclo medio de venda | mesmo dia-3 dias | mesmo dia-7 dias | > 14 dias |
+
+### SaaS / Tecnologia B2B
+| Etapa | Benchmark (mediana) | Faixa aceitavel | Sinal de alerta |
+|-------|---------------------|-----------------|-----------------|
+| Lead → MQL | 15-25% | 10-35% | < 8% |
+| MQL → SQL (SDR qualifica) | 30-40% | 20-50% | < 15% |
+| SQL → Demo/Trial | 50-65% | 40-75% | < 35% |
+| Demo → Proposta | 40-55% | 30-65% | < 25% |
+| Proposta → Fechamento | 20-30% | 15-40% | < 12% |
+| **Conversao geral (lead → venda)** | **1-3%** | **0.5-5%** | **< 0.3%** |
+| Ciclo medio de venda | 30-60 dias | 14-120 dias | > 180 dias |
+
+### Servicos Gerais (Dedetizacao, Limpeza, Manutencao, Reformas)
+| Etapa | Benchmark (mediana) | Faixa aceitavel | Sinal de alerta |
+|-------|---------------------|-----------------|-----------------|
+| Lead → Primeiro Contato | 70-85% | 60-90% | < 55% |
+| Primeiro Contato → Orcamento | 45-60% | 35-70% | < 30% |
+| Orcamento → Fechamento | 25-40% | 15-50% | < 12% |
+| **Conversao geral (lead → venda)** | **8-18%** | **5-25%** | **< 4%** |
+| Ciclo medio de venda | 1-7 dias | mesmo dia-14 dias | > 21 dias |
+
+---
+
+## Segmentos Nao Listados
+
+Se o segmento do cliente nao esta acima, use os seguintes benchmarks genericos para PMEs brasileiras e ajuste:
+
+| Etapa | Benchmark generico PME Brasil |
+|-------|-------------------------------|
+| Lead → Primeiro Contato | 60-75% |
+| Primeiro Contato → Qualificacao | 30-45% |
+| Qualificacao → Proposta | 40-55% |
+| Proposta → Fechamento | 20-35% |
+| **Conversao geral** | **3-8%** |
+
+---
+
+## Como Interpretar os Gaps
+
+### Status por gap
+
+| Gap vs benchmark | Status | Acao recomendada |
+|------------------|--------|------------------|
+| +5pp ou mais | Acima do benchmark | Manter e otimizar |
+| -5pp a +5pp | No benchmark | Monitorar, buscar melhoria incremental |
+| -5pp a -15pp | Abaixo do benchmark | Investigar causa raiz, plano de acao |
+| -15pp ou mais | Critico | Acao urgente, prioridade 1 |
+
+### Como calcular impacto financeiro
+
+Formula por etapa:
+```
+Leads perdidos = Volume da etapa x (Benchmark - Taxa atual) / 100
+Receita perdida = Leads perdidos x Taxa conversao restante x Ticket medio
+```
+
+Exemplo:
+- 100 leads/mes, taxa contato atual 45%, benchmark 65%
+- Leads perdidos: 100 x (65-45)/100 = 20 leads
+- Se a conversao restante (contato→venda) e 12% e ticket medio R$2.000
+- Receita perdida: 20 x 0.12 x 2.000 = R$4.800/mes
+
+---
+
+## Classificacao de Objecoes (Taxonomia)
+
+### Tipos de objecao
+
+| Tipo | Descricao | Sinal tipico | Abordagem recomendada |
+|------|-----------|--------------|----------------------|
+| **Preco** | "Ta caro", "Nao tenho orcamento", "O concorrente e mais barato" | Questionamento sobre valores antes de entender a proposta | Demonstrar ROI, comparar custo da inacao, parcelar |
+| **Urgencia** | "Agora nao e o momento", "Vou pensar", "Me liga mes que vem" | Adiamento sem motivo concreto | Criar senso de urgencia real (escassez, sazonalidade, custo de esperar) |
+| **Autoridade** | "Preciso falar com meu socio/esposa", "Quem decide e o diretor" | Envolver terceiro no final do processo | Identificar decisor cedo, pedir para incluir na proxima conversa |
+| **Confianca** | "Nao conheco voces", "Como sei que funciona?", "Tem garantia?" | Ceticismo sobre capacidade/resultado | Cases, depoimentos, garantia, prova social, trial |
+| **Necessidade** | "Nao preciso disso agora", "Ja tenho algo parecido" | Nao reconhece o problema como prioritario | Aprofundar nas dores, mostrar custo da inacao, comparar com alternativa atual |
+| **Concorrente** | "Estou vendo com a empresa X", "Ja uso o concorrente Y" | Comparacao direta com alternativa | Diferenciar sem depreciar, focar no que so voce oferece |
+
+### Momento no funil
+
+| Momento | Objecoes tipicas | Estrategia |
+|---------|------------------|-----------|
+| Primeiro Contato | Necessidade, Confianca | Gerar interesse, nao vender ainda |
+| Qualificacao | Urgencia, Autoridade | Validar timing e decisor |
+| Proposta | Preco, Concorrente | Demonstrar valor e diferenciacao |
+| Negociacao | Preco, Urgencia | Fechar com condicao especial ou prazo |
+
+---
+
+## SLA Recomendado por Tipo de Negocio
+
+### Negocios de ciclo curto (< 7 dias: varejo, alimentacao, servicos)
+| Score | SLA | Justificativa |
+|-------|-----|---------------|
+| 5 estrelas | 5 minutos | Lead quente esfria em minutos |
+| 4 estrelas | 1 hora | Ainda esta comparando, precisa ser rapido |
+| 3 estrelas | 4 horas | Regua automatica suficiente |
+
+### Negocios de ciclo medio (7-30 dias: saude, educacao, servicos profissionais)
+| Score | SLA | Justificativa |
+|-------|-----|---------------|
+| 5 estrelas | 15 minutos | Demonstra profissionalismo e urgencia |
+| 4 estrelas | 2 horas | Mesmo turno, preferencialmente |
+| 3 estrelas | 12 horas | Regua automatica com conteudo de valor |
+
+### Negocios de ciclo longo (> 30 dias: imobiliario, SaaS, B2B)
+| Score | SLA | Justificativa |
+|-------|-----|---------------|
+| 5 estrelas | 30 minutos | Rapido, mas o processo e mais consultivo |
+| 4 estrelas | 4 horas | Mesmo dia, com abordagem personalizada |
+| 3 estrelas | 24 horas | Nutricao com conteudo educativo |
+
+---
+
+## Perguntas de Diagnostico para o Operador
+
+Use estas perguntas para extrair dados quando o cliente nao tem metricas formais:
+
+### Volume
+- Quantos leads novos entram por mes (WhatsApp, formulario, telefone, indicacao)?
+- De onde vem a maioria? (trafego pago, organico, indicacao, Google)
+- Esse volume e estavel ou varia muito?
+
+### Processo
+- Quando chega um lead, quem responde? Em quanto tempo (real, nao ideal)?
+- Existe script ou roteiro? Ou cada vendedor faz do seu jeito?
+- Como decidem se um lead e bom ou ruim?
+- Usam CRM ou planilha? Ou nada?
+
+### Conversao
+- De cada 10 leads que entram, quantos viram cliente? (estimativa grosseira serve)
+- Qual a maior dificuldade: conseguir leads, conseguir responder rapido, ou conseguir fechar?
+- Qual o ultimo lead bom que fechou? O que tinha de diferente?
+- Qual o ultimo lead bom que perdeu? O que aconteceu?
+
+### Objecoes
+- Qual a frase que mais ouvem quando perdem uma venda?
+- O preco e o principal problema ou e outra coisa?
+- Quando o lead some (ghosting), em que momento da conversa geralmente acontece?
+
+### Time
+- Quantas pessoas vendem?
+- Existe alguem que vende muito mais que os outros? O que essa pessoa faz de diferente?
+- O time tem meta? Bate?

--- a/.agents/skills/account-diagnostico-comercial/schema.json
+++ b/.agents/skills/account-diagnostico-comercial/schema.json
@@ -1,0 +1,554 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DiagnosticoComercial",
+  "description": "Output estruturado da skill diagnostico-comercial: diagnostico do funil de vendas com benchmarks, mapa de objecoes, criterios de qualificacao e SLA.",
+  "type": "object",
+  "required": [
+    "summary",
+    "funnel_diagnosis",
+    "objection_map",
+    "qualification_criteria",
+    "sla",
+    "action_plan",
+    "client_name",
+    "summary_headline",
+    "summary_highlights",
+    "summary_key_findings"
+  ],
+  "properties": {
+    "client_name": {
+      "type": "string",
+      "description": "Nome do cliente — sempre presente em todo output."
+    },
+    "summary": {
+      "type": "string",
+      "description": "Resumo executivo de 2-3 frases do diagnostico. Inclui gargalo principal, criterio 5 estrelas resumido e SLA de 5 estrelas."
+    },
+    "summary_headline": {
+      "type": "string",
+      "description": "Manchete em 1 linha (~120 caracteres) com o veredito da skill."
+    },
+    "summary_highlights": {
+      "type": "array",
+      "description": "KPIs em destaque (4-6 itens). Categorias: posicao | competicao | janela | maturidade | oportunidade | risco.",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "label",
+          "value",
+          "tone"
+        ],
+        "properties": {
+          "category": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "subtext": {
+            "type": "string"
+          },
+          "tone": {
+            "type": "string",
+            "enum": [
+              "green",
+              "yellow",
+              "red",
+              "blue",
+              "gray"
+            ]
+          }
+        }
+      }
+    },
+    "summary_key_findings": {
+      "type": "array",
+      "description": "3-5 achados categorizados (vantagem | contexto | ameaca | acao).",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "text"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "vantagem",
+              "contexto",
+              "ameaca",
+              "acao"
+            ]
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "funnel_diagnosis": {
+      "type": "array",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "stage",
+          "current_rate",
+          "benchmark",
+          "bottleneck",
+          "root_cause"
+        ],
+        "properties": {
+          "stage": {
+            "type": "string",
+            "description": "Nome da etapa do funil (ex: 'Lead para Primeiro Contato', 'Qualificacao para Proposta')."
+          },
+          "current_rate": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 100,
+            "description": "Taxa de conversao atual em percentual."
+          },
+          "benchmark": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 100,
+            "description": "Taxa de conversao benchmark do setor em percentual."
+          },
+          "gap": {
+            "type": "number",
+            "description": "Diferenca entre a taxa atual e o benchmark (positivo = acima, negativo = abaixo)."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "above_benchmark",
+              "at_benchmark",
+              "below_benchmark",
+              "critical"
+            ],
+            "description": "Classificacao do desempenho da etapa."
+          },
+          "bottleneck": {
+            "type": "string",
+            "description": "Descricao especifica do gargalo identificado nesta etapa."
+          },
+          "root_cause": {
+            "type": "string",
+            "description": "Causa raiz mais provavel do gargalo."
+          },
+          "financial_impact_monthly": {
+            "type": "number",
+            "description": "Impacto financeiro estimado em reais por mes (receita perdida)."
+          }
+        }
+      },
+      "description": "Diagnostico de cada etapa do funil com taxas de conversao vs benchmarks."
+    },
+    "funnel_extended": {
+      "type": "array",
+      "description": "Funil estendido em 6-7 etapas para visualizacao no estilo 'Destrava Receita' (R->L). Opcional. Quando presente, o portal renderiza chevrons em vez do funil tradicional.",
+      "minItems": 4,
+      "maxItems": 8,
+      "items": {
+        "type": "object",
+        "required": ["stage", "volume", "rate_label"],
+        "properties": {
+          "stage": {
+            "type": "string",
+            "description": "Nome da etapa (ex: Exposicao, Atencao, Interesse, Qualificacao, Compromisso, Decisao, Retencao)."
+          },
+          "volume": {
+            "type": "number",
+            "description": "Volume absoluto na etapa (mensal — todas as etapas devem usar o mesmo recorte)."
+          },
+          "volume_label": {
+            "type": "string",
+            "description": "Label de volume formatado (ex: '52.929/mês'). Se ausente, o renderer formata automaticamente."
+          },
+          "rate_label": {
+            "type": "string",
+            "description": "Label de taxa formatado (ex: '2,01% CTR', '24%', 'base', '100% [E]')."
+          },
+          "subtext": {
+            "type": "string",
+            "description": "Subtexto curto explicativo (fonte do dado, ressalva metodologica, etc.)."
+          },
+          "status": {
+            "type": ["string", "null"],
+            "enum": ["above_benchmark", "at_benchmark", "below_benchmark", "critical", null],
+            "description": "Status da etapa (mesma taxonomia do funnel_diagnosis). Null para etapas sem benchmark mapeado."
+          },
+          "estimated": {
+            "type": "boolean",
+            "description": "True se o valor é estimativa (renderer aplica tratamento visual diferenciado)."
+          },
+          "is_active_constraint": {
+            "type": "boolean",
+            "description": "True para a etapa que representa a 'Restrição Ativa' (gargalo principal). Apenas uma etapa deve ser true."
+          }
+        }
+      }
+    },
+    "primary_bottleneck": {
+      "type": "object",
+      "properties": {
+        "stage": {
+          "type": "string",
+          "description": "Etapa do funil onde esta o gargalo principal."
+        },
+        "description": {
+          "type": "string",
+          "description": "Descricao do gargalo principal."
+        },
+        "estimated_improvement": {
+          "type": "string",
+          "description": "Estimativa de melhoria se corrigido (ex: '+15% na conversao geral = +R$12.000/mes')."
+        }
+      }
+    },
+    "objection_map": {
+      "type": "array",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "objection",
+          "type",
+          "funnel_moment",
+          "recommended_response",
+          "sdr_prevention"
+        ],
+        "properties": {
+          "objection": {
+            "type": "string",
+            "description": "A objecao exata como o lead a expressa."
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "price",
+              "urgency",
+              "authority",
+              "trust",
+              "need",
+              "competitor"
+            ],
+            "description": "Tipo da objecao segundo classificacao BANT+."
+          },
+          "funnel_moment": {
+            "type": "string",
+            "enum": [
+              "first_contact",
+              "qualification",
+              "proposal",
+              "negotiation"
+            ],
+            "description": "Em que momento do funil a objecao tipicamente aparece."
+          },
+          "frequency": {
+            "type": "string",
+            "enum": [
+              "high",
+              "medium",
+              "low"
+            ],
+            "description": "Frequencia estimada com que essa objecao aparece."
+          },
+          "recommended_response": {
+            "type": "string",
+            "description": "Script curto de resposta recomendada para o vendedor humano (2-3 frases)."
+          },
+          "sdr_prevention": {
+            "type": "string",
+            "description": "Como o SDR IA deve abordar preventivamente para evitar que a objecao surja."
+          },
+          "example_dialogue": {
+            "type": "object",
+            "properties": {
+              "lead_says": {
+                "type": "string",
+                "description": "Frase tipica do lead ao apresentar a objecao."
+              },
+              "sdr_responds": {
+                "type": "string",
+                "description": "Resposta do SDR IA para a objecao."
+              }
+            }
+          }
+        }
+      },
+      "description": "Mapa completo de objecoes com tipo, momento, resposta e prevencao."
+    },
+    "objection_pattern": {
+      "type": "object",
+      "properties": {
+        "most_frequent_type": {
+          "type": "string",
+          "description": "Tipo de objecao mais frequente."
+        },
+        "most_critical_moment": {
+          "type": "string",
+          "description": "Momento do funil mais critico para objecoes."
+        },
+        "deal_killer_objection": {
+          "type": "string",
+          "description": "Objecao que mais mata vendas."
+        },
+        "main_recommendation": {
+          "type": "string",
+          "description": "Recomendacao principal para reduzir objecoes."
+        }
+      }
+    },
+    "qualification_criteria": {
+      "type": "object",
+      "required": [
+        "five_star",
+        "four_star",
+        "three_star",
+        "one_two_star"
+      ],
+      "properties": {
+        "five_star": {
+          "type": "object",
+          "required": [
+            "profile",
+            "mandatory_signals",
+            "action",
+            "example"
+          ],
+          "properties": {
+            "profile": {
+              "type": "string",
+              "description": "Descricao curta do perfil 5 estrelas."
+            },
+            "mandatory_signals": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Sinais obrigatorios — TODOS devem estar presentes."
+            },
+            "action": {
+              "type": "string",
+              "description": "Acao imediata ao identificar este lead."
+            },
+            "example": {
+              "type": "string",
+              "description": "Exemplo concreto de um lead 5 estrelas tipico."
+            }
+          }
+        },
+        "four_star": {
+          "type": "object",
+          "required": [
+            "profile",
+            "signals",
+            "min_signals",
+            "action",
+            "example"
+          ],
+          "properties": {
+            "profile": {
+              "type": "string",
+              "description": "Descricao curta do perfil 4 estrelas."
+            },
+            "signals": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Sinais possiveis — pelo menos min_signals devem estar presentes."
+            },
+            "min_signals": {
+              "type": "integer",
+              "description": "Quantidade minima de sinais presentes para 4 estrelas."
+            },
+            "action": {
+              "type": "string",
+              "description": "Acao ao identificar este lead."
+            },
+            "example": {
+              "type": "string",
+              "description": "Exemplo concreto de um lead 4 estrelas tipico."
+            }
+          }
+        },
+        "three_star": {
+          "type": "object",
+          "required": [
+            "profile",
+            "signals",
+            "min_signals",
+            "action",
+            "example"
+          ],
+          "properties": {
+            "profile": {
+              "type": "string",
+              "description": "Descricao curta do perfil 3 estrelas."
+            },
+            "signals": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Sinais possiveis para 3 estrelas."
+            },
+            "min_signals": {
+              "type": "integer",
+              "description": "Quantidade minima de sinais presentes para 3 estrelas."
+            },
+            "action": {
+              "type": "string",
+              "description": "Acao ao identificar este lead."
+            },
+            "example": {
+              "type": "string",
+              "description": "Exemplo concreto de um lead 3 estrelas tipico."
+            }
+          }
+        },
+        "one_two_star": {
+          "type": "object",
+          "required": [
+            "profile",
+            "disqualification_signals",
+            "action",
+            "example"
+          ],
+          "properties": {
+            "profile": {
+              "type": "string",
+              "description": "Descricao curta do perfil 1-2 estrelas."
+            },
+            "disqualification_signals": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Sinais de desqualificacao — qualquer um e suficiente."
+            },
+            "action": {
+              "type": "string",
+              "description": "Acao ao identificar este lead."
+            },
+            "example": {
+              "type": "string",
+              "description": "Exemplo concreto de um lead 1-2 estrelas tipico."
+            }
+          }
+        },
+        "tiebreaker_rules": {
+          "type": "object",
+          "properties": {
+            "three_vs_four": {
+              "type": "string",
+              "description": "Regra de desempate entre 3 e 4 estrelas."
+            },
+            "two_vs_three": {
+              "type": "string",
+              "description": "Regra de desempate entre 2 e 3 estrelas."
+            }
+          }
+        }
+      }
+    },
+    "sla": {
+      "type": "object",
+      "required": [
+        "five_star_minutes",
+        "four_star_hours",
+        "three_star_hours"
+      ],
+      "properties": {
+        "five_star_minutes": {
+          "type": "integer",
+          "description": "Tempo maximo de resposta em minutos para leads 5 estrelas."
+        },
+        "five_star_responsible": {
+          "type": "string",
+          "description": "Responsavel por atender leads 5 estrelas."
+        },
+        "five_star_channel": {
+          "type": "string",
+          "description": "Canal de contato para leads 5 estrelas."
+        },
+        "four_star_hours": {
+          "type": "number",
+          "description": "Tempo maximo de resposta em horas para leads 4 estrelas."
+        },
+        "four_star_responsible": {
+          "type": "string",
+          "description": "Responsavel por atender leads 4 estrelas."
+        },
+        "three_star_hours": {
+          "type": "number",
+          "description": "Tempo maximo para leads 3 estrelas entrarem em regua automatica (em horas)."
+        },
+        "escalation_5star_minutes": {
+          "type": "integer",
+          "description": "Tempo em minutos apos o qual escalar se lead 5 estrelas nao foi contatado."
+        },
+        "escalation_4star_hours": {
+          "type": "number",
+          "description": "Tempo em horas apos o qual escalar se lead 4 estrelas nao foi contatado."
+        },
+        "escalation_responsible": {
+          "type": "string",
+          "description": "Para quem escalar se o SLA for violado."
+        }
+      }
+    },
+    "action_plan": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 5,
+      "items": {
+        "type": "object",
+        "required": [
+          "action",
+          "responsible",
+          "timeline",
+          "measurement"
+        ],
+        "properties": {
+          "priority": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 5,
+            "description": "Prioridade da acao (1 = maior impacto)."
+          },
+          "action": {
+            "type": "string",
+            "description": "Descricao especifica da acao."
+          },
+          "responsible": {
+            "type": "string",
+            "description": "Quem e responsavel pela execucao (vendedor, SDR IA, gestor, consultor)."
+          },
+          "timeline": {
+            "type": "string",
+            "description": "Prazo realista para implementacao."
+          },
+          "measurement": {
+            "type": "string",
+            "description": "Como medir se a acao deu resultado."
+          },
+          "expected_impact": {
+            "type": "string",
+            "description": "Estimativa quantitativa do impacto esperado."
+          }
+        }
+      },
+      "description": "Plano de acao comercial com 3-5 acoes priorizadas por impacto."
+    }
+  }
+}

--- a/.agents/skills/account-sdr-ia-config/SKILL.md
+++ b/.agents/skills/account-sdr-ia-config/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: account-sdr-ia-config
+description: "Configuracao do SDR IA no Patagon + integracao Kommo: setup do agente, field mapping, alertas para vendedor e teste com 5 leads simulados. Use quando o operador disser 'configurar patagon', 'setup sdr', 'integrar kommo', 'colocar o agente no ar', ou apos copy-scripts-sdr."
+area: account
+author: luizfreitasv4
+version: 1.0.0
+dependencies:
+  - copy-scripts-sdr
+  - account-crm-setup
+outputs: ["account-sdr-ia-config.json"]
+week: 4
+estimated_time: "4h"
+semi_manual: true
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta versao foi portada do sistema de Estruturacao Estrategica. As regras abaixo tem precedencia sobre caminhos e persistencia citados no fluxo original:
+
+- Trabalhe somente em `squads/{squad}/clientes/{cliente}/`, nunca em um diretorio `clientes/` solto na raiz.
+- Leia primeiro o `CLAUDE.md` ou `AGENTS.md` da KB, `mission-control/`, `calls/`, `docs/` e `campanhas/`.
+- Se `client.json` existir, use-o como fonte complementar. Se nao existir, derive o contexto da KB e do Mission Control; nao exija nem invente esse arquivo.
+- Salve entregaveis em `squads/{squad}/clientes/{cliente}/outputs/`, em JSON e Markdown quando o fluxo pedir ambos.
+- Registre decisoes e progresso no `mission-control/historico-checkins.md` ou no arquivo de historico equivalente encontrado na KB.
+- Resolva recursos empacotados a partir do proprio diretorio desta skill. Se uma integracao externa nao estiver configurada, declare o gap e continue apenas com os dados reais disponiveis.
+
+
+# Configuracao do SDR IA (Patagon + Kommo) — POP 3.7
+
+> **Posição no fluxo:** Semana 4 — Identidade de Comunicação e Plano de Mídia (**comum** a todos os modelos) a todos os modelos. Coloca o agente do `copy-scripts-sdr` no ar, integrado ao CRM (account-crm-setup). Sobe ao vivo só após validar o scoring com leads reais.
+
+Voce e um guia tecnico para configuracao do agente SDR IA no Patagon com integracao Kommo CRM. Esta skill e SEMI-MANUAL: voce gera as instrucoes passo a passo e o operador executa no Patagon e Kommo. Apos cada etapa, o operador confirma que executou.
+
+> **IMPORTANCIA:** Esta e a skill que coloca o SDR IA no ar. Tudo das semanas anteriores converge aqui. Erro na configuração = leads mal qualificados ou alertas que não chegam.
+
+> **PRE-REQUISITOS:**
+> - WhatsApp Business do cliente conectado ao Patagon
+> - Kommo CRM configurado com pipeline (account-crm-setup)
+> - Scripts SDR aprovados pelo cliente (copy-scripts-sdr)
+> - Brandbook com tom de voz aprovado
+
+## Dados necessários
+
+1. `client.json` (seção `briefing`) — NOME_CLIENTE, PRODUTO_SERVICO
+2. `outputs/copy-scripts-sdr.json` — TODOS os scripts, perguntas, fluxos, objeções
+3. `outputs/account-diagnostico-comercial.json` — critérios 1-5 estrelas, SLA
+4. `outputs/designer-manual-marca.json` — TOM_DE_VOZ, nome do agente
+5. `outputs/account-crm-setup.json` — pipeline configurado no Kommo
+
+Se alguma dependência não estiver completa:
+
+> BLOQUEIO: A skill {NOME_SKILL} precisa estar completa antes de configurar o SDR IA.
+> Execute `/{skill}` antes de continuar.
+
+Confirme com o operador:
+
+> Vamos configurar o SDR IA de {NOME_CLIENTE}.
+> - WhatsApp Business conectado ao Patagon? [sim/nao]
+> - Kommo configurado com pipeline? [sim/nao]
+> - Scripts aprovados pelo cliente? [sim/nao]
+> - Vendedor para alertas: Nome e WhatsApp?
+>
+> Se algum item for "nao", precisamos resolver antes.
+
+---
+
+## Geração
+
+Gere o output COMPLETO de uma vez: guia de configuração Patagon + integração Kommo + alertas + teste com 5 leads. Use os dados de `client.json` (briefing) e outputs de skills dependentes em `outputs/`.
+
+Consulte `references/guia-patagon-kommo.md` para detalhes técnicos.
+
+### Configuração do agente no Patagon (passo a passo)
+
+**PASSO 1:** Criar agente (nome, descrição)
+**PASSO 2:** Configurar persona (personalidade completa, tom de voz, regras: máx 3 frases, nunca revelar IA, etc.)
+**PASSO 3:** Configurar mensagem de boas-vindas (colar mensagem aprovada)
+**PASSO 4:** Configurar perguntas de qualificação (Q1-Q5, abertas, obrigatórias)
+**PASSO 5:** Configurar regras de scoring (critérios por estrela + ação para cada score)
+**PASSO 6:** Configurar tratamento de objeções (cada objeção + resposta + genérica)
+**PASSO 7:** Configurar follow-ups (1h, 24h, 3d + máx 3)
+**PASSO 8:** Configurar handoff (mensagem de transferência + destinatário)
+**PASSO 9:** Salvar (NÃO ativar ainda — esperar testes)
+
+### Integração Patagon → Kommo
+
+**PASSO 1:** Conectar (Settings → Integrations → Kommo, API key)
+**PASSO 2:** Field mapping (nome, telefone, score, produto, UTMs, histórico, resumo)
+**PASSO 3:** Configurar pipeline destino (score 4-5★ → Qualificados, 3★ → Nutrição, 1-2★ → Frios)
+**PASSO 4:** Tags automáticas (por score e por origem/UTM)
+**PASSO 5:** Testar conexão (enviar lead teste, verificar campos e tags)
+
+### Alertas para vendedor
+
+**PASSO 1:** Definir destinatários (vendedor principal + backup)
+**PASSO 2:** Template do alerta (nome, score, interesse, resumo, link Kommo, SLA)
+**PASSO 3:** Condições de disparo (score >= 4★, qualificação concluída, dentro do horário comercial)
+**PASSO 4:** Escalamento (se vendedor não responder em X min → backup → mensagem automática ao lead)
+**PASSO 5:** Relatório diário opcional
+
+### Teste com 5 leads simulados
+
+**Lead 1 — 5★ (quente):** urgente, decisor, com budget → resultado esperado: score 5★, alerta, Kommo "Qualificado"
+**Lead 2 — 4★ (qualificado):** interessado, sem urgência → resultado esperado: score 4★, alerta
+**Lead 3 — 3★ (morno):** curioso, pesquisando → resultado esperado: score 3★, sem alerta, "Nutrição"
+**Lead 4 — 1-2★ (frio):** não é ICP → resultado esperado: score baixo, tag "Frio"
+**Lead 5 — Com objeção forte:** interessado + objeção de preço → testar tratamento
+
+**Checklist por lead:**
+- [ ] Resposta < 5 segundos
+- [ ] Boas-vindas correta
+- [ ] Qualificação na ordem
+- [ ] Score correto
+- [ ] Kommo com campos preenchidos
+- [ ] Tag correta
+- [ ] Etapa do pipeline correta
+- [ ] Alerta enviado (se 4-5★)
+- [ ] Tom consistente com brandbook
+- [ ] Nada pareceu robótico
+
+**Tabela de resultados:**
+
+| Lead | Score esperado | Score real | Kommo OK | Alerta OK | Tempo | Status |
+|------|---------------|------------|----------|-----------|-------|--------|
+
+Se houver falhas: instruções de debug (score incorreto, campo não mapeado, alerta não chegou, tom inconsistente).
+
+## Auto-validação
+
+Antes de mostrar ao operador, verifique:
+
+- [ ] Todos os scripts aprovados foram incluídos nas instruções?
+- [ ] Field mapping cobre todos os campos necessários?
+- [ ] SLA nos alertas é consistente com o diagnóstico comercial?
+- [ ] 5 cenários de teste cobrem todos os fluxos (5★, 4★, 3★, 1-2★, objeção)?
+
+Se falhou → regenere silenciosamente.
+
+## Apresentação e decisões
+
+Apresente o output COMPLETO ao operador — guia completo de configuração.
+
+O operador executa cada etapa sequencialmente no Patagon e Kommo. Após cada bloco, confirma execução:
+
+1. "Agente criado no Patagon? Alguma tela diferente?"
+2. "Integração Kommo funcionando? Lead teste chegou com campos?"
+3. "Alertas configurados? Vendedor recebeu teste?"
+4. "5 testes executados — resultados?"
+
+Se todos os testes passaram → go-live. Se houver falhas → debug e reteste.
+
+## Finalização
+
+Operador aprova (todos os testes passam).
+1. Salve em `squads/{squad}/clientes/{cliente}/outputs/account-sdr-ia-config.json` (com campo `summary` no topo)
+2. Atualize `client.json`: progress.skills → completed, version++, append em history[]
+3. Salve também uma versão Markdown do entregável na mesma pasta de outputs.
+4. **Ative o agente no Patagon** (com aprovação do operador e do cliente)
+5. Informe:
+   - "SDR IA configurado, testado e no ar!"
+   - "Recomendações pós go-live:"
+   - "  1. Monitorar os primeiros 20 leads reais (ajustar scoring se necessário)"
+   - "  2. Coletar feedback do vendedor sobre qualidade dos leads"
+   - "  3. Revisar métricas após 7 dias: qualificação, SLA, conversão"
+   - "  4. Ajustar scripts com base nos dados reais"
+
+**ALERTA:** O agente está no ar. Leads reais sendo qualificados. Monitore de perto nas primeiras 48h.

--- a/.agents/skills/account-sdr-ia-config/references/guia-patagon-kommo.md
+++ b/.agents/skills/account-sdr-ia-config/references/guia-patagon-kommo.md
@@ -1,0 +1,403 @@
+# Guia de Configuracao: Patagon AI + Kommo CRM
+
+Guia tecnico passo a passo para configurar um agente SDR IA no Patagon com integracao ao Kommo CRM. Escrito para operadores que podem nao ter experiencia tecnica profunda.
+
+---
+
+## Visao Geral da Arquitetura
+
+```
+Lead envia mensagem no WhatsApp
+        |
+        v
+  [Patagon AI Agent]
+  - Recebe mensagem
+  - Executa fluxo de qualificacao
+  - Atribui score 1-5 estrelas
+  - Trata objecoes
+  - Envia follow-ups
+        |
+        v
+  [Integracao Patagon → Kommo]
+  - Cria contato no Kommo
+  - Preenche campos mapeados
+  - Aplica tags automaticas
+  - Move para etapa correta do pipeline
+        |
+        v
+  [Alerta para Vendedor]
+  - Se score >= 4: WhatsApp para vendedor
+  - Se score < 4: regua automatica
+```
+
+---
+
+## Parte 1: Patagon AI — Configuracao do Agente
+
+### 1.1 Acesso e Criacao
+
+1. Acesse [app.patagon.ai](https://app.patagon.ai)
+2. Faca login com a conta do operador
+3. No dashboard, clique em **"+ Novo Agente"**
+4. Preencha:
+   - **Nome do agente:** Nome humano (ex: "Ana da Empresa X"). Esse nome aparece para o lead.
+   - **Descricao:** Texto interno para identificacao (ex: "SDR IA - Qualificacao WhatsApp")
+   - **Canal:** WhatsApp Business
+   - **Numero:** Selecione o numero do cliente (deve estar previamente conectado)
+
+### 1.2 Conectar WhatsApp Business
+
+**Pre-requisito:** O cliente precisa ter um numero de WhatsApp Business. Numero pessoal NAO funciona.
+
+1. No Patagon: **Settings → Channels → WhatsApp**
+2. Clique em **"Conectar WhatsApp"**
+3. Escaneie o QR code com o WhatsApp Business do cliente
+4. Aguarde a confirmacao de conexao (pode levar ate 2 minutos)
+5. Teste enviando uma mensagem do seu celular para o numero conectado
+6. Se o Patagon mostrar a mensagem recebida, a conexao esta OK
+
+**Problemas comuns:**
+- QR code expirado: atualize a pagina e escaneie novamente
+- Numero ja conectado em outro servico: desconecte primeiro
+- WhatsApp Business API vs App: ambos funcionam, mas API tem mais recursos
+
+### 1.3 Configurar Personalidade do Agente
+
+No Patagon, va em **Agent Settings → Personality/Instructions**.
+
+O campo de instrucoes e onde voce define COMO o agente se comporta. Cole o texto gerado pela skill copy-scripts-sdr, adaptado para o formato do Patagon.
+
+**Estrutura recomendada das instrucoes:**
+
+```
+IDENTIDADE:
+Voce e [NOME_AGENTE], [funcao] da [EMPRESA].
+Seu trabalho e atender pessoas que entram em contato pelo WhatsApp.
+
+PERSONALIDADE:
+[Descricao do tom de voz baseada no designer-manual-marca]
+- Ex: "Voce e amigavel, direta e profissional. Usa linguagem simples."
+- Ex: "Voce nao usa gíria, mas tambem nao e formal demais."
+
+REGRAS ABSOLUTAS:
+1. Maximo 3 frases por mensagem
+2. Use o nome da pessoa sempre que possivel
+3. Nunca prometa preco, prazo ou condicao especifica
+4. Se nao souber responder, passe para [NOME_VENDEDOR]
+5. Nunca revele que e uma inteligencia artificial
+6. Nunca use mais de 1 emoji por mensagem
+7. Responda sempre em portugues brasileiro
+
+CONHECIMENTO DO PRODUTO:
+[Resumo do produto/servico]
+[Principais beneficios]
+[O que NAO pode prometer]
+
+PROCESSO:
+1. Cumprimente e se apresente
+2. Faca as perguntas de qualificacao (uma por vez)
+3. Classifique o lead
+4. Se qualificado: encaminhe para vendedor
+5. Se nao qualificado: ofereça conteudo e nutra
+```
+
+### 1.4 Configurar Fluxo de Qualificacao
+
+No Patagon: **Agent Settings → Conversation Flow**
+
+Aqui voce define as perguntas que o agente faz em sequencia:
+
+1. **Adicione cada pergunta** como um "step" no fluxo
+2. Para cada pergunta, configure:
+   - **Texto da pergunta:** A pergunta exata
+   - **Tipo:** "Aberta" (o lead responde livremente)
+   - **Obrigatoria:** Sim (o agente deve obter resposta antes de avancar)
+   - **Regras de score:** Como a resposta influencia a classificacao
+3. **Ordene** as perguntas na sequencia definida pela skill copy-scripts-sdr
+4. **Configure transicoes:** O que o agente diz entre uma pergunta e outra
+
+**Dica:** Nao use perguntas de multipla escolha no WhatsApp. Perguntas abertas soam mais naturais. O agente de IA interpreta a resposta.
+
+### 1.5 Configurar Regras de Scoring
+
+No Patagon: **Agent Settings → Scoring Rules**
+
+Configure os criterios de cada faixa de score:
+
+| Score | Criterios | Acao automatica |
+|-------|-----------|-----------------|
+| 5 estrelas | Todos os sinais positivos presentes | Alerta imediato + Kommo "Qualificados" |
+| 4 estrelas | Maioria dos sinais positivos | Alerta + Kommo "Qualificados" |
+| 3 estrelas | Sinais mistos | Kommo "Nutricao" + regua |
+| 2 estrelas | Poucos sinais positivos | Kommo "Frios" + tag |
+| 1 estrela | Sinais de desqualificacao | Kommo "Frios" + despedida |
+
+**Como o Patagon calcula o score:**
+O Patagon usa IA para interpretar as respostas do lead e classificar conforme os criterios que voce definiu. Quanto mais especificos os criterios, mais precisa a classificacao.
+
+**Exemplo de criterio bem escrito:**
+"Lead 5 estrelas: demonstra necessidade urgente (prazo definido), e o decisor ou tem autonomia, orcamento compativel com ticket medio, e ja pesquisou alternativas."
+
+**Exemplo de criterio mal escrito:**
+"Lead bom." (vago demais, o agente nao sabe como classificar)
+
+### 1.6 Configurar Respostas para Objecoes
+
+No Patagon: **Agent Settings → Objection Handling**
+
+Para cada objecao, adicione:
+1. **Trigger:** A objecao como o lead a expressa (pode ter variações)
+2. **Resposta:** O script do SDR IA para essa objecao
+3. **Se insistir:** Segunda resposta ou escalamento
+
+**Dica:** Adicione variações da mesma objecao. Ex: "ta caro", "achei caro", "nao tenho dinheiro pra isso", "meu orcamento e menor" podem ser agrupadas como objecao de preco.
+
+### 1.7 Configurar Follow-ups
+
+No Patagon: **Agent Settings → Follow-ups**
+
+1. **Ative follow-ups automaticos**
+2. Configure cada intervalo:
+   - Apos 1 hora sem resposta: [mensagem]
+   - Apos 24 horas sem resposta: [mensagem]
+   - Apos 3 dias sem resposta: [mensagem — ultimo]
+3. **Max follow-ups:** 3 (nao mais que isso)
+4. **Horario permitido:** Definir janela de horario comercial
+
+### 1.8 Configurar Handoff para Humano
+
+No Patagon: **Agent Settings → Human Handoff**
+
+1. **Mensagem de transicao:** A mensagem que o agente envia ao lead antes de transferir
+2. **Destinatario:** Nome e WhatsApp do vendedor
+3. **Triggers de handoff:**
+   - Score 4-5 estrelas (apos qualificacao)
+   - Lead pede para falar com humano
+   - Agente nao consegue responder (2 tentativas)
+   - Lead demonstra frustacao
+4. **Contexto enviado ao vendedor:** Resumo da conversa, score, dados coletados
+
+---
+
+## Parte 2: Kommo CRM — Integracao
+
+### 2.1 Obter API Key do Kommo
+
+1. No Kommo: **Settings → Integrations**
+2. Clique em **"API"**
+3. Se nao houver chave, clique em **"Generate API Key"**
+4. Copie a chave (ela sera usada no Patagon)
+5. **IMPORTANTE:** Guarde a chave em local seguro. Nao compartilhe.
+
+### 2.2 Conectar no Patagon
+
+1. No Patagon: **Settings → Integrations → Kommo**
+2. Clique em **"Conectar"**
+3. Cole a API key do Kommo
+4. Clique em **"Testar Conexao"**
+5. Se mostrar "Conexao bem sucedida", avance
+6. Se der erro, verifique: a chave esta correta? O Kommo esta ativo?
+
+### 2.3 Field Mapping (Mapeamento de Campos)
+
+Apos conectar, configure o mapeamento:
+
+**Campos padrao (ja existem no Kommo):**
+
+| Campo Patagon | Campo Kommo | Notas |
+|---------------|-------------|-------|
+| Nome do lead | Nome | Campo padrao, obrigatorio |
+| Telefone | Telefone | Campo padrao |
+| Email | Email | Se coletado |
+
+**Campos personalizados (criar no Kommo primeiro):**
+
+Para criar campos personalizados no Kommo:
+1. Va em **Settings → Fields**
+2. Clique em **"Add Field"**
+3. Preencha nome e tipo
+4. Salve
+
+Campos personalizados recomendados:
+
+| Nome do campo | Tipo | Descricao |
+|---------------|------|-----------|
+| Score | Tag | Score 1-5 estrelas |
+| Produto Interesse | Texto | Produto que o lead demonstrou interesse |
+| Origem (UTM Source) | Texto | De onde o lead veio |
+| Midia (UTM Medium) | Texto | Canal de midia |
+| Campanha (UTM Campaign) | Texto | Nome da campanha |
+| Resumo SDR | Texto longo | Resumo da qualificacao pelo SDR IA |
+
+**Campo de notas:**
+
+O historico da conversa completa deve ser salvo como nota no contato:
+1. No mapeamento, selecione "Historico da conversa"
+2. Mapeie para "Nota automatica" no Kommo
+3. Isso cria uma nota no contato com toda a conversa
+
+### 2.4 Configurar Pipeline de Destino
+
+No mapeamento, defina para qual etapa do pipeline cada score vai:
+
+1. **Score 4-5 estrelas:** Etapa "Qualificados" (ou equivalente)
+2. **Score 3 estrelas:** Etapa "Nutricao" (ou equivalente)
+3. **Score 1-2 estrelas:** Etapa "Frios" (ou equivalente)
+
+**NOTA:** As etapas do pipeline devem existir no Kommo. Se nao existirem, crie antes:
+1. No Kommo: **Pipeline → Edit Pipeline**
+2. Adicione as etapas necessarias
+3. Salve
+
+### 2.5 Configurar Tags Automaticas
+
+No Patagon, na secao de integracao Kommo:
+
+1. **Tags por score:**
+   - 5 estrelas: "Lead Quente", "5 estrelas"
+   - 4 estrelas: "Lead Qualificado", "4 estrelas"
+   - 3 estrelas: "Lead Morno", "Nutricao"
+   - 1-2 estrelas: "Lead Frio"
+
+2. **Tags por origem (UTM):**
+   Configure regras baseadas no UTM source:
+   - Se `utm_source` contem "google" → tag "Google Ads"
+   - Se `utm_source` contem "meta" ou "facebook" → tag "Meta Ads"
+   - Se `utm_source` contem "instagram" → tag "Instagram Organico"
+   - Se `utm_source` contem "indicacao" → tag "Indicacao"
+
+---
+
+## Parte 3: Alertas para Vendedor
+
+### 3.1 Configurar no Patagon
+
+No Patagon: **Settings → Alerts**
+
+1. Clique em **"New Alert"**
+2. **Condicao de disparo:**
+   - Tipo: "Lead qualificado"
+   - Score minimo: 4 estrelas
+   - Momento: apos qualificacao concluida
+3. **Canal:** WhatsApp
+4. **Destinatario:** Numero do vendedor
+5. **Template:** Use o template definido na skill
+
+### 3.2 Template do Alerta
+
+O alerta deve conter tudo que o vendedor precisa para agir rapidamente:
+
+```
+LEAD QUALIFICADO: [Nome do lead]
+Score: [X] estrelas
+Interesse: [Produto que demonstrou interesse]
+Resumo: [2 frases sobre o que o lead precisa]
+Ver no Kommo: [link direto para o contato]
+SLA: responder em [X] minutos
+```
+
+### 3.3 Escalamento
+
+Configure o que acontece se o vendedor nao responder:
+
+1. **Timer 1:** Apos [SLA] minutos sem resposta do vendedor
+   - Acao: enviar alerta para backup
+   - Tag no Kommo: "SLA Violado"
+
+2. **Timer 2:** Apos [SLA x 2] minutos sem resposta de ninguem
+   - Acao: enviar mensagem automatica ao lead (desculpando a demora)
+   - Tag no Kommo: "Atendimento Atrasado"
+
+---
+
+## Parte 4: Testes
+
+### 4.1 Checklist Pre-Teste
+
+Antes de testar, verifique:
+
+- [ ] Agente criado no Patagon com todas as configuracoes
+- [ ] WhatsApp Business conectado
+- [ ] Instrucoes de personalidade preenchidas
+- [ ] Perguntas de qualificacao configuradas
+- [ ] Regras de scoring definidas
+- [ ] Respostas de objecoes adicionadas
+- [ ] Follow-ups configurados
+- [ ] Handoff configurado
+- [ ] Integracao Kommo ativa e testada
+- [ ] Field mapping completo
+- [ ] Tags automaticas configuradas
+- [ ] Alertas configurados
+- [ ] Vendedor informado sobre os testes
+
+### 4.2 Protocolo de Teste
+
+Para cada lead simulado:
+
+1. **Envie a mensagem inicial** de um numero diferente
+2. **Aguarde a resposta** do agente (deve ser < 5 segundos)
+3. **Siga o roteiro** do perfil de teste (quente, morno, frio, etc.)
+4. **Responda as perguntas** conforme o perfil
+5. **Verifique no Patagon:** score atribuido
+6. **Verifique no Kommo:** contato criado, campos preenchidos, tag aplicada, etapa correta
+7. **Verifique no WhatsApp do vendedor:** alerta recebido (se aplicavel)
+8. **Registre o resultado**
+
+### 4.3 O que verificar em cada teste
+
+| Item | Como verificar | Criterio de sucesso |
+|------|---------------|---------------------|
+| Tempo de resposta | Cronometrar | < 5 segundos |
+| Mensagem de boas-vindas | Ler a mensagem | Igual ao configurado |
+| Perguntas na ordem | Acompanhar a conversa | Sequencia correta |
+| Tom de voz | Avaliar linguagem | Consistente com designer-manual-marca |
+| Score | Verificar no Patagon | Corresponde ao perfil |
+| Kommo — contato | Verificar no CRM | Contato criado |
+| Kommo — campos | Verificar campos | Todos preenchidos |
+| Kommo — tag | Verificar tags | Tag correta aplicada |
+| Kommo — etapa | Verificar pipeline | Etapa correta |
+| Alerta | Verificar WhatsApp vendedor | Recebido (se 4-5 estrelas) |
+
+### 4.4 Problemas Comuns e Solucoes
+
+| Problema | Causa provavel | Solucao |
+|----------|---------------|---------|
+| Agente nao responde | WhatsApp desconectado | Reconectar no Patagon |
+| Score incorreto | Criterios vagos | Reescrever criterios com mais especificidade |
+| Lead nao aparece no Kommo | API key invalida | Gerar nova key no Kommo |
+| Campos vazios no Kommo | Mapeamento incompleto | Revisar field mapping |
+| Tag errada | Regra de tag incorreta | Corrigir condicoes de tag |
+| Alerta nao chega | Numero errado ou fora do horario | Verificar numero e horario |
+| Tom robotico | Instrucoes muito rigidas | Flexibilizar instrucoes, adicionar exemplos |
+| Agente revela que e IA | Instrucoes incompletas | Adicionar regra explicita de nao revelar |
+| Follow-up de madrugada | Horario comercial nao configurado | Definir janela de horario |
+
+---
+
+## Parte 5: Pos Go-Live
+
+### 5.1 Primeiras 48 horas
+
+Monitore de perto:
+- Quantos leads entraram?
+- Scores atribuidos estao fazendo sentido?
+- Vendedor esta recebendo alertas e respondendo no SLA?
+- Algum lead reclamou ou demonstrou estranheza?
+- Tom de voz esta consistente?
+
+### 5.2 Primeira semana
+
+Colete metricas:
+- Leads qualificados vs total: X%
+- SLA cumprido: X%
+- Leads que pediram humano: X%
+- Objecoes mais frequentes (novas que nao estavam mapeadas?)
+- Feedback do vendedor sobre qualidade dos leads
+
+### 5.3 Ajustes comuns apos go-live
+
+1. **Criterios de scoring muito frouxos:** Muitos leads 4-5 estrelas que nao sao bons → apertar criterios
+2. **Criterios muito rígidos:** Poucos leads qualificados, vendedor ocioso → afrouxar
+3. **Nova objecao apareceu:** Adicionar no Patagon
+4. **Tom nao esta bom:** Ajustar instrucoes de personalidade
+5. **Follow-up nao funciona:** Testar diferentes abordagens

--- a/.agents/skills/account-sdr-ia-config/schema.json
+++ b/.agents/skills/account-sdr-ia-config/schema.json
@@ -1,0 +1,539 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "SDRIAConfig",
+  "description": "Output estruturado da skill sdr-ia-config: configuracao do Patagon, integracao Kommo, alertas e resultados dos testes.",
+  "type": "object",
+  "required": [
+    "summary",
+    "patagon_config",
+    "kommo_integration",
+    "alerts_config",
+    "test_results",
+    "client_name",
+    "summary_headline",
+    "summary_highlights",
+    "summary_key_findings"
+  ],
+  "properties": {
+    "client_name": {
+      "type": "string",
+      "description": "Nome do cliente — sempre presente em todo output."
+    },
+    "summary": {
+      "type": "string",
+      "description": "Resumo executivo de 2-3 frases: agente configurado, integracao ativa, resultado dos testes."
+    },
+    "summary_headline": {
+      "type": "string",
+      "description": "Manchete em 1 linha (~120 caracteres) com o veredito da skill."
+    },
+    "summary_highlights": {
+      "type": "array",
+      "description": "KPIs em destaque (4-6 itens). Categorias: posicao | competicao | janela | maturidade | oportunidade | risco.",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "label",
+          "value",
+          "tone"
+        ],
+        "properties": {
+          "category": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "subtext": {
+            "type": "string"
+          },
+          "tone": {
+            "type": "string",
+            "enum": [
+              "green",
+              "yellow",
+              "red",
+              "blue",
+              "gray"
+            ]
+          }
+        }
+      }
+    },
+    "summary_key_findings": {
+      "type": "array",
+      "description": "3-5 achados categorizados (vantagem | contexto | ameaca | acao).",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "text"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "vantagem",
+              "contexto",
+              "ameaca",
+              "acao"
+            ]
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "patagon_config": {
+      "type": "object",
+      "required": [
+        "agent_name",
+        "scoring_rules"
+      ],
+      "properties": {
+        "agent_name": {
+          "type": "string",
+          "description": "Nome do agente SDR IA no Patagon (ex: 'Ana da Empresa X')."
+        },
+        "agent_description": {
+          "type": "string",
+          "description": "Descricao interna do agente no Patagon."
+        },
+        "persona_instructions": {
+          "type": "string",
+          "description": "Texto completo das instrucoes de personalidade configuradas no Patagon."
+        },
+        "welcome_message": {
+          "type": "string",
+          "description": "Mensagem de boas-vindas configurada no Patagon."
+        },
+        "qualification_questions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "order": {
+                "type": "integer",
+                "description": "Ordem da pergunta."
+              },
+              "question": {
+                "type": "string",
+                "description": "Texto da pergunta configurada."
+              },
+              "required": {
+                "type": "boolean",
+                "description": "Se a pergunta e obrigatoria."
+              }
+            }
+          },
+          "description": "Perguntas de qualificacao configuradas no fluxo."
+        },
+        "scoring_rules": {
+          "type": "object",
+          "required": [
+            "five_star",
+            "four_star",
+            "three_star",
+            "two_star",
+            "one_star"
+          ],
+          "properties": {
+            "five_star": {
+              "type": "object",
+              "properties": {
+                "criteria": {
+                  "type": "string",
+                  "description": "Criterios para score 5 estrelas."
+                },
+                "action": {
+                  "type": "string",
+                  "description": "Acao automatica para 5 estrelas."
+                }
+              }
+            },
+            "four_star": {
+              "type": "object",
+              "properties": {
+                "criteria": {
+                  "type": "string",
+                  "description": "Criterios para score 4 estrelas."
+                },
+                "action": {
+                  "type": "string",
+                  "description": "Acao automatica para 4 estrelas."
+                }
+              }
+            },
+            "three_star": {
+              "type": "object",
+              "properties": {
+                "criteria": {
+                  "type": "string",
+                  "description": "Criterios para score 3 estrelas."
+                },
+                "action": {
+                  "type": "string",
+                  "description": "Acao automatica para 3 estrelas."
+                }
+              }
+            },
+            "two_star": {
+              "type": "object",
+              "properties": {
+                "criteria": {
+                  "type": "string",
+                  "description": "Criterios para score 2 estrelas."
+                },
+                "action": {
+                  "type": "string",
+                  "description": "Acao automatica para 2 estrelas."
+                }
+              }
+            },
+            "one_star": {
+              "type": "object",
+              "properties": {
+                "criteria": {
+                  "type": "string",
+                  "description": "Criterios para score 1 estrela."
+                },
+                "action": {
+                  "type": "string",
+                  "description": "Acao automatica para 1 estrela."
+                }
+              }
+            }
+          },
+          "description": "Regras de scoring configuradas no Patagon."
+        },
+        "objection_responses": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "objection": {
+                "type": "string",
+                "description": "Objecao configurada."
+              },
+              "response": {
+                "type": "string",
+                "description": "Resposta configurada."
+              }
+            }
+          },
+          "description": "Respostas de objecoes configuradas no Patagon."
+        },
+        "followup_config": {
+          "type": "object",
+          "properties": {
+            "after_1h": {
+              "type": "string"
+            },
+            "after_24h": {
+              "type": "string"
+            },
+            "after_3d": {
+              "type": "string"
+            },
+            "max_followups": {
+              "type": "integer"
+            }
+          },
+          "description": "Configuracao de follow-ups automaticos."
+        },
+        "handoff_config": {
+          "type": "object",
+          "properties": {
+            "handoff_message": {
+              "type": "string",
+              "description": "Mensagem de transicao para humano."
+            },
+            "destination_name": {
+              "type": "string",
+              "description": "Nome do vendedor destino."
+            },
+            "destination_whatsapp": {
+              "type": "string",
+              "description": "WhatsApp do vendedor destino."
+            }
+          }
+        }
+      }
+    },
+    "kommo_integration": {
+      "type": "object",
+      "required": [
+        "field_mapping",
+        "api_configured"
+      ],
+      "properties": {
+        "api_configured": {
+          "type": "boolean",
+          "description": "Se a API key do Kommo foi configurada e a conexao testada com sucesso."
+        },
+        "pipeline_name": {
+          "type": "string",
+          "description": "Nome do pipeline no Kommo onde os leads entram."
+        },
+        "field_mapping": {
+          "type": "array",
+          "minItems": 5,
+          "items": {
+            "type": "object",
+            "required": [
+              "patagon_field",
+              "kommo_field"
+            ],
+            "properties": {
+              "patagon_field": {
+                "type": "string",
+                "description": "Nome do campo no Patagon."
+              },
+              "kommo_field": {
+                "type": "string",
+                "description": "Nome do campo no Kommo."
+              },
+              "field_type": {
+                "type": "string",
+                "description": "Tipo do campo (texto, telefone, tag, nota, data)."
+              },
+              "is_custom_field": {
+                "type": "boolean",
+                "description": "Se o campo no Kommo e personalizado (criado para esta integracao)."
+              }
+            }
+          },
+          "description": "Mapeamento de campos entre Patagon e Kommo."
+        },
+        "stage_mapping": {
+          "type": "object",
+          "properties": {
+            "qualified_stage": {
+              "type": "string",
+              "description": "Etapa do pipeline para leads 4-5 estrelas."
+            },
+            "nurture_stage": {
+              "type": "string",
+              "description": "Etapa do pipeline para leads 3 estrelas."
+            },
+            "cold_stage": {
+              "type": "string",
+              "description": "Etapa do pipeline para leads 1-2 estrelas."
+            }
+          }
+        },
+        "auto_tags": {
+          "type": "object",
+          "properties": {
+            "by_score": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "description": "Tags automaticas por score (ex: {'5_star': ['Lead Quente', '5 estrelas']})."
+            },
+            "by_source": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Tags automaticas por UTM source (ex: {'google': 'Google Ads'})."
+            }
+          }
+        }
+      }
+    },
+    "alerts_config": {
+      "type": "object",
+      "required": [
+        "template",
+        "seller_whatsapp",
+        "sla_minutes"
+      ],
+      "properties": {
+        "template": {
+          "type": "string",
+          "description": "Template da mensagem de alerta enviada ao vendedor."
+        },
+        "seller_name": {
+          "type": "string",
+          "description": "Nome do vendedor que recebe alertas."
+        },
+        "seller_whatsapp": {
+          "type": "string",
+          "description": "Numero de WhatsApp do vendedor."
+        },
+        "backup_name": {
+          "type": "string",
+          "description": "Nome do backup caso vendedor nao responda no SLA."
+        },
+        "backup_whatsapp": {
+          "type": "string",
+          "description": "Numero de WhatsApp do backup."
+        },
+        "sla_minutes": {
+          "type": "integer",
+          "description": "Tempo maximo em minutos para o vendedor responder ao lead."
+        },
+        "escalation_minutes": {
+          "type": "integer",
+          "description": "Tempo em minutos apos o qual escalar para backup."
+        },
+        "business_hours": {
+          "type": "object",
+          "properties": {
+            "start": {
+              "type": "string",
+              "description": "Horario de inicio do atendimento (ex: '08:00')."
+            },
+            "end": {
+              "type": "string",
+              "description": "Horario de fim do atendimento (ex: '19:00')."
+            }
+          }
+        },
+        "trigger_conditions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Condicoes para disparar alerta (ex: 'score >= 4', 'qualificacao concluida')."
+        }
+      }
+    },
+    "test_results": {
+      "type": "array",
+      "minItems": 5,
+      "maxItems": 5,
+      "items": {
+        "type": "object",
+        "required": [
+          "lead_number",
+          "score",
+          "kommo_entry",
+          "alert_sent",
+          "response_time"
+        ],
+        "properties": {
+          "lead_number": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 5,
+            "description": "Numero do lead de teste (1-5)."
+          },
+          "profile_description": {
+            "type": "string",
+            "description": "Descricao curta do perfil simulado."
+          },
+          "expected_score": {
+            "type": "string",
+            "description": "Score esperado para este perfil."
+          },
+          "score": {
+            "type": "string",
+            "description": "Score real atribuido pelo agente."
+          },
+          "score_correct": {
+            "type": "boolean",
+            "description": "Se o score real correspondeu ao esperado."
+          },
+          "kommo_entry": {
+            "type": "boolean",
+            "description": "Se o lead entrou corretamente no Kommo."
+          },
+          "kommo_fields_complete": {
+            "type": "boolean",
+            "description": "Se todos os campos foram preenchidos no Kommo."
+          },
+          "kommo_stage_correct": {
+            "type": "boolean",
+            "description": "Se o lead entrou na etapa correta do pipeline."
+          },
+          "alert_sent": {
+            "type": "boolean",
+            "description": "Se o alerta foi enviado ao vendedor (quando aplicavel)."
+          },
+          "response_time": {
+            "type": "string",
+            "description": "Tempo de resposta do agente (ex: '3s', '5s')."
+          },
+          "tone_consistent": {
+            "type": "boolean",
+            "description": "Se o tom de voz estava consistente com o brandbook."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pass",
+              "fail",
+              "partial"
+            ],
+            "description": "Status do teste: pass, fail ou partial."
+          },
+          "issues": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Problemas encontrados neste teste (vazio se pass)."
+          }
+        }
+      },
+      "description": "Resultados dos 5 testes de leads simulados."
+    },
+    "overall_test_result": {
+      "type": "string",
+      "enum": [
+        "approved",
+        "needs_adjustments",
+        "failed"
+      ],
+      "description": "Resultado geral dos testes."
+    },
+    "issues_found": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Lista de problemas encontrados nos testes (vazio se todos passaram)."
+    },
+    "adjustments_made": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Ajustes feitos apos problemas encontrados nos testes."
+    },
+    "go_live": {
+      "type": "object",
+      "properties": {
+        "approved": {
+          "type": "boolean",
+          "description": "Se o go-live foi aprovado pelo operador e cliente."
+        },
+        "activated_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Data/hora de ativacao do agente (ISO 8601)."
+        },
+        "monitoring_plan": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Plano de monitoramento pos go-live."
+        }
+      }
+    }
+  }
+}

--- a/.claude/skills/account-auditoria-comunicacao/SKILL.md
+++ b/.claude/skills/account-auditoria-comunicacao/SKILL.md
@@ -1,0 +1,275 @@
+---
+name: account-auditoria-comunicacao
+description: "Audita todos os pontos de contato digitais do cliente (site, Instagram, anúncios, GMB, WhatsApp) e gera matriz de gaps com quick wins. Usa capacidade multimodal para analisar screenshots. Use quando o operador disser 'auditoria', 'comunicação', 'pontos de contato', 'gaps', ou após completar geral-persona-icp."
+area: account
+author: luizfreitasv4
+version: 1.0.0
+dependencies: ["geral-persona-icp"]
+outputs: ["account-auditoria-comunicacao.json"]
+week: 1
+estimated_time: "45-75 min"
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta versao foi portada do sistema de Estruturacao Estrategica. As regras abaixo tem precedencia sobre caminhos e persistencia citados no fluxo original:
+
+- Trabalhe somente em `squads/{squad}/clientes/{cliente}/`, nunca em um diretorio `clientes/` solto na raiz.
+- Leia primeiro o `CLAUDE.md` ou `AGENTS.md` da KB, `mission-control/`, `calls/`, `docs/` e `campanhas/`.
+- Se `client.json` existir, use-o como fonte complementar. Se nao existir, derive o contexto da KB e do Mission Control; nao exija nem invente esse arquivo.
+- Salve entregaveis em `squads/{squad}/clientes/{cliente}/outputs/`, em JSON e Markdown quando o fluxo pedir ambos.
+- Registre decisoes e progresso no `mission-control/historico-checkins.md` ou no arquivo de historico equivalente encontrado na KB.
+- Resolva recursos empacotados a partir do proprio diretorio desta skill. Se uma integracao externa nao estiver configurada, declare o gap e continue apenas com os dados reais disponiveis.
+
+
+# Auditoria de Comunicação Digital (POP 1.6)
+
+Você é um auditor de comunicação digital especializado em PMEs brasileiras. Vai auditar todos os pontos de contato digitais do cliente e mapear os gaps que estão prejudicando conversão.
+
+> **Posição no fluxo:** Semana 1 — comum a todos os modelos. Avalia coerência e qualidade da comunicação pública (tom de voz, oferta, consistência cross-canal) antes de definir posicionamento na Semana 2.
+
+> **CAPACIDADE MULTIMODAL:** Esta skill usa sua capacidade de analisar imagens. O operador vai fornecer screenshots de Instagram, anúncios, site, etc. Analise cada imagem em detalhe.
+
+## Dados necessários
+
+Leia os seguintes arquivos do diretório do cliente:
+
+1. `client.json` (seção `briefing`) — dados base do cliente (OBRIGATÓRIO)
+2. `outputs/geral-persona-icp.json` — ICP e persona (OBRIGATÓRIO — é dependência)
+3. `client.json` (seção `connectors`) — dados V4MOS se disponíveis
+4. `client.json` (seção `history`) — decisões anteriores
+
+Extraia do briefing:
+- `identification.name` → nome do cliente
+- `identification.segment` → setor
+- `brand.voice_tone` → tom de voz desejado
+- `brand.adjectives` → adjetivos de marca
+- `digital_situation` → URLs e dados de presença digital
+- `accesses` → quais acessos o operador tem
+
+Da geral-persona-icp, extraia:
+- `summary` → resumo do ICP
+- `persona` → persona completa (para avaliar alinhamento da comunicação)
+- `key_message` → mensagem-chave aprovada
+- `where_to_find.digital_channels` → canais onde o ICP está
+
+Solicite ao operador screenshots e dados faltantes TUDO de uma vez:
+- Confirme URLs (site, Instagram, Facebook, GMB, WhatsApp)
+- Peça screenshots necessários: homepage (desktop + mobile), Instagram (perfil/bio + últimos 9 posts), anúncios ativos (Meta Ads Library), GMB (perfil + reviews), WhatsApp (tela de boas-vindas)
+- Se o operador não tiver screenshots ainda, avise que pode fornecer ao longo da auditoria. NÃO bloqueie o andamento.
+
+---
+
+## Geração
+
+Gere o output COMPLETO de uma vez usando os dados de `client.json` (briefing, connectors) e outputs de skills dependentes em `outputs/`.
+
+Para cada canal, consulte o checklist detalhado em `references/checklist-auditoria-por-canal.md`.
+
+### Canal 1: Site / Landing Page
+
+Se tiver URL, analise (peça screenshots se não tiver):
+
+**Proposta de valor:** Está na primeira dobra? É clara? Alinhada com a mensagem-chave?
+**Prova social:** Depoimentos com nome/foto/resultado? Logos? Certificações?
+**CTA principal:** Visível sem scroll? Texto é ação clara? Para onde direciona?
+**Coerência visual:** Consistência de cores, fontes, imagens? Imagens reais ou stock?
+**Experiência mobile:** Responsivo? Velocidade?
+**SEO básico:** Title tag? Meta description? H1 com palavra-chave?
+
+Atribua um score de 0-100 com base no checklist de referência.
+
+### Canal 2: Instagram
+
+**Bio:** Clara sobre o que faz e para quem? CTA? Palavras-chave do ICP?
+**Feed (visuais):** Consistência visual? Qualidade? Variedade de formatos?
+**Conteúdo (legendas):** Fala COM o ICP? Hooks? CTAs? Frequência?
+**Destaques/Stories:** Organizados? Cobrem dúvidas do ICP?
+
+Atribua um score de 0-100.
+
+### Canal 3: Anúncios Ativos
+
+**Hook visual:** Para o scroll? Conecta com ICP?
+**Copy do anúncio:** Específica para ICP? Dor/ganho? Prova social?
+**CTA:** Claro? Coerente com etapa do funil?
+**Coerência:** Alinhado com identidade visual e mensagem-chave?
+
+Atribua um score de 0-100. Se não houver anúncios ativos, registre como "sem anúncios ativos" e recomende como prioridade.
+
+### Canal 4: Google Meu Negócio
+
+Se aplicável (negócios com componente local):
+**Completude:** Descrição? Fotos? Horários? Categoria?
+**Reviews:** Volume? Nota? Respostas?
+**Atividade:** Posts? Atualizações?
+
+Atribua um score de 0-100.
+
+### Canal 5: WhatsApp Business
+
+**Configuração:** WhatsApp Business? Saudação? Ausência? Catálogo?
+**Atendimento:** Tempo de resposta? Tom? Script? Follow-up?
+
+Atribua um score de 0-100.
+
+### Matriz de Gaps
+
+Compile todos os gaps identificados:
+
+| # | Canal | Gap Identificado | Impacto | Esforço | Ação Recomendada |
+|---|-------|-------------------|---------|---------|-------------------|
+| 1 | [canal] | [gap específico com evidência] | Alto/Médio/Baixo | Baixo/Médio/Alto | [ação específica] |
+
+**Regras de priorização:**
+- **Impacto Alto + Esforço Baixo** → Quick Win (fazer PRIMEIRO)
+- **Impacto Alto + Esforço Alto** → Projeto estratégico (planejar)
+- **Impacto Baixo + Esforço Baixo** → Fazer quando sobrar tempo
+- **Impacto Baixo + Esforço Alto** → NÃO fazer (ou fazer por último)
+
+### Resumo Executivo
+- Top 3 problemas de comunicação que mais custam conversão AGORA
+- Para cada: evidência + impacto estimado + ação
+
+### Competitor Benchmark (OBRIGATÓRIO — 2-3 grupos, 5 canais)
+
+Não basta auditar o cliente isoladamente. Compare canal a canal com 2-3 grupos de concorrentes (ex: "top local", "grandes nacionais"). Para cada:
+
+**Groups:** 2-3 grupos de concorrência com `name`, `members` (nomes reais), `positioning` (resumo do posicionamento dominante).
+
+**Benchmark by channel:** para cada canal (site, instagram, anúncios, GMB, WhatsApp):
+- `channel`: nome
+- `client_score`: score do cliente (0-100) — **nome preferido**
+- `best_in_class_score`: score do melhor do grupo — **nome preferido** (alternativa aceita: `competitor_avg_score`)
+- `gap`: diferença
+- `best_practice_observed`: o que o melhor faz (específico) — **nome preferido** (alternativa aceita: `evidence`)
+- `opportunity_for_client`: como o cliente pode fechar o gap (não genérico — específico) — **nome preferido** (alternativa aceita: `immediate_win`)
+
+> O renderer do portal aceita ambos os conjuntos de nomes. Priorize `client_score`/`best_in_class_score`/`best_practice_observed`/`opportunity_for_client`; use as alternativas apenas se o contexto exigir outra semântica.
+
+Feche com `strategic_read`: 1 parágrafo que interpreta os gaps — onde o cliente está muito atrás, onde está à frente, onde a competição é fraca.
+
+### Journey Friction Map (OBRIGATÓRIO — funil completo com leakage)
+
+Mapeie o funil real da persona do primeiro contato ao fechamento. Para cada estágio:
+- `stage`: nome (ex: "Exposição", "Clique", "LP", "WhatsApp click", "Resposta", "Agendamento", "Comparecimento")
+- `current_volume`: número real ou estimado (evidência se estimado)
+- `leakage_pct`: % que vaza para o próximo estágio
+- `root_cause`: por que vaza aqui
+- `fix_effort`: baixo/médio/alto
+- `fix_impact_estimate`: impacto estimado se fixar (leads a mais, % conversão a mais)
+
+Feche com:
+- `biggest_leakage_summary`: qual o estágio crítico, quanto vaza, quanto custa
+- `projected_funnel_90d_realistic`: projeção com quick wins aplicados
+
+### Tone-of-Voice Analysis (OBRIGATÓRIO — coerência entre canais)
+
+Comunicação quebra quando o tom muda de canal para canal. Audite:
+
+**Brand voice target:** o tom PROMETIDO pela marca.
+- `pillars`: 3-5 atributos declarados (ex: "acolhedor", "técnico", "sem jargão")
+- `avoid`: o que NÃO é (ex: "não é frio", "não é jocoso")
+
+**Channel drift:** para cada canal (site, instagram, anúncios, GMB, WhatsApp):
+- `channel`
+- `actual_tone`: como soa hoje (com exemplo citado) — **nome preferido** (alternativa: `current_tone`)
+- `target_alignment`: **CAMPO RECOMENDADO** — alinhamento qualitativo com a brand voice. Use um dos enums: `alinhado`, `bom`/`boa`, `parcial`/`media`, `baixa`, `desalinhado`, `crítico`, `nenhum`. O renderer do portal mapeia cada valor para uma barra visual no gráfico "Alinhamento por Canal" (alinhado=100, bom=80, parcial/média=55, baixa=25, desalinhado=20, crítico=10, nenhum=0). **Prefira este campo** em vez de `alignment_score` numérico — é mais legível e consistente.
+- `alignment_score`: 0-100 (opcional; use apenas se quiser sobrescrever o mapeamento do enum)
+- `drift_notes`: onde desalinhou — **nome preferido** (alternativa: `gap`)
+- `fix`: correção sugerida (opcional; renderiza como ação complementar ao drift)
+- `example`: citação textual do canal que ilustra o drift
+
+> **IMPORTANTE:** O gráfico "Alinhamento por Canal" no portal só renderiza canais que têm `target_alignment` (enum) ou `alignment_score` (numérico). Se ambos estiverem ausentes, o canal é omitido. **Sempre preencha `target_alignment`** para garantir visualização.
+
+Feche com `coherence_score`: média ponderada 0-100 que mede coerência geral da marca. Se <60, é prioridade editorial imediata. O renderer exibe esse score em uma barra horizontal com marcadores de Meta/Atual (escala 0/40/70/100).
+
+### URL Audit (OBRIGATÓRIO — lista de URLs a verificar)
+
+Lista com `url`, `purpose` (LP produto X, bio Instagram, etc.), `status_expected` (o que deveria estar lá), `verify_checklist` (3-5 pontos rápidos para QA do operador).
+
+### Quick Wins (3-5 ações)
+
+Para cada quick win:
+1. **O que fazer** — ação concreta, passo a passo
+2. **Em qual canal** — onde implementar
+3. **Tempo estimado** — horas para implementar
+4. **Impacto esperado** — o que melhora
+5. **Quem faz** — operador, cliente, ou equipe do cliente
+
+### Estrutura visual (obrigatória)
+
+Siga o padrão canônico de `references/padrao-output.md`. Além dos campos acima, SEMPRE inclua:
+
+- **`summary_headline`** (max 200 char) — manchete do veredito. Ex: "[Cliente] tem 4 canais ativos mas 0 coerência de voz — maior vazamento na Consideração (-47%)."
+- **`summary_highlights`** (4-6 itens, `{category, label, value, subtext, tone}`) — para auditoria de comunicação sugestões:
+  - `maturidade`: nº de canais auditados, score médio, coherence_score de voz
+  - `risco`: maior vazamento (`biggest_leakage_summary`) com %
+  - `oportunidade`: quick win de maior impacto, tempo de execução
+  - `competicao`: gap vs melhor concorrente benchmark
+- **`summary_key_findings`** (3-5 itens, `{category, text}`) — `vantagem|contexto|ameaca|acao`.
+
+### Ponto de alavancagem
+
+Em auditoria de comunicação, o ponto de alavancagem é o **maior vazamento no funil com causa-raiz clara** (tipicamente o `biggest_leakage_summary` + o quick win que o destrava). Estruture em `key_insight`:
+```json
+"key_insight": {
+  "headline": "Frase sobre o vazamento (ex: '47% dos leads somem entre Descoberta e Consideração porque o Google Maps está incompleto')",
+  "context": "2-3 linhas ligando causa-raiz a impacto de receita",
+  "numbered_reasons": ["(1) evidência do vazamento", "(2) causa-raiz", "(3) quick win que destrava"],
+  "discussion_anchor": "Por que o stakeholder precisa aprovar este quick win antes de escalar mídia"
+}
+```
+
+Se a auditoria revelou ausência de ativos críticos (sem site, GMB sem reviews, redes zeradas), inclua `honesty_alert`.
+
+## Auto-validação
+
+Antes de mostrar ao operador, verifique:
+
+- [ ] Mencionou o cliente pelo nome?
+- [ ] Usou dados reais do client.json (não inventou)?
+- [ ] Nenhum item genérico (ex: "quer crescer", "qualidade e compromisso")?
+- [ ] Schema da skill validou?
+- [ ] Todos os campos do schema preenchidos (ou com `null` + `unavailable_reason` no pai)?
+- [ ] Nenhuma string vazia (`""`) — substituí por `null` + reason quando o dado não existe?
+- [ ] Estimativas marcadas com `estimated: true` ou `[E]`?
+- [ ] Consistente com outputs anteriores (ICP, posicionamento)?
+- [ ] Cada gap tem evidência concreta (não opinião vaga)?
+- [ ] Quick wins são realmente executáveis em < 1 semana sem custo?
+- [ ] Scores por canal estão calibrados (nem tudo é 50/100)?
+- [ ] `competitor_benchmark` tem 2-3 grupos e tabela canal-a-canal com melhor prática observada e oportunidade específica?
+- [ ] `journey_friction_map` mapeia o funil completo com leakage_pct e root_cause para cada estágio?
+- [ ] `biggest_leakage_summary` identifica QUAL estágio é o maior buraco (com número)?
+- [ ] `tone_of_voice_analysis` compara brand voice declarada vs atual por canal, com coherence_score final?
+- [ ] `url_audit` lista todas as URLs críticas com verify_checklist?
+- [ ] Tem `summary_headline` específico?
+- [ ] `summary_highlights` tem 4-6 itens com categorias e tons válidos?
+- [ ] `summary_key_findings` cobre pelo menos 3 dos 4 tipos?
+- [ ] Identificou `key_insight` (maior vazamento + quick win)?
+- [ ] Se há fragilidade estrutural (ativos faltando), incluiu `honesty_alert`?
+
+Se falhou → regenere silenciosamente. Não avise o operador.
+
+## Apresentação e decisões
+
+Apresente o output COMPLETO ao operador — auditoria canal por canal com scores, matriz de gaps, resumo executivo e quick wins.
+
+Revise o output. O que está errado, exagerado ou faltando?
+
+- "Algum canal que eu avaliei de forma que não condiz com a realidade?"
+- "Tem algum canal adicional que deveria ser auditado? (YouTube, TikTok, LinkedIn, etc.)"
+- "A priorização faz sentido?"
+- "Algum gap que é mais urgente do que parece por contexto que eu não conheço?"
+- "Esses quick wins são viáveis no contexto deste cliente?"
+
+## Finalização
+
+Operador aprova (com ou sem ajustes).
+1. Salve em `squads/{squad}/clientes/{cliente}/outputs/account-auditoria-comunicacao.json` (com campo `summary` no topo)
+2. Atualize `client.json`: progress.skills → completed, version++, append em history[]
+3. Salve também uma versão Markdown do entregável na mesma pasta de outputs.
+4. Sugira próxima skill do dependency_graph
+   - "Auditoria salva. Os gaps identificados serão endereçados na produção da Semana 3: designer-manual-marca, designer-landing-page, copy-anuncios."
+   - "Os quick wins podem ser implementados AGORA enquanto as próximas skills são executadas."
+   - Sugira a próxima skill (se semana 1 ainda não completou, sugira as faltantes)

--- a/.claude/skills/account-auditoria-comunicacao/references/checklist-auditoria-por-canal.md
+++ b/.claude/skills/account-auditoria-comunicacao/references/checklist-auditoria-por-canal.md
@@ -1,0 +1,319 @@
+# Checklist de Auditoria por Canal
+
+Checklist detalhado para auditar cada ponto de contato digital. Use como base para atribuir scores e identificar gaps.
+
+---
+
+## Canal 1: Site / Landing Page
+
+### 1.1 Primeira Dobra (Above the Fold)
+
+| # | Item | O que verificar | Peso |
+|---|------|-----------------|------|
+| 1 | Proposta de valor | Visitante entende em 5 segundos o que o negocio faz e para quem? | Alto |
+| 2 | Headline | E especifica, orientada a beneficio, e fala com o ICP? | Alto |
+| 3 | Subheadline | Complementa a headline com detalhe ou prova? | Medio |
+| 4 | CTA principal | Visivel sem scroll? Texto e acao clara (nao "Saiba mais")? | Alto |
+| 5 | Imagem/video hero | Representa o publico-alvo ou o resultado? (nao stock generico) | Medio |
+| 6 | Navegacao | Simples, sem excesso de opcoes? Facilita encontrar o que importa? | Baixo |
+
+### 1.2 Prova Social
+
+| # | Item | O que verificar | Peso |
+|---|------|-----------------|------|
+| 7 | Depoimentos | Tem? Com nome + foto + resultado especifico? | Alto |
+| 8 | Quantidade | Pelo menos 3 depoimentos? | Medio |
+| 9 | Diversidade | Depoimentos de perfis diferentes (segmentos, tamanhos)? | Baixo |
+| 10 | Logos/selos | Clientes conhecidos, certificacoes, premios? | Medio |
+| 11 | Numeros | "500+ clientes", "R$X em resultados" — dados quantificaveis? | Medio |
+| 12 | Rating | Estrelas / nota de satisfacao visivel? | Baixo |
+
+### 1.3 Conteudo e Estrutura
+
+| # | Item | O que verificar | Peso |
+|---|------|-----------------|------|
+| 13 | Beneficios | Lista beneficios (nao features)? Fala a lingua do ICP? | Alto |
+| 14 | Objecoes | Trata as principais objecoes do ICP na pagina? | Alto |
+| 15 | Como funciona | Explica o processo em 3-4 etapas simples? | Medio |
+| 16 | Pricing | Se aplicavel, precos claros? Ou pelo menos "a partir de"? | Medio |
+| 17 | FAQ | Responde as perguntas mais comuns? | Medio |
+| 18 | Garantia/risco | Tem garantia, trial, ou reducao de risco? | Medio |
+
+### 1.4 Tecnico
+
+| # | Item | O que verificar | Peso |
+|---|------|-----------------|------|
+| 19 | HTTPS | Site seguro (cadeado)? | Alto |
+| 20 | Velocidade | Carrega em menos de 3 segundos? (PageSpeed score > 50 mobile) | Alto |
+| 21 | Mobile | Responsivo? Elementos acessiveis no celular? Texto legivel? | Alto |
+| 22 | Formulario | Se tem, tem poucos campos? (nome + telefone/email minimo) | Medio |
+| 23 | WhatsApp float | Botao de WhatsApp visivel e funcionando? | Medio |
+| 24 | Pixel/Tag | Meta Pixel e Google Tag instalados? (verificar via extensao) | Alto |
+
+### 1.5 SEO Basico
+
+| # | Item | O que verificar | Peso |
+|---|------|-----------------|------|
+| 25 | Title tag | Existe, tem ate 60 caracteres, inclui palavra-chave? | Alto |
+| 26 | Meta description | Existe, tem ate 155 caracteres, e persuasiva? | Medio |
+| 27 | H1 | Unico, relevante, contem palavra-chave principal? | Alto |
+| 28 | URLs amigaveis | Sem parametros estranhos, com palavras-chave? | Baixo |
+| 29 | Alt text | Imagens tem alt text descritivo? | Baixo |
+| 30 | Sitemap | Sitemap.xml existe e esta enviado ao Search Console? | Baixo |
+
+### Tabela de Scoring — Site
+
+| Score | Criterio |
+|-------|----------|
+| 0-20 | Site nao existe, esta fora do ar, ou e tao ruim que prejudica a marca |
+| 21-40 | Site existe mas sem proposta de valor clara, sem CTA, sem prova social, lento |
+| 41-60 | Site funcional: tem proposta, CTA, e alguma prova social. Mobile OK mas nao otimizado |
+| 61-80 | Site bom: proposta clara, CTAs estrategicos, prova social forte, rapido, mobile-first |
+| 81-100 | Site excelente: otimizado para conversao, A/B testado, tracking completo, experiencia premium |
+
+---
+
+## Canal 2: Instagram
+
+### 2.1 Perfil/Bio
+
+| # | Item | O que verificar | Peso |
+|---|------|-----------------|------|
+| 1 | Foto de perfil | Profissional? Logo ou rosto reconhecivel? Visivel em tamanho pequeno? | Medio |
+| 2 | Nome | Contem o nome do negocio + palavra-chave? (ex: "Dr. Paulo \| Dentista Curitiba") | Alto |
+| 3 | Bio - O que faz | Claro em 1 linha o que o negocio faz? | Alto |
+| 4 | Bio - Para quem | Fala para quem e o servico/produto? | Alto |
+| 5 | Bio - Diferencial | Tem algo que diferencia dos concorrentes? | Medio |
+| 6 | Bio - CTA | Tem CTA claro? ("Agende", "Compre", "Fale conosco") | Alto |
+| 7 | Link | Link funcional na bio? (Linktree, site, WhatsApp) | Alto |
+| 8 | Categoria | Categoria correta do perfil business? | Baixo |
+| 9 | Contato | Botoes de contato configurados (telefone, email, endereco)? | Medio |
+
+### 2.2 Feed
+
+| # | Item | O que verificar | Peso |
+|---|------|-----------------|------|
+| 10 | Consistencia visual | Paleta de cores consistente? Estilo reconhecivel? | Alto |
+| 11 | Qualidade das imagens | Profissionais ou amadoras? Boa iluminacao e composicao? | Alto |
+| 12 | Variedade de formatos | Usa estático + carrossel + Reels? Ou so 1 formato? | Medio |
+| 13 | Frequencia | Quantos posts por semana? Consistente ou irregular? | Alto |
+| 14 | Grid | Grid visualmente harmonioso (nao precisa ser perfeito, mas coerente)? | Baixo |
+
+### 2.3 Conteudo
+
+| # | Item | O que verificar | Peso |
+|---|------|-----------------|------|
+| 15 | Hooks nas legendas | Primeira linha prende atencao? Gera curiosidade? | Alto |
+| 16 | Valor para o ICP | Conteudo e util/relevante para o cliente ideal? | Alto |
+| 17 | Mix de conteudo | Tem educativo + social proof + produto + bastidores + entretenimento? | Medio |
+| 18 | CTAs nos posts | Pede acao? (salvar, compartilhar, comentar, clicar no link) | Alto |
+| 19 | Hashtags | Usa hashtags relevantes? Nao excessivas (5-15)? | Baixo |
+| 20 | Engajamento | Comentarios e likes condizem com o numero de seguidores? | Medio |
+
+### 2.4 Stories e Destaques
+
+| # | Item | O que verificar | Peso |
+|---|------|-----------------|------|
+| 21 | Stories ativos | Posta Stories regularmente? (diariamente e ideal) | Alto |
+| 22 | Destaques organizados | Capas bonitas e nomeadas? | Medio |
+| 23 | Destaques essenciais | Tem: Sobre nos, Servicos/Produtos, Depoimentos, FAQ/Como funciona? | Alto |
+| 24 | Interatividade | Usa enquetes, perguntas, quizzes? | Baixo |
+
+### Tabela de Scoring — Instagram
+
+| Score | Criterio |
+|-------|----------|
+| 0-20 | Perfil inexistente, abandonado (ultimo post 3+ meses), ou tao amador que prejudica |
+| 21-40 | Perfil existe mas bio fraca, feed inconsistente, sem estrategia de conteudo |
+| 41-60 | Perfil ativo: bio OK, feed razoavel, posts regulares. Mas sem estrategia para o ICP |
+| 61-80 | Perfil bom: bio estrategica, feed consistente, conteudo para o ICP, bom engajamento |
+| 81-100 | Perfil excelente: estrategia clara, conteudo premium, community ativa, Reels virais |
+
+---
+
+## Canal 3: Anuncios Ativos
+
+### 3.1 Criativos
+
+| # | Item | O que verificar | Peso |
+|---|------|-----------------|------|
+| 1 | Hook visual | Para o scroll em 1 segundo? Destaca do feed? | Alto |
+| 2 | Texto no criativo | Se tem, e legivel e impactante? (max 20% da area) | Alto |
+| 3 | Formato | Usa formatos variados (video, carrossel, colecao)? | Medio |
+| 4 | Persona visual | Pessoas no criativo representam o ICP? | Alto |
+| 5 | Branding | Logo/cores da marca presentes sem poluir? | Medio |
+
+### 3.2 Copy do Anuncio
+
+| # | Item | O que verificar | Peso |
+|---|------|-----------------|------|
+| 6 | Hook textual | Primeira linha prende (pergunta, numero, provocacao)? | Alto |
+| 7 | Dor/Ganho | Menciona dor ou ganho especifico do ICP? | Alto |
+| 8 | Prova social | Inclui numero, depoimento, ou resultado no copy? | Medio |
+| 9 | CTA | Claro, especifico, e orientado a acao? | Alto |
+| 10 | Urgencia/escassez | Tem elemento de urgencia quando apropriado? | Baixo |
+
+### 3.3 Estrategia
+
+| # | Item | O que verificar | Peso |
+|---|------|-----------------|------|
+| 11 | Funil | Tem anuncios de topo, meio e fundo? Ou so 1 tipo? | Alto |
+| 12 | Volume | Quantos criativos ativos? (ideal: 5+ por campanha) | Alto |
+| 13 | Teste A/B | Variações de criativo/copy rodando ao mesmo tempo? | Medio |
+| 14 | Coerencia | Anuncio → LP → CTA: jornada coerente? | Alto |
+
+### Tabela de Scoring — Anuncios
+
+| Score | Criterio |
+|-------|----------|
+| 0-20 | Sem anuncios ativos ou 1 anuncio generico rodando ha meses |
+| 21-40 | Poucos anuncios, sem variacao, copy generica, sem hook visual |
+| 41-60 | Anuncios funcionais: hook razoavel, copy com beneficio, mas sem testes ou funil |
+| 61-80 | Anuncios bons: criativos variados, copy especifica para ICP, funil configurado |
+| 81-100 | Anuncios excelentes: framework criativo, testes continuos, funil completo, dados de performance |
+
+---
+
+## Canal 4: Google Meu Negocio (GMB)
+
+### 4.1 Perfil
+
+| # | Item | O que verificar | Peso |
+|---|------|-----------------|------|
+| 1 | Reivindicado | Perfil reivindicado e verificado? | Alto |
+| 2 | Nome | Correto (sem keyword stuffing)? | Medio |
+| 3 | Categoria | Categoria primaria correta? Categorias secundarias relevantes? | Alto |
+| 4 | Descricao | Preenchida, com palavras-chave, orientada ao cliente? | Alto |
+| 5 | Horarios | Atualizados e corretos? Inclui horarios especiais? | Medio |
+| 6 | Telefone | Correto e rastreavel? | Medio |
+| 7 | Site | Link correto para o site? | Medio |
+| 8 | Endereco | Correto, com pin no mapa posicionado certo? | Medio |
+
+### 4.2 Conteudo Visual
+
+| # | Item | O que verificar | Peso |
+|---|------|-----------------|------|
+| 9 | Foto de capa | Profissional e representativa? | Medio |
+| 10 | Fotos do local | Pelo menos 10 fotos profissionais? (fachada, interior, equipe, produtos) | Alto |
+| 11 | Fotos atualizadas | Fotos dos ultimos 6 meses? | Medio |
+| 12 | Videos | Tem video curto do negocio? | Baixo |
+
+### 4.3 Reviews
+
+| # | Item | O que verificar | Peso |
+|---|------|-----------------|------|
+| 13 | Volume | Quantas reviews tem? (benchmark: 50+ e bom, 100+ e otimo) | Alto |
+| 14 | Nota media | Acima de 4.0? Acima de 4.5? | Alto |
+| 15 | Respostas | Negocio responde reviews? Todas ou so algumas? | Alto |
+| 16 | Qualidade das respostas | Respostas personalizadas ou copy-paste? | Medio |
+| 17 | Reviews negativos | Como lida com criticas? Profissional ou defensivo? | Alto |
+| 18 | Recencia | Tem reviews recentes (ultimo mes)? | Medio |
+
+### 4.4 Posts e Atividade
+
+| # | Item | O que verificar | Peso |
+|---|------|-----------------|------|
+| 19 | Posts ativos | Publica posts/updates no GMB? Com que frequencia? | Medio |
+| 20 | Ofertas | Usa funcao de ofertas/eventos? | Baixo |
+| 21 | Perguntas | Respondeu as perguntas dos usuarios? | Medio |
+| 22 | Produtos/servicos | Lista de produtos/servicos preenchida? | Medio |
+
+### Tabela de Scoring — GMB
+
+| Score | Criterio |
+|-------|----------|
+| 0-20 | Nao reivindicado, ou reivindicado mas vazio (sem fotos, sem descricao) |
+| 21-40 | Basico preenchido mas poucas fotos, sem reviews respondidos, sem posts |
+| 41-60 | Perfil completo: fotos, descricao, reviews respondidos. Mas sem posts ativos |
+| 61-80 | Perfil bom: completo + reviews fortes + posts regulares + fotos profissionais |
+| 81-100 | Perfil excelente: domina pack local, 100+ reviews 4.5+, posts semanais, Q&A respondidos |
+
+---
+
+## Canal 5: WhatsApp Business
+
+### 5.1 Configuracao
+
+| # | Item | O que verificar | Peso |
+|---|------|-----------------|------|
+| 1 | Tipo | WhatsApp Business (nao pessoal)? | Alto |
+| 2 | Perfil | Foto profissional, descricao do negocio, endereco, horario? | Medio |
+| 3 | Saudacao | Mensagem automatica de boas-vindas configurada? | Alto |
+| 4 | Ausencia | Mensagem de ausencia configurada fora do horario? | Medio |
+| 5 | Respostas rapidas | Templates de respostas frequentes salvos? | Medio |
+| 6 | Catalogo | Catalogo de produtos/servicos preenchido com fotos e precos? | Medio |
+| 7 | Labels | Etiquetas para organizar conversas (novo lead, em negociacao, cliente)? | Baixo |
+
+### 5.2 Atendimento
+
+| # | Item | O que verificar | Peso |
+|---|------|-----------------|------|
+| 8 | Tempo de resposta | Responde em quanto tempo? (ideal: < 5min em horario comercial) | Alto |
+| 9 | Tom de atendimento | Profissional e alinhado com o tom de voz da marca? | Alto |
+| 10 | Script de qualificacao | Tem perguntas padrao para qualificar o lead? | Alto |
+| 11 | Follow-up | Faz follow-up se o lead nao responde? Em quanto tempo? | Alto |
+| 12 | Encerramento | Fecha o atendimento de forma profissional? Pede feedback? | Baixo |
+
+### 5.3 Integracao
+
+| # | Item | O que verificar | Peso |
+|---|------|-----------------|------|
+| 13 | CRM | Integrado com CRM? Leads sao registrados automaticamente? | Alto |
+| 14 | Multi-atendentes | Tem mais de 1 pessoa atendendo? Como organizam? | Medio |
+| 15 | Automacao | Usa chatbot ou fluxos automatizados? | Medio |
+| 16 | Historico | Mantem historico de conversas organizavel? | Baixo |
+
+### Tabela de Scoring — WhatsApp
+
+| Score | Criterio |
+|-------|----------|
+| 0-20 | WhatsApp pessoal, sem saudacao, sem perfil, atendimento caótico |
+| 21-40 | WhatsApp Business mas sem saudacao, sem catalogo, resposta demorada |
+| 41-60 | Configurado basico: saudacao + catalogo. Mas sem script, sem follow-up padrao |
+| 61-80 | Bom: saudacao + catalogo + script + follow-up. Integrado com CRM |
+| 81-100 | Excelente: automatizado, qualificacao, integrado com CRM, multi-atendente, metricas |
+
+---
+
+## Checklist Transversal: Coerencia entre Canais
+
+Alem de auditar cada canal individualmente, verifique a coerencia ENTRE canais:
+
+| # | Item | O que verificar |
+|---|------|-----------------|
+| 1 | Tom de voz | O tom e consistente no site, Instagram, WhatsApp e GMB? |
+| 2 | Identidade visual | Cores, fontes e estilo sao os mesmos em todos os canais? |
+| 3 | Mensagem | A proposta de valor e a mesma em todos os canais? |
+| 4 | Informacoes | Telefone, endereco, horario sao iguais em todos os canais? |
+| 5 | Links | Todos os links entre canais funcionam? (Instagram → site, GMB → WhatsApp, etc.) |
+| 6 | Jornada | A jornada do lead faz sentido? (viu anuncio → clicou → site → WhatsApp → fechou?) |
+
+Se houver incoerencia entre canais, registre como gap na matriz com impacto ALTO (confunde o cliente e reduz confianca).
+
+---
+
+## Gaps mais Comuns por Tipo de Negocio
+
+### E-commerce
+- Site sem reviews de produto
+- Instagram sem link para produtos especificos (so link geral)
+- Anuncios levam para home em vez de pagina do produto
+- Sem remarketing para abandonadores de carrinho
+
+### Servicos Locais (clinica, escritorio, restaurante)
+- GMB incompleto ou sem reviews respondidos
+- Instagram fala sobre o negocio mas nao para o cliente
+- Site sem agendamento online
+- WhatsApp demora para responder e nao faz follow-up
+
+### Educacao (cursos, escolas)
+- LP sem prova social de resultados de alunos
+- Instagram so posta conteudo educativo, nao converte
+- Sem urgencia/escassez nas ofertas
+- CRM nao faz nurturing de leads frios
+
+### SaaS / Tech
+- Site cheio de features, sem beneficios claros
+- Sem trial ou demonstracao acessivel
+- Conteudo tecnico demais para o decisor (que e gestor, nao tecnico)
+- CTA generico ("Fale conosco" em vez de "Comece seu teste gratis")

--- a/.claude/skills/account-auditoria-comunicacao/references/padrao-output.md
+++ b/.claude/skills/account-auditoria-comunicacao/references/padrao-output.md
@@ -1,0 +1,202 @@
+# Padrão de Output das Skills — V4 Estruturação IA
+
+Este documento define a **estrutura canônica** que todos os outputs de skill devem seguir para renderizar no portal com hierarquia visual consistente. O objetivo é que o operador e o stakeholder final abram qualquer entregável e encontrem o mesmo ritmo: manchete → KPIs → achados categorizados → ponto de alavancagem destacado → detalhes expansíveis.
+
+---
+
+## Princípios
+
+1. **Manchete antes de texto.** Toda skill abre com uma frase única e específica que resume a conclusão. Não é parágrafo, é headline.
+2. **Números em destaque, não escondidos no corpo do texto.** KPIs que importam viram cards. Texto corrido é para contexto, não para fato quantitativo.
+3. **Achados categorizados por intenção.** Cada insight é classificado como `vantagem | contexto | ameaca | acao` — o leitor identifica o tom antes de ler.
+4. **Ponto de alavancagem visualmente isolado.** Toda skill tem UM ponto onde a conversa com o stakeholder precisa acontecer. Esse ponto ganha hero visual (border, gradient, quote destacada).
+5. **Detalhe denso → colapsável.** Listas longas (concorrentes, itens de checklist, fontes) ficam em `<details>` para não afogar a leitura.
+
+---
+
+## Campos obrigatórios no JSON
+
+Todo output de skill DEVE ter estes campos no topo (antes dos campos específicos da skill):
+
+```json
+{
+  "client_name": "Nome do Cliente",
+  "summary": "Resumo em 1-2 frases. Específico, com dados reais. Alimenta o resumo executivo do portal.",
+
+  "summary_headline": "Manchete em 1 linha (max 120 caracteres). A frase que o stakeholder lê primeiro.",
+
+  "summary_highlights": [
+    {
+      "category": "posicao | competicao | janela | maturidade | oportunidade | risco",
+      "label": "Rótulo curto (max 30 char)",
+      "value": "Valor em destaque (número, %, status)",
+      "subtext": "Contexto em 1 linha (max 60 char)",
+      "tone": "green | yellow | red | blue | gray"
+    }
+  ],
+
+  "summary_key_findings": [
+    {
+      "category": "vantagem | contexto | ameaca | acao",
+      "text": "Achado em 1-2 linhas. Específico, acionável."
+    }
+  ]
+}
+```
+
+### Regras dos campos de summary
+
+**`summary_headline`**: É a ÚNICA frase que o stakeholder precisa ler se só tiver 5 segundos. Deve conter o veredito da skill. Exemplos bons:
+- ✓ "[Cliente] é o ÚNICO player premium da microrregião com [diferencial declarado] — janela competitiva de 12-18 meses."
+- ✗ "Análise de mercado concluída com sucesso."
+
+**`summary_highlights`** (4-6 itens): KPIs visuais. Categorias sugeridas:
+- `posicao` — onde o cliente está hoje vs potencial
+- `competicao` — quem disputa o mesmo espaço
+- `janela` — tempo/urgência
+- `maturidade` — estágio atual em algum eixo
+- `oportunidade` — tamanho do ganho possível
+- `risco` — tamanho da ameaça
+
+Agrupar de 2 em 2 por categoria no renderer (dá layout balanceado 3x2 ou 2x2).
+
+**`summary_key_findings`** (3-5 itens): Achados que embasam a manchete. Categorias:
+- `vantagem` (✓ verde) — o que o cliente tem a favor
+- `contexto` (i azul) — o que é fato do mercado, neutro
+- `ameaca` (! vermelho) — o que pode dar errado
+- `acao` (▸ laranja) — o que precisa ser feito
+
+---
+
+## Ponto de Alavancagem (hero block)
+
+Toda skill deve identificar **UM bloco que merece destaque visual especial** — o ponto onde a conversa estratégica precisa acontecer. O nome do campo varia por skill, mas a estrutura é consistente:
+
+```json
+{
+  "key_leverage_point": {
+    "headline": "Frase-manchete do ponto (pode ir como quote)",
+    "context": "Contexto em 2-3 linhas explicando o cenário",
+    "numbered_reasons": [
+      "Razão 1 (parse-friendly, pode começar com texto direto)",
+      "Razão 2",
+      "Razão 3"
+    ],
+    "discussion_anchor": "Frase curta sobre POR QUE este é o ponto de conversa com o stakeholder"
+  }
+}
+```
+
+Exemplos por skill:
+- `pesquisa-mercado` → `unexploited_opportunity` (whitespace estratégico)
+- `persona-icp` → persona principal + dor mais ignorada
+- `swot` → combinação força × oportunidade mais assimétrica
+- `posicionamento` → PUV vs alternativas descartadas
+- `diagnostico-midia` → canal mais subotimizado + upside estimado
+- `diagnostico-maturidade` → pilar mais fraco com maior impacto
+
+O renderer aplica:
+- Border verde 2px + gradient sutil
+- Selo "Whitespace Estratégico · Discussão com Stakeholder" no topo
+- Pill de viabilidade/urgência à direita
+- Quote/headline em card branco isolado
+- Razões numeradas em 3 círculos
+- Footer "💬 Momento de validar com a stakeholder"
+
+---
+
+## Alerta de honestidade
+
+Se a pesquisa/análise revelou fragilidade do cliente (não há diferencial real, ICP mal definido, mercado saturado, etc.), inclua:
+
+```json
+{
+  "honesty_alert": "Texto explicando a fragilidade encontrada e o que precisa ser feito antes de seguir."
+}
+```
+
+Esse campo renderiza em box amarelo/vermelho após os achados. **Nunca omita** se a realidade justifica. O valor do sistema depende de não vender aspiracional como real.
+
+---
+
+## Instrução para a IA da skill
+
+Em cada `SKILL.md`, incluir esta seção na geração:
+
+> ### Estrutura visual (obrigatória)
+>
+> Além dos campos específicos desta skill, gere SEMPRE:
+>
+> - `summary_headline` — manchete em 1 linha com o veredito
+> - `summary_highlights` — 4-6 KPIs categorizados (`posicao|competicao|janela|maturidade|oportunidade|risco`) com `{label, value, subtext, tone}`
+> - `summary_key_findings` — 3-5 achados categorizados (`vantagem|contexto|ameaca|acao`)
+> - `honesty_alert` se houver fragilidade
+>
+> Identifique o **ponto de alavancagem** desta skill (o bloco que merece hero visual) e estruture-o com headline + contexto + razões numeradas + discussion anchor.
+>
+> Consulte `references/padrao-output.md` para especificação completa.
+
+E na auto-validação:
+
+> - [ ] Tem `summary_headline` específico (não "análise concluída")?
+> - [ ] `summary_highlights` tem 4-6 itens com categorias válidas?
+> - [ ] `summary_key_findings` cobre pelo menos 3 dos 4 tipos (vantagem/contexto/ameaça/ação)?
+> - [ ] Identificou o ponto de alavancagem para discussão com stakeholder?
+> - [ ] Se há fragilidade, incluiu `honesty_alert`?
+
+---
+
+## Completude (regra crítica)
+
+**Todo campo definido no schema da skill é obrigatório no output.** Não omitir campos — o renderer assume que os campos do schema existem e quebra/fica vazio silenciosamente quando faltam.
+
+Se um dado **não pode ser obtido** (GA4 não instalado, conector não conectado, cliente não sabe, etc.), preencher com `null` E adicionar `unavailable_reason` no objeto pai:
+
+```json
+{
+  "current_conversion_rate": null,
+  "current_bounce_rate": null,
+  "avg_time_on_page": null,
+  "unavailable_reason": "GA4 não instalado no site — métricas de analytics não coletadas nesta auditoria"
+}
+```
+
+Para arrays vazios legitimamente (ex: nenhum competidor identificado), preencher com `[]` e adicionar uma nota no campo irmão `{campo}_note`:
+
+```json
+{
+  "competitors": [],
+  "competitors_note": "Nenhum concorrente direto identificado na microrregião após busca em Google Maps + Instagram."
+}
+```
+
+Para valores **estimados** (sem fonte pública), adicionar flag `[E]` no texto OU campo `estimated: true` no objeto:
+
+```json
+{ "tam_brl": 450000000, "estimated": true, "estimation_basis": "IBGE população × SEBRAE ticket médio" }
+```
+
+**Nunca** deixar string vazia (`""`), zero falso (`0` quando não é zero real), ou omitir o campo. Essas três formas são invisíveis para o renderer e geram o bug "coluna vazia".
+
+Valide o JSON contra o `schema.json` empacotado na skill e corrija campos ausentes ou `null` sem `unavailable_reason`.
+
+### Checklist adicional de auto-validação
+
+> - [ ] Todos os campos do schema estão presentes (preenchidos ou com `null` + `unavailable_reason`)?
+> - [ ] Nenhuma string vazia (`""`) — substituí por `null` + reason quando o dado não existe?
+> - [ ] Arrays vazios legítimos têm `{campo}_note` explicando por quê?
+> - [ ] Estimativas marcadas com `estimated: true` ou `[E]`?
+
+---
+
+## Tons de voz
+
+- `green` — oportunidade/vantagem/confirmado
+- `yellow` — atenção/potencial/médio
+- `red` — risco/ameaça/fraco
+- `blue` — contexto/informativo/neutro
+- `gray` — desativado/aspiracional/ausente
+
+Usar tons consistentemente: nunca pintar ameaça de verde ou vantagem de vermelho para "chamar atenção". O tom é semântico.
+
+---

--- a/.claude/skills/account-auditoria-comunicacao/schema.json
+++ b/.claude/skills/account-auditoria-comunicacao/schema.json
@@ -1,0 +1,800 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "AuditoriaComunicacao",
+  "description": "Output estruturado da skill auditoria-comunicacao: auditoria por canal, matriz de gaps e quick wins.",
+  "type": "object",
+  "required": [
+    "summary",
+    "channels_audited",
+    "gap_matrix",
+    "executive_summary",
+    "quick_wins",
+    "client_name",
+    "summary_headline",
+    "summary_highlights",
+    "summary_key_findings"
+  ],
+  "properties": {
+    "client_name": {
+      "type": "string",
+      "description": "Nome do cliente — sempre presente em todo output."
+    },
+    "summary": {
+      "type": "string",
+      "description": "Resumo de 1-2 frases da auditoria. Usado como referência rápida por outras skills."
+    },
+    "summary_headline": {
+      "type": "string",
+      "maxLength": 200,
+      "description": "Manchete em 1 linha com o veredito desta skill (hero do resumo executivo no portal). Ver references/padrao-output.md"
+    },
+    "summary_highlights": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 8,
+      "description": "KPIs visuais categorizados para o resumo executivo. Cada item: {category, label, value, subtext, tone}.",
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "label",
+          "value"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "posicao",
+              "competicao",
+              "janela",
+              "maturidade",
+              "oportunidade",
+              "risco"
+            ]
+          },
+          "label": {
+            "type": "string",
+            "maxLength": 40
+          },
+          "value": {
+            "type": "string"
+          },
+          "subtext": {
+            "type": "string",
+            "maxLength": 80
+          },
+          "tone": {
+            "type": "string",
+            "enum": [
+              "green",
+              "yellow",
+              "red",
+              "blue",
+              "gray"
+            ]
+          }
+        }
+      }
+    },
+    "summary_key_findings": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 6,
+      "description": "Achados categorizados por intenção (vantagem/contexto/ameaça/ação). Pelo menos 3 dos 4 tipos cobertos.",
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "text"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "vantagem",
+              "contexto",
+              "ameaca",
+              "acao"
+            ]
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "icp_reference": {
+      "type": "string",
+      "description": "Resumo do ICP usado como referência para avaliar alinhamento da comunicação."
+    },
+    "channels_audited": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "score",
+          "gaps",
+          "recommendations"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Nome do canal auditado (ex: 'site', 'instagram', 'google_meu_negocio', 'whatsapp', 'anuncios')."
+          },
+          "url_or_handle": {
+            "type": "string",
+            "description": "URL ou handle do canal auditado."
+          },
+          "score": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 100,
+            "description": "Score do canal (0-100)."
+          },
+          "classification": {
+            "type": "string",
+            "enum": [
+              "critical",
+              "low",
+              "medium",
+              "good",
+              "excellent"
+            ],
+            "description": "Classificação do canal."
+          },
+          "screenshots_analyzed": {
+            "type": "boolean",
+            "description": "Se screenshots foram fornecidos e analisados para este canal."
+          },
+          "audit_details": {
+            "type": "object",
+            "description": "Detalhes da auditoria específicos por canal.",
+            "properties": {
+              "value_proposition": {
+                "type": "object",
+                "properties": {
+                  "present": {
+                    "type": "boolean"
+                  },
+                  "clear": {
+                    "type": "boolean"
+                  },
+                  "aligned_with_icp": {
+                    "type": "boolean"
+                  },
+                  "notes": {
+                    "type": "string"
+                  }
+                }
+              },
+              "social_proof": {
+                "type": "object",
+                "properties": {
+                  "present": {
+                    "type": "boolean"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "quality": {
+                    "type": "string",
+                    "enum": [
+                      "none",
+                      "weak",
+                      "moderate",
+                      "strong"
+                    ]
+                  },
+                  "notes": {
+                    "type": "string"
+                  }
+                }
+              },
+              "cta": {
+                "type": "object",
+                "properties": {
+                  "present": {
+                    "type": "boolean"
+                  },
+                  "visible": {
+                    "type": "boolean"
+                  },
+                  "action_oriented": {
+                    "type": "boolean"
+                  },
+                  "notes": {
+                    "type": "string"
+                  }
+                }
+              },
+              "visual_consistency": {
+                "type": "object",
+                "properties": {
+                  "consistent": {
+                    "type": "boolean"
+                  },
+                  "professional": {
+                    "type": "boolean"
+                  },
+                  "notes": {
+                    "type": "string"
+                  }
+                }
+              },
+              "mobile_experience": {
+                "type": "object",
+                "properties": {
+                  "responsive": {
+                    "type": "boolean"
+                  },
+                  "speed": {
+                    "type": "string"
+                  },
+                  "notes": {
+                    "type": "string"
+                  }
+                }
+              },
+              "content_quality": {
+                "type": "object",
+                "properties": {
+                  "speaks_to_icp": {
+                    "type": "boolean"
+                  },
+                  "frequency": {
+                    "type": "string"
+                  },
+                  "engagement_level": {
+                    "type": "string"
+                  },
+                  "notes": {
+                    "type": "string"
+                  }
+                }
+              },
+              "additional_notes": {
+                "type": "string",
+                "description": "Observações adicionais específicas do canal."
+              }
+            }
+          },
+          "gaps": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "gap",
+                "impact"
+              ],
+              "properties": {
+                "gap": {
+                  "type": "string",
+                  "description": "Descrição específica do gap encontrado."
+                },
+                "evidence": {
+                  "type": "string",
+                  "description": "Evidência concreta do gap (o que foi observado)."
+                },
+                "impact": {
+                  "type": "string",
+                  "enum": [
+                    "high",
+                    "medium",
+                    "low"
+                  ],
+                  "description": "Impacto na conversão/resultado."
+                }
+              }
+            },
+            "description": "Gaps identificados neste canal."
+          },
+          "recommendations": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "action",
+                "priority"
+              ],
+              "properties": {
+                "action": {
+                  "type": "string",
+                  "description": "Ação recomendada para corrigir o gap."
+                },
+                "priority": {
+                  "type": "string",
+                  "enum": [
+                    "immediate",
+                    "short_term",
+                    "medium_term"
+                  ],
+                  "description": "Quando implementar."
+                },
+                "effort": {
+                  "type": "string",
+                  "enum": [
+                    "low",
+                    "medium",
+                    "high"
+                  ],
+                  "description": "Esforço para implementar."
+                }
+              }
+            },
+            "description": "Recomendações para este canal."
+          }
+        }
+      },
+      "description": "Auditoria detalhada de cada canal digital."
+    },
+    "gap_matrix": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "rank",
+          "channel",
+          "gap",
+          "impact",
+          "effort",
+          "recommended_action"
+        ],
+        "properties": {
+          "rank": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Posição na prioridade."
+          },
+          "channel": {
+            "type": "string",
+            "description": "Canal onde o gap foi encontrado."
+          },
+          "gap": {
+            "type": "string",
+            "description": "Descrição do gap."
+          },
+          "impact": {
+            "type": "string",
+            "enum": [
+              "high",
+              "medium",
+              "low"
+            ],
+            "description": "Impacto na conversão."
+          },
+          "effort": {
+            "type": "string",
+            "enum": [
+              "low",
+              "medium",
+              "high"
+            ],
+            "description": "Esforço para resolver."
+          },
+          "recommended_action": {
+            "type": "string",
+            "description": "Ação recomendada."
+          },
+          "quadrant": {
+            "type": "string",
+            "enum": [
+              "quick_win",
+              "strategic_project",
+              "fill_time",
+              "deprioritize"
+            ],
+            "description": "Classificação na matriz impacto x esforço."
+          }
+        }
+      },
+      "description": "Matriz consolidada de todos os gaps, priorizada por impacto x esforço."
+    },
+    "executive_summary": {
+      "type": "object",
+      "required": [
+        "top_problems",
+        "overall_assessment"
+      ],
+      "properties": {
+        "overall_assessment": {
+          "type": "string",
+          "description": "Avaliação geral da comunicação digital do cliente (1-2 parágrafos)."
+        },
+        "top_problems": {
+          "type": "array",
+          "minItems": 3,
+          "maxItems": 3,
+          "items": {
+            "type": "object",
+            "required": [
+              "problem",
+              "evidence",
+              "impact",
+              "action"
+            ],
+            "properties": {
+              "problem": {
+                "type": "string",
+                "description": "Descrição do problema."
+              },
+              "evidence": {
+                "type": "string",
+                "description": "Evidência concreta."
+              },
+              "impact": {
+                "type": "string",
+                "description": "Impacto estimado na conversão/resultado."
+              },
+              "action": {
+                "type": "string",
+                "description": "Ação para resolver."
+              }
+            }
+          },
+          "description": "Top 3 problemas de comunicação que mais custam conversão."
+        },
+        "communication_score": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100,
+          "description": "Score geral de comunicação (média dos canais auditados)."
+        }
+      }
+    },
+    "competitor_benchmark": {
+      "type": "object",
+      "description": "Benchmark canal-a-canal contra grupos de concorrentes.",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "groups": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "name"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "members": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "positioning": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "benchmark_by_channel": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "channel"
+            ],
+            "properties": {
+              "channel": {
+                "type": "string"
+              },
+              "client_score": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 100,
+                "description": "Score do cliente (0-100). Nome preferido."
+              },
+              "best_in_class_score": {
+                "type": "number",
+                "description": "Score do melhor concorrente do grupo."
+              },
+              "competitor_avg_score": {
+                "type": "number",
+                "description": "Alternativa: média dos concorrentes. O renderer aceita best_in_class_score OU competitor_avg_score."
+              },
+              "gap": {
+                "type": "number",
+                "description": "Diferença entre best_in_class e client_score."
+              },
+              "best_practice_observed": {
+                "type": "string",
+                "description": "O que o melhor concorrente faz (específico). Nome preferido."
+              },
+              "evidence": {
+                "type": "string",
+                "description": "Alternativa a best_practice_observed — evidência concreta observada."
+              },
+              "opportunity_for_client": {
+                "type": "string",
+                "description": "Como o cliente pode fechar o gap (específico, não genérico). Nome preferido."
+              },
+              "immediate_win": {
+                "type": "string",
+                "description": "Alternativa a opportunity_for_client — ganho imediato possível."
+              }
+            }
+          }
+        },
+        "strategic_read": {
+          "type": "string"
+        }
+      }
+    },
+    "journey_friction_map": {
+      "type": "object",
+      "description": "Mapa de fricção do funil real da persona, estágio a estágio.",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "stages": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "stage"
+            ],
+            "properties": {
+              "stage": {
+                "type": "string"
+              },
+              "current_volume": {
+                "type": [
+                  "number",
+                  "string"
+                ]
+              },
+              "leakage_pct": {
+                "type": "number",
+                "description": "% que vaza para o próximo estágio."
+              },
+              "root_cause": {
+                "type": "string"
+              },
+              "fix_effort": {
+                "type": "string",
+                "enum": [
+                  "low",
+                  "medium",
+                  "high"
+                ]
+              },
+              "fix_impact_estimate": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "biggest_leakage_summary": {
+          "type": "string"
+        },
+        "projected_funnel_90d_realistic": {
+          "type": "string"
+        }
+      }
+    },
+    "tone_of_voice_analysis": {
+      "type": "object",
+      "description": "Auditoria de coerência do tom de voz entre canais.",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "brand_voice_target": {
+          "type": "object",
+          "properties": {
+            "pillars": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "avoid": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "channel_drift": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "channel"
+            ],
+            "properties": {
+              "channel": {
+                "type": "string"
+              },
+              "actual_tone": {
+                "type": "string",
+                "description": "Como soa hoje (com exemplo citado). Nome preferido."
+              },
+              "current_tone": {
+                "type": "string",
+                "description": "Alternativa a actual_tone."
+              },
+              "alignment_score": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 100,
+                "description": "Score numérico 0-100. Opcional se target_alignment for usado."
+              },
+              "target_alignment": {
+                "type": "string",
+                "enum": [
+                  "alinhado",
+                  "aligned",
+                  "bom",
+                  "boa",
+                  "good",
+                  "parcial",
+                  "partial",
+                  "media",
+                  "média",
+                  "medium",
+                  "baixa",
+                  "baixo",
+                  "low",
+                  "desalinhado",
+                  "misaligned",
+                  "critico",
+                  "crítico",
+                  "nenhum",
+                  "none",
+                  "nao",
+                  "não"
+                ],
+                "description": "Alinhamento qualitativo com a brand voice. O renderer do portal mapeia para score (alinhado=100, bom=80, parcial/média=55, baixa=25, desalinhado=20, crítico=10, nenhum=0). Preferido sobre alignment_score numérico por ser mais legível."
+              },
+              "drift_notes": {
+                "type": "string",
+                "description": "Onde desalinhou. Nome preferido."
+              },
+              "gap": {
+                "type": "string",
+                "description": "Alternativa a drift_notes — descrição do gap observado."
+              },
+              "fix": {
+                "type": "string",
+                "description": "Correção sugerida. Se presente, o renderer exibe como ação complementar ao drift_notes."
+              },
+              "example": {
+                "type": "string",
+                "description": "Citação textual do canal que ilustra o drift."
+              }
+            }
+          }
+        },
+        "coherence_score": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100
+        }
+      }
+    },
+    "url_audit": {
+      "type": "object",
+      "description": "Lista de URLs críticas a verificar pelo operador.",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "urls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "url",
+              "purpose"
+            ],
+            "properties": {
+              "url": {
+                "type": "string"
+              },
+              "purpose": {
+                "type": "string"
+              },
+              "status_expected": {
+                "type": "string"
+              },
+              "verify_checklist": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "quick_wins": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 5,
+      "items": {
+        "type": "object",
+        "required": [
+          "action",
+          "channel",
+          "time_estimate",
+          "expected_impact"
+        ],
+        "properties": {
+          "action": {
+            "type": "string",
+            "description": "Ação concreta passo a passo."
+          },
+          "channel": {
+            "type": "string",
+            "description": "Canal onde implementar."
+          },
+          "time_estimate": {
+            "type": "string",
+            "description": "Tempo estimado para implementar (ex: '1h', '30min', '2h')."
+          },
+          "expected_impact": {
+            "type": "string",
+            "description": "O que melhora com essa ação."
+          },
+          "who_does_it": {
+            "type": "string",
+            "enum": [
+              "operator",
+              "client",
+              "client_team",
+              "designer"
+            ],
+            "description": "Quem implementa."
+          },
+          "steps": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Passos detalhados para implementar."
+          }
+        }
+      },
+      "description": "Ações implementáveis em menos de 1 semana sem custo adicional."
+    },
+    "key_insight": {
+      "type": "object",
+      "description": "Ponto de alavancagem desta skill — o bloco que merece destaque visual para conversa com o stakeholder. Ver PADRAO-OUTPUT.md.",
+      "properties": {
+        "headline": {
+          "type": "string",
+          "description": "Frase-manchete do ponto (pode virar quote destacada no renderer)"
+        },
+        "context": {
+          "type": "string",
+          "description": "Contexto em 2-3 linhas explicando o cenário"
+        },
+        "numbered_reasons": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Razões numeradas (o renderer vira 3 cards numerados)"
+        },
+        "discussion_anchor": {
+          "type": "string",
+          "description": "Por que este é o ponto para stakeholder decidir/validar"
+        }
+      }
+    },
+    "honesty_alert": {
+      "type": "string",
+      "description": "Alerta se a análise revelou fragilidade real do cliente (não há diferencial claro, premissa contraditória, etc.). Nunca omitir se justificado."
+    }
+  }
+}

--- a/.claude/skills/account-cliente-oculto/SKILL.md
+++ b/.claude/skills/account-cliente-oculto/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: account-cliente-oculto
+description: "Simulacao de cliente oculto: cria perfil de comprador ficticio, operador executa no canal real, IA analisa a conversa e gera relatorio com nota 0-10. Use quando o operador disser 'cliente oculto', 'mystery shopping', 'testar atendimento', 'simular compra', ou na Semana 3 do modelo Inside Sales (POP 3.2)."
+area: account
+author: luizfreitasv4
+version: 1.0.0
+dependencies:
+  - geral-persona-icp
+outputs: ["account-cliente-oculto.json"]
+week: 3
+modelo_venda: inside-sales
+estimated_time: "1.5h"
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta versao foi portada do sistema de Estruturacao Estrategica. As regras abaixo tem precedencia sobre caminhos e persistencia citados no fluxo original:
+
+- Trabalhe somente em `squads/{squad}/clientes/{cliente}/`, nunca em um diretorio `clientes/` solto na raiz.
+- Leia primeiro o `CLAUDE.md` ou `AGENTS.md` da KB, `mission-control/`, `calls/`, `docs/` e `campanhas/`.
+- Se `client.json` existir, use-o como fonte complementar. Se nao existir, derive o contexto da KB e do Mission Control; nao exija nem invente esse arquivo.
+- Salve entregaveis em `squads/{squad}/clientes/{cliente}/outputs/`, em JSON e Markdown quando o fluxo pedir ambos.
+- Registre decisoes e progresso no `mission-control/historico-checkins.md` ou no arquivo de historico equivalente encontrado na KB.
+- Resolva recursos empacotados a partir do proprio diretorio desta skill. Se uma integracao externa nao estiver configurada, declare o gap e continue apenas com os dados reais disponiveis.
+
+
+# Cliente Oculto (POP 3.2 — Inside Sales)
+
+Voce e um especialista em avaliacao de experiencia de compra e mystery shopping. Vai criar um cenario de simulacao realista para testar o atendimento comercial do cliente e, apos a execucao pelo operador, analisar a conversa gerando um relatorio detalhado com nota e recomendacoes.
+
+> **Posição no fluxo:** Semana 3, cabeça do modelo **Inside Sales** (POP 3.2). Roda **antes** do Diagnóstico Comercial (3.3) — é um input independente que mede a realidade do atendimento; o comercial usa esses achados. Mínimo 3-5 simulações em horários variados.
+
+## Dados necessários
+
+1. `client.json` (seção `briefing`) — NOME_CLIENTE, PRODUTO_SERVICO, CANAL_CONTATO
+2. `outputs/geral-persona-icp.json` — RESUMO_ICP, perfil demografico, comportamento
+3. `outputs/account-diagnostico-comercial.json` — **se já existir** (opcional; normalmente o cliente oculto roda antes do comercial)
+4. `client.json` (seção `connectors`) — dados adicionais de canais
+
+Confirme com o operador:
+
+> Vamos criar e executar um cliente oculto para {NOME_CLIENTE}.
+> Canal principal: {CANAL — WhatsApp / formulario / email / Instagram DM}
+> Correto? IMPORTANTE: voce (operador) vai executar a simulacao manualmente. Eu crio o roteiro e depois analiso.
+
+---
+
+## Geração
+
+Gere o output COMPLETO de uma vez: perfil do comprador + script da simulação. Use os dados de `client.json` (briefing) e outputs de skills dependentes em `outputs/`.
+
+Consulte `references/criterios-avaliacao-cliente-oculto.md` para os criterios de avaliação.
+
+### Perfil do comprador simulado
+
+- Nome fictício, contexto plausível e específico
+- Urgência (alta/média/baixa) com motivo
+- Budget declarado (como/quando mencionar)
+- Objeção principal (alinhada ao diagnóstico)
+- Nível de conhecimento do produto
+
+### Script da simulação
+
+**Mensagem de abertura:** como o ICP real enviaria
+**Mensagens de acompanhamento:** se não houver resposta (30min, 2h)
+**4 perguntas para fazer ao longo da conversa:** cada uma testando uma dimensão (conhecimento do produto, objeção de preço, urgência/follow-up, personalização)
+**Comportamento do comprador:** atraso de resposta, cautela, objeção de preço na proposta, "vou pensar" para testar follow-up
+
+Apresente ao operador e peça validação de que é realista.
+
+### Execução (MANUAL pelo operador)
+
+> **ATENCAO: Esta etapa e MANUAL.** Voce (operador) executa a simulação seguindo o roteiro.
+>
+> **Instrucoes:**
+> 1. Use numero/conta que NÃO esteja associado a V4 ou ao seu nome
+> 2. Siga o roteiro mas adapte naturalmente
+> 3. Anote tempos exatos de cada resposta
+> 4. Documente TODA a conversa (print ou cópia)
+> 5. NÃO revele que é teste
+> 6. Se pedirem dados sensíveis, invente dados fictícios
+>
+> Cole aqui o histórico completo com horários quando terminar.
+
+Aguarde o operador executar e colar o histórico.
+
+### Análise da conversa e relatório
+
+Após receber o histórico, analise e gere o relatório:
+
+**Nota geral: X/10** (EXCELENTE 9-10 / BOM 7-8 / REGULAR 5-6 / RUIM 3-4 / CRITICO 0-2)
+
+**7 critérios avaliados:**
+1. Tempo de primeira resposta (meta: < 5 min)
+2. Qualidade da abordagem inicial
+3. Identificação de necessidade
+4. Conhecimento do produto
+5. Tratamento de objeção de preço
+6. CTA e tentativa de avançar o funil
+7. Follow-up após conversa
+
+Para cada: nota 0-10 + observação + evidência (trecho da conversa).
+
+**Pontos fortes** (com evidência)
+**Pontos críticos** (em ordem de impacto, com: problema, impacto estimado, como o SDR IA vai resolver)
+
+**Impacto estimado do SDR IA:**
+- Tempo de resposta: de {atual} para < 5 segundos
+- Taxa de contato: de {atual}% para {projeção}%
+- Taxa de qualificação: de {atual}% para {projeção}%
+- Impacto financeiro: +R${valor}/mês
+
+## Auto-validação
+
+Antes de mostrar ao operador, verifique:
+
+- [ ] Mencionou o cliente pelo nome?
+- [ ] Usou dados reais (não inventou)?
+- [ ] Perfil é realista (time não perceberá que é teste)?
+- [ ] Critérios de avaliação são justos e baseados em evidência?
+- [ ] Impacto do SDR IA é realista (não exagerado)?
+
+Se falhou → regenere silenciosamente. Não avise o operador.
+
+## Apresentação e decisões
+
+Apresente o relatório COMPLETO ao operador.
+
+Revise o output. O que está errado, exagerado ou faltando?
+
+- "O relatorio reflete fielmente o que voce observou?"
+- "Algum detalhe que interpretei errado?"
+- "Os pontos criticos estao na ordem certa de impacto?"
+
+## Finalização
+
+Operador aprova (com ou sem ajustes).
+1. Salve em `squads/{squad}/clientes/{cliente}/outputs/account-cliente-oculto.json` (com campo `summary` no topo)
+2. Atualize `client.json`: progress.skills → completed, version++, append em history[]
+3. Salve também uma versão Markdown do entregável na mesma pasta de outputs.
+4. Sugira a próxima skill com base nas dependências do frontmatter e no estado da KB
+   - "Cliente oculto concluido. Nota: {X}/10. Pontos criticos: {lista}."
+   - Sugira: `/account-diagnostico-comercial` (3.3) — usa estes achados para cravar o gargalo e calibrar a qualificação.
+
+**NOTA:** O relatório pode ser compartilhado com o cliente como evidência do valor do SDR IA. O contraste "antes vs depois" é poderoso.

--- a/.claude/skills/account-cliente-oculto/references/criterios-avaliacao-cliente-oculto.md
+++ b/.claude/skills/account-cliente-oculto/references/criterios-avaliacao-cliente-oculto.md
@@ -1,0 +1,205 @@
+# Criterios de Avaliacao — Cliente Oculto
+
+Framework completo para avaliacao de mystery shopping em PMEs brasileiras. Cada criterio tem peso, escala de nota, e exemplos concretos de cada faixa de avaliacao.
+
+---
+
+## Criterio 1: Tempo de Primeira Resposta
+
+**Peso:** 20% da nota final
+**Meta:** < 5 minutos
+
+| Nota | Tempo | Descricao |
+|------|-------|-----------|
+| 10 | < 1 minuto | Resposta quase instantanea. Impressiona o lead. |
+| 9 | 1-3 minutos | Muito rapido. Lead ainda esta quente e engajado. |
+| 8 | 3-5 minutos | Dentro da meta. Aceitavel para a maioria dos segmentos. |
+| 7 | 5-10 minutos | Ligeiramente acima da meta. Lead ainda esta no celular. |
+| 6 | 10-15 minutos | Comeca a perder atencao. Lead pode estar vendo concorrente. |
+| 5 | 15-30 minutos | Problematico. Lead provavelmente ja enviou mensagem para outro. |
+| 4 | 30-60 minutos | Ruim. Lead ja esta em outra atividade. |
+| 3 | 1-2 horas | Muito ruim. Lead precisa ser re-engajado. |
+| 2 | 2-4 horas | Critico. Lead provavelmente ja comprou do concorrente. |
+| 1 | 4-24 horas | Inaceitavel. Demonstra total falta de processo. |
+| 0 | > 24 horas ou sem resposta | O lead foi perdido. |
+
+**O que observar:**
+- A resposta foi automatica (chatbot) ou humana?
+- Se automatica, era util ou so "aguarde que ja iremos atende-lo"?
+- O lead precisou mandar mais de uma mensagem para ser atendido?
+
+**Impacto real:** Pesquisas mostram que a chance de qualificar um lead cai 10x se o contato for feito apos 5 minutos vs nos primeiros 5 minutos (estudo InsideSales/Harvard Business Review). Em WhatsApp, o efeito e ainda mais dramatico porque o lead espera resposta imediata.
+
+---
+
+## Criterio 2: Qualidade da Abordagem Inicial
+
+**Peso:** 15% da nota final
+
+| Nota | Descricao | Exemplo |
+|------|-----------|---------|
+| 9-10 | Personalizada, calorosa, com pergunta de contexto. Se apresentou pelo nome. | "Oi, Marcos! Sou a Ana da [empresa]. Vi que voce tem interesse em [produto]. Me conta um pouco da sua situacao — em que posso te ajudar?" |
+| 7-8 | Boa abordagem, se apresentou, mas poderia ser mais personalizada. | "Ola, tudo bem? Sou o Pedro da [empresa]. Como posso te ajudar?" |
+| 5-6 | Generica mas educada. Nao se apresentou ou nao fez pergunta. | "Ola, obrigado pelo contato! Segue nosso catalogo." |
+| 3-4 | Fria ou mecanica. Parece copiar e colar. | "Boa tarde. Qual servico deseja?" |
+| 1-2 | Rude, confusa ou incoerente. | "Oi" (e espera o lead puxar a conversa) |
+| 0 | Nao houve abordagem. Lead nao foi respondido. | — |
+
+**O que observar:**
+- O atendente se apresentou pelo nome?
+- Usou o nome do lead (se disponivel)?
+- Fez alguma pergunta para entender o contexto?
+- A mensagem era personalizada ou copy-paste?
+- O tom era coerente com o tipo de negocio?
+- Enviou audio, texto, ou figurinha? (audio sem contexto e negativo)
+
+---
+
+## Criterio 3: Identificacao de Necessidade
+
+**Peso:** 15% da nota final
+
+| Nota | Descricao | Sinais |
+|------|-----------|--------|
+| 9-10 | Fez perguntas abertas e especificas para entender a real necessidade. Escutou antes de vender. | Perguntas como "qual seu objetivo principal?", "o que te motivou a procurar isso agora?", "ja tentou resolver de outra forma?" |
+| 7-8 | Fez perguntas, mas poderiam ser mais profundas. | Perguntas genericas como "o que voce precisa?" sem aprofundar |
+| 5-6 | Fez 1-2 perguntas basicas e ja partiu para a apresentacao. | "Voce quer o servico X ou Y?" e ja enviou proposta |
+| 3-4 | Nao perguntou nada. Apresentou o produto direto. | Mandou catalogo/precos sem perguntar o que o lead precisa |
+| 1-2 | Ignorou o que o lead disse e falou de outra coisa. | Lead fala do problema, atendente responde com promocao |
+| 0 | Nao houve interacao suficiente para avaliar. | — |
+
+**O que observar:**
+- Quantas perguntas foram feitas antes de apresentar o produto?
+- As perguntas eram abertas ou fechadas?
+- O atendente ouviu as respostas e adaptou a abordagem?
+- Houve empatia com a situacao do lead?
+- O atendente tentou entender o "por que agora?" (timing da necessidade)
+
+---
+
+## Criterio 4: Conhecimento do Produto
+
+**Peso:** 10% da nota final
+
+| Nota | Descricao | Sinais |
+|------|-----------|--------|
+| 9-10 | Domina o produto, responde com seguranca, usa exemplos e casos. | "No caso de academias, o que funciona melhor e [X] porque [motivo com exemplo real]." |
+| 7-8 | Conhece bem, responde sem hesitar, mas sem exemplos. | Respostas corretas e seguras, porem teoricas |
+| 5-6 | Conhece o basico, hesita em detalhes. | "Acho que sim... vou confirmar com a equipe." |
+| 3-4 | Pouco conhecimento, da respostas vagas. | "Temos varios pacotes, vou te mandar o material." |
+| 1-2 | Nao sabe sobre o produto, da informacao errada. | Respostas confusas ou contraditorias |
+| 0 | Nao demonstrou nenhum conhecimento. | Nao respondeu perguntas sobre o produto |
+
+**O que observar:**
+- O atendente sabia responder sem precisar "verificar"?
+- Usou termos tecnicos de forma acessivel ou confundiu o lead?
+- Conseguiu comparar opcoes/pacotes com clareza?
+- Usou exemplos ou casos de sucesso para ilustrar?
+- As informacoes dadas sao consistentes (nao se contradizem)?
+
+---
+
+## Criterio 5: Tratamento de Objecao de Preco
+
+**Peso:** 15% da nota final
+
+| Nota | Descricao | Sinais |
+|------|-----------|--------|
+| 9-10 | Reconheceu a objecao, demonstrou valor antes de falar em preco, usou ROI ou comparacao. | "Entendo a preocupacao. Olha, o Joao tinha a mesma dúvida e em 2 meses recuperou o investimento porque [resultado]." |
+| 7-8 | Boa resposta, demonstrou valor, mas poderia ser mais especifica. | "O valor reflete [beneficio], e a maioria dos clientes veem retorno em [prazo]." |
+| 5-6 | Tentou justificar, mas ficou na superficie. Ou foi direto para desconto. | "O preco e justo pelo que oferecemos" ou "posso ver um desconto" |
+| 3-4 | Ficou defensivo ou desconfortavel com a objecao. | "E esse o preco, nao tem como mudar" ou silencio constrangedor |
+| 1-2 | Deu desconto imediatamente sem justificar. Ou ignorou a objecao. | "Te faco por X, pode ser?" (sem perguntar por que achou caro) |
+| 0 | Nao houve objecao de preco (lead nao chegou a esse ponto) ou atendente sumiu. | — |
+
+**O que observar:**
+- O atendente perguntou POR QUE achou caro? (comparando com o que?)
+- Tentou entender se e falta de budget ou falta de valor percebido?
+- Usou prova social (outros clientes, resultados)?
+- Fez ancoragem de preco (mostrou o custo da inacao)?
+- Ofereceu alternativas antes de desconto (plano menor, parcelamento)?
+- Se deu desconto, condicionou a algo (fechar agora, contrato maior)?
+
+---
+
+## Criterio 6: CTA e Tentativa de Avancar o Funil
+
+**Peso:** 15% da nota final
+
+| Nota | Descricao | Sinais |
+|------|-----------|--------|
+| 9-10 | Propoe proximo passo claro e especifico, com data/horario. | "Que tal a gente marcar uma conversa de 15 minutos amanha as 14h pra eu entender melhor e montar uma proposta personalizada?" |
+| 7-8 | Propoe proximo passo, mas sem data especifica. | "Vou te mandar uma proposta, pode ser?" |
+| 5-6 | Tentativa timida de avancar. | "Se quiser, posso te mandar mais informacoes." |
+| 3-4 | Nao propoe proximo passo. Deixa na mao do lead. | "Qualquer dúvida, estou a disposicao." |
+| 1-2 | Encerra a conversa sem CTA. | "Ok, obrigado pelo contato." |
+| 0 | Conversa morreu sem conclusao. | Atendente parou de responder |
+
+**O que observar:**
+- Houve tentativa de agendar proxima interacao?
+- O CTA era especifico (data, horario, canal)?
+- O atendente usou senso de urgencia apropriado?
+- Houve alguma oferta ou condicao para incentivar acao?
+- O lead saiu sabendo o que acontece a seguir?
+
+---
+
+## Criterio 7: Follow-up Apos Conversa
+
+**Peso:** 10% da nota final
+
+| Nota | Descricao | Tempo |
+|------|-----------|-------|
+| 9-10 | Follow-up proativo com valor agregado em 1-2 horas. | "Oi Marcos, lembrei que voce perguntou sobre [X]. Separei esse caso aqui que e parecido com o seu." |
+| 7-8 | Follow-up em ate 24 horas com conteudo relevante. | "Oi, continuando nossa conversa de ontem, montei uma proposta personalizada pra voce." |
+| 5-6 | Follow-up generico em 24-48 horas. | "Oi, tudo bem? Pensou na proposta?" |
+| 3-4 | Follow-up apenas apos 3+ dias. | "Ola, ainda tem interesse?" (4 dias depois) |
+| 1-2 | Nenhum follow-up em 1 semana. | — |
+| 0 | Nenhum follow-up em 2+ semanas. Lead esquecido. | — |
+
+**O que observar:**
+- Houve follow-up sem o lead pedir?
+- O follow-up tinha valor (conteudo, proposta) ou era so cobranca?
+- O tom era natural ou robótico/automatizado?
+- Usou alguma informacao da conversa anterior?
+- Quantas tentativas de follow-up foram feitas?
+
+---
+
+## Formula de Calculo da Nota Final
+
+```
+Nota final = (C1 x 0.20) + (C2 x 0.15) + (C3 x 0.15) + (C4 x 0.10) + (C5 x 0.15) + (C6 x 0.15) + (C7 x 0.10)
+```
+
+### Classificacao
+
+| Nota | Classificacao | Descricao |
+|------|---------------|-----------|
+| 9.0 - 10.0 | Excelente | Atendimento de referencia. Poucas melhorias necessarias. |
+| 7.0 - 8.9 | Bom | Atendimento competente. Melhorias pontuais. |
+| 5.0 - 6.9 | Regular | Funciona, mas perde vendas por falta de processo. SDR IA tera alto impacto. |
+| 3.0 - 4.9 | Ruim | Processo quebrado. Leads estao sendo desperdicados. SDR IA e urgente. |
+| 0.0 - 2.9 | Critico | Atendimento inexistente ou prejudicial. Cada dia sem SDR IA e dinheiro perdido. |
+
+---
+
+## Erros Comuns que Invalidam a Simulacao
+
+1. **Usar numero/conta associado a V4:** O time pode reconhecer e dar tratamento VIP
+2. **Perfil muito diferente do ICP:** O atendimento pode ser diferente para um perfil que nao e o publico-alvo
+3. **Revelar que e teste antes de terminar:** Invalida completamente os dados
+4. **Nao registrar horarios:** Sem horarios, nao da para avaliar tempo de resposta
+5. **Simular apenas em horario comercial pico:** Teste em horarios variados revela realidade
+6. **Desistir cedo demais:** A simulacao deve ir ate o ponto de proposta de valor/preco
+
+---
+
+## Dicas para Simulacao Realista
+
+1. **Use linguagem natural do ICP:** Se o ICP e informal, escreva com gíria/abreviacao. Se e formal, escreva formalmente.
+2. **Responda com atraso realista:** Um lead real nao responde instantaneamente a cada mensagem.
+3. **Demonstre hesitacao real:** Faca perguntas que um comprador cauteloso faria.
+4. **Nao facilite:** Se o atendente nao perguntar algo, nao ofereça a informacao espontaneamente.
+5. **Teste o "vou pensar":** Essa frase e o teste definitivo — o follow-up (ou falta dele) revela muito.
+6. **Documente tudo:** Print de tela com horarios visíveis e a melhor evidencia.

--- a/.claude/skills/account-cliente-oculto/schema.json
+++ b/.claude/skills/account-cliente-oculto/schema.json
@@ -1,0 +1,352 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ClienteOculto",
+  "description": "Output estruturado da skill cliente-oculto: simulacao de mystery shopping com perfil do comprador, script de simulacao e avaliacao detalhada.",
+  "type": "object",
+  "required": [
+    "summary",
+    "buyer_profile",
+    "simulation_script",
+    "evaluation",
+    "client_name",
+    "summary_headline",
+    "summary_highlights",
+    "summary_key_findings"
+  ],
+  "properties": {
+    "client_name": {
+      "type": "string",
+      "description": "Nome do cliente — sempre presente em todo output."
+    },
+    "summary": {
+      "type": "string",
+      "description": "Resumo executivo de 2-3 frases: nota geral, principal ponto forte, principal ponto critico e impacto estimado do SDR IA."
+    },
+    "summary_headline": {
+      "type": "string",
+      "description": "Manchete em 1 linha (~120 caracteres) com o veredito da skill."
+    },
+    "summary_highlights": {
+      "type": "array",
+      "description": "KPIs em destaque (4-6 itens). Categorias: posicao | competicao | janela | maturidade | oportunidade | risco.",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "label",
+          "value",
+          "tone"
+        ],
+        "properties": {
+          "category": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "subtext": {
+            "type": "string"
+          },
+          "tone": {
+            "type": "string",
+            "enum": [
+              "green",
+              "yellow",
+              "red",
+              "blue",
+              "gray"
+            ]
+          }
+        }
+      }
+    },
+    "summary_key_findings": {
+      "type": "array",
+      "description": "3-5 achados categorizados (vantagem | contexto | ameaca | acao).",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "text"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "vantagem",
+              "contexto",
+              "ameaca",
+              "acao"
+            ]
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "buyer_profile": {
+      "type": "object",
+      "required": [
+        "name",
+        "situation",
+        "urgency",
+        "budget",
+        "main_objection"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Nome ficticio do comprador simulado."
+        },
+        "situation": {
+          "type": "string",
+          "description": "Contexto plausivel que justifica o interesse no produto/servico."
+        },
+        "urgency": {
+          "type": "string",
+          "enum": [
+            "high",
+            "medium",
+            "low"
+          ],
+          "description": "Nivel de urgencia do comprador simulado."
+        },
+        "urgency_reason": {
+          "type": "string",
+          "description": "Motivo concreto da urgencia (ou falta dela)."
+        },
+        "budget": {
+          "type": "string",
+          "description": "Budget declarado ou implicito do comprador simulado."
+        },
+        "main_objection": {
+          "type": "string",
+          "description": "Objecao principal que sera levantada durante a simulacao."
+        },
+        "knowledge_level": {
+          "type": "string",
+          "enum": [
+            "low",
+            "medium",
+            "high"
+          ],
+          "description": "Nivel de conhecimento do comprador sobre o produto/servico."
+        }
+      }
+    },
+    "simulation_script": {
+      "type": "object",
+      "required": [
+        "opening_message",
+        "followup_30min",
+        "followup_2h",
+        "questions"
+      ],
+      "properties": {
+        "opening_message": {
+          "type": "string",
+          "description": "Mensagem de abertura natural que o ICP real enviaria."
+        },
+        "followup_30min": {
+          "type": "string",
+          "description": "Mensagem de follow-up caso nao haja resposta em 30 minutos."
+        },
+        "followup_2h": {
+          "type": "string",
+          "description": "Mensagem de follow-up caso nao haja resposta em 2 horas."
+        },
+        "questions": {
+          "type": "array",
+          "minItems": 3,
+          "items": {
+            "type": "object",
+            "required": [
+              "question",
+              "objective"
+            ],
+            "properties": {
+              "question": {
+                "type": "string",
+                "description": "Pergunta que o comprador simulado fara."
+              },
+              "objective": {
+                "type": "string",
+                "description": "O que essa pergunta testa (conhecimento do produto, objecao de preco, follow-up, etc.)."
+              }
+            }
+          },
+          "description": "Perguntas estrategicas para testar diferentes aspectos do atendimento."
+        },
+        "buyer_behavior_rules": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Regras de comportamento do comprador simulado (atraso de resposta, cautela, etc.)."
+        }
+      }
+    },
+    "simulation_metadata": {
+      "type": "object",
+      "properties": {
+        "date": {
+          "type": "string",
+          "format": "date",
+          "description": "Data da simulacao (ISO 8601)."
+        },
+        "channel": {
+          "type": "string",
+          "description": "Canal onde a simulacao foi executada (WhatsApp, formulario, email, Instagram DM)."
+        },
+        "attendant_name": {
+          "type": "string",
+          "description": "Nome do atendente que respondeu (ou 'nao se identificou')."
+        },
+        "total_duration_minutes": {
+          "type": "integer",
+          "description": "Duracao total da conversa em minutos."
+        },
+        "conversation_transcript": {
+          "type": "string",
+          "description": "Transcricao completa da conversa com horarios."
+        }
+      }
+    },
+    "evaluation": {
+      "type": "object",
+      "required": [
+        "overall_score",
+        "strengths",
+        "critical_improvements",
+        "sdr_impact_per_improvement"
+      ],
+      "properties": {
+        "overall_score": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 10,
+          "description": "Nota geral de 0 a 10."
+        },
+        "classification": {
+          "type": "string",
+          "enum": [
+            "excellent",
+            "good",
+            "regular",
+            "poor",
+            "critical"
+          ],
+          "description": "Classificacao textual baseada na nota."
+        },
+        "criteria_scores": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "criterion",
+              "score",
+              "observation"
+            ],
+            "properties": {
+              "criterion": {
+                "type": "string",
+                "description": "Nome do criterio avaliado."
+              },
+              "score": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 10,
+                "description": "Nota de 0 a 10 para este criterio."
+              },
+              "observation": {
+                "type": "string",
+                "description": "Observacao detalhada sobre o desempenho neste criterio."
+              },
+              "evidence": {
+                "type": "string",
+                "description": "Trecho da conversa que evidencia a avaliacao."
+              }
+            }
+          },
+          "description": "Notas individuais por criterio de avaliacao."
+        },
+        "strengths": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "description": "Ponto forte observado com evidencia da conversa."
+          },
+          "description": "Lista de pontos fortes identificados no atendimento."
+        },
+        "critical_improvements": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "description": "Ponto critico de melhoria em ordem de impacto."
+          },
+          "description": "Lista de pontos criticos de melhoria ordenados por impacto."
+        },
+        "sdr_impact_per_improvement": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": [
+              "improvement",
+              "sdr_solution",
+              "estimated_impact"
+            ],
+            "properties": {
+              "improvement": {
+                "type": "string",
+                "description": "Ponto critico que o SDR IA vai resolver."
+              },
+              "sdr_solution": {
+                "type": "string",
+                "description": "Como especificamente o SDR IA vai resolver este ponto."
+              },
+              "estimated_impact": {
+                "type": "string",
+                "description": "Impacto estimado da melhoria (ex: '+20% na taxa de contato')."
+              }
+            }
+          },
+          "description": "Mapeamento de como o SDR IA vai resolver cada ponto critico."
+        },
+        "overall_sdr_impact": {
+          "type": "object",
+          "properties": {
+            "response_time_before": {
+              "type": "string",
+              "description": "Tempo de resposta observado na simulacao."
+            },
+            "response_time_after": {
+              "type": "string",
+              "description": "Tempo de resposta projetado com SDR IA (< 5 segundos)."
+            },
+            "contact_rate_before": {
+              "type": "number",
+              "description": "Taxa de contato estimada atual (%)."
+            },
+            "contact_rate_after": {
+              "type": "number",
+              "description": "Taxa de contato projetada com SDR IA (%)."
+            },
+            "financial_impact_monthly": {
+              "type": "number",
+              "description": "Impacto financeiro mensal estimado em reais."
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/.claude/skills/account-crm-setup/SKILL.md
+++ b/.claude/skills/account-crm-setup/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: account-crm-setup
+description: "Configura o CRM Kommo com pipeline personalizado, réguas de boas-vindas e nutrição, e testa com lead fictício. Semi-manual — operador executa no Kommo. Use quando disser /account-crm-setup ou 'configurar CRM' ou 'setup Kommo' ou 'automação de leads'."
+area: account
+author: luizfreitasv4
+version: 1.0.0
+dependencies:
+  - geral-persona-icp
+inputs:
+  - client.json (briefing)
+  - geral-persona-icp.json
+  - designer-manual-marca.json
+output: account-crm-setup.json
+week: 4
+type: semi-manual
+estimated_time: "4h"
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta versao foi portada do sistema de Estruturacao Estrategica. As regras abaixo tem precedencia sobre caminhos e persistencia citados no fluxo original:
+
+- Trabalhe somente em `squads/{squad}/clientes/{cliente}/`, nunca em um diretorio `clientes/` solto na raiz.
+- Leia primeiro o `CLAUDE.md` ou `AGENTS.md` da KB, `mission-control/`, `calls/`, `docs/` e `campanhas/`.
+- Se `client.json` existir, use-o como fonte complementar. Se nao existir, derive o contexto da KB e do Mission Control; nao exija nem invente esse arquivo.
+- Salve entregaveis em `squads/{squad}/clientes/{cliente}/outputs/`, em JSON e Markdown quando o fluxo pedir ambos.
+- Registre decisoes e progresso no `mission-control/historico-checkins.md` ou no arquivo de historico equivalente encontrado na KB.
+- Resolva recursos empacotados a partir do proprio diretorio desta skill. Se uma integracao externa nao estiver configurada, declare o gap e continue apenas com os dados reais disponiveis.
+
+
+# CRM Setup — Pipeline + Réguas de Automação (POP 3.6)
+
+> **Posição no fluxo:** Semana 4 — Identidade de Comunicação e Plano de Mídia (**comum** a todos os modelos) (e-commerce / inside-sales / pdv). É "Implementação **ou** Otimização" — comece classificando o cenário de partida. O pipeline reflete o processo definido nos diagnósticos do modelo; o CRM **espelha** o processo (não o contrário).
+
+Você é um consultor especializado em automação comercial para PMEs brasileiras, com experiência em Kommo CRM. Vai classificar o cenário do cliente, criar/otimizar o pipeline personalizado, templates de mensagem para as réguas de automação (boas-vindas e nutrição), e guiar o operador na configuração — incluindo migração/limpeza de base e governança.
+
+### Cenário de partida (classifique primeiro)
+- **Cenário A — do zero:** sem CRM. Implementar do zero.
+- **Cenário B — subutilizado:** CRM existe mas mal usado. Reconfigurar + adotar.
+- **Cenário C — otimização:** CRM em uso. Otimizar sem ruptura (esgotar otimização antes de propor troca de ferramenta).
+
+## Dados necessários
+
+1. `client.json` (seção `briefing`) — nome, segmento, produto/serviço, processo comercial atual, WhatsApp, CRM atual (se houver)
+2. `outputs/geral-persona-icp.json` — ICP, dores, objeções, linguagem
+3. `outputs/designer-manual-marca.json` — tom de voz, vocabulário (se existir — melhora qualidade)
+4. `client.json` (seção `history`) — decisões anteriores
+
+---
+
+## Geração
+
+Gere o output COMPLETO de uma vez: pipeline + réguas + guia de configuração + checklist de teste. Use os dados de `client.json` (briefing) e outputs de skills dependentes em `outputs/`.
+
+Consulte `references/guia-kommo-setup.md` para referência de configuração.
+
+### Pipeline de vendas (personalizado)
+
+Etapas baseadas no processo comercial do cliente:
+```
+[Etapa 1] → [Etapa 2] → ... → [Fechado-Ganho / Fechado-Perdido]
+```
+Personalize nomes conforme o processo real (ex: "Orçamento Solicitado" em vez de "Proposta Enviada").
+
+### Tags e propriedades
+
+- Origem: Meta Ads | Google Ads | Indicação | Orgânico | Site | WhatsApp
+- Score SDR: 1-5 estrelas
+- Produto de interesse: [do briefing]
+- Temperatura: Frio | Morno | Quente
+
+### Régua 1 — Boas-vindas (3 mensagens automáticas)
+
+*Mensagem 1 (imediata):* Boas-vindas + confirmação + próximo passo. Máx 3 frases.
+*Mensagem 2 (24h sem resposta):* Follow-up leve + conteúdo de valor + CTA suave. Máx 3 frases.
+*Mensagem 3 (48h sem resposta):* Última tentativa + pergunta direta + abertura de saída. Máx 3 frases.
+
+### Régua 2 — Nutrição (4 touchpoints em 30 dias)
+
+Para leads score 1-3 estrelas:
+*Semana 1:* Conteúdo de valor (WhatsApp + Email) — educativo
+*Semana 2:* Caso de sucesso / prova social (WhatsApp + Email) — inspiracional
+*Semana 3:* Diferencial do produto (WhatsApp) — educativo + pitch leve
+*Semana 4:* Oferta / CTA direto (WhatsApp + Email) — direto, urgência real
+
+### Guia de configuração Kommo (passo a passo)
+
+**PASSO 1:** Criar pipeline (Settings > Pipeline). Renomear etapas.
+**PASSO 2:** Configurar tags e campos customizados.
+**PASSO 3:** Configurar Salesbot (boas-vindas) — trigger, condições, mensagens com delays.
+**PASSO 4:** Configurar Salesbot (nutrição) — trigger por score, 4 ações com delays de 7 dias.
+**PASSO 5:** Conectar WhatsApp Business. Testar envio.
+
+### Migração e limpeza de base (Cenários B e C)
+
+Se já existe base/CRM:
+- **Migrar base ativa primeiro**, histórico depois — nunca tudo de uma vez.
+- **Deduplicar, padronizar e enriquecer** antes de importar (sem lixo).
+- Mapear campos antigos → novos; registrar o que não migra e por quê.
+
+### Governança e adoção
+
+- **Campos obrigatórios** por etapa (origem, score, motivo de perda como lista fechada, próximo follow-up).
+- **Dashboards operacionais** (funil, SLA, motivos de perda).
+- **Treinamento + documento de governança** + plano de adoção (o CRM só vale se o time usar).
+
+### Checklist de teste
+
+**TESTE 1: PIPELINE** — criar lead manual, mover por etapas, verificar tags
+**TESTE 2: RÉGUA DE BOAS-VINDAS** — criar lead, verificar 3 mensagens com timings
+**TESTE 3: RÉGUA DE NUTRIÇÃO** — criar lead score baixo, verificar sequência
+**TESTE 4: INTEGRAÇÃO WHATSAPP** — enviar teste, verificar formatação e histórico
+**TESTE 5: CENÁRIO REAL** — submeter formulário, verificar pipeline + tags + salesbot
+
+## Auto-validação
+
+Antes de mostrar ao operador, verifique:
+
+- [ ] Mencionou o cliente pelo nome?
+- [ ] Usou dados reais do client.json (não inventou)?
+- [ ] Nenhum item genérico (ex: "quer crescer", "qualidade e compromisso")?
+- [ ] Schema da skill validou?
+- [ ] Todos os campos do schema preenchidos (ou com `null` + `unavailable_reason` no pai)?
+- [ ] Nenhuma string vazia (`""`) — substituí por `null` + reason quando o dado não existe?
+- [ ] Estimativas marcadas com `estimated: true` ou `[E]`?
+- [ ] Consistente com outputs anteriores (ICP)?
+- [ ] Mensagens de boas-vindas têm máximo 3 frases cada (WhatsApp)?
+- [ ] Régua de nutrição endereça a objeção principal do ICP?
+- [ ] Pipeline reflete o processo real (não genérico)?
+
+Se falhou → regenere silenciosamente. Não avise o operador.
+
+## Apresentação e decisões
+
+Apresente o output COMPLETO ao operador — pipeline, réguas, guia e checklist.
+
+Revise o output. O que está errado, exagerado ou faltando?
+
+- "O pipeline reflete o processo real de vendas? Nomes das etapas fazem sentido?"
+- "As tags cobrem todas as origens de leads?"
+- "O tom das mensagens está natural e alinhado com a marca?"
+- "As mensagens de boas-vindas são curtas o suficiente para WhatsApp?"
+- "A régua de nutrição endereça a objeção principal do ICP?"
+
+**Próximo passo (semi-manual):**
+O operador executa a configuração no Kommo seguindo o guia passo a passo. Após configurar, executa o checklist de teste. Se algum teste falhar, ajude a debugar.
+
+## Finalização
+
+Operador aprova (com ou sem ajustes, após testes passarem).
+1. Salve em `squads/{squad}/clientes/{cliente}/outputs/account-crm-setup.json` (com campo `summary` no topo)
+2. Atualize `client.json`: progress.skills → completed, version++, append em history[]
+3. Salve também uma versão Markdown do entregável na mesma pasta de outputs.
+4. Sugira próxima skill do dependency_graph
+
+## Formato do output (account-crm-setup.json)
+
+```json
+{
+  "pipeline_stages": [{ "order": 1, "name": "Lead", "description": "string", "auto_actions": ["string"] }],
+  "tags": { "origin": ["string"], "score": ["string"], "products": ["string"], "temperature": ["string"] },
+  "welcome_sequence": [{ "order": 1, "timing": "imediata", "channel": "whatsapp", "message": "string" }],
+  "nurture_sequence": [{ "week": 1, "channel": "whatsapp + email", "message_type": "string", "whatsapp_message": "string", "email_subject": "string", "email_body": "string" }],
+  "test_checklist": [{ "test": "Pipeline", "steps": ["string"], "passed": null }]
+}
+```
+
+
+## Campo obrigatório: summary
+
+Sempre inclua no JSON de saída:
+```json
+"summary": "Resumo de 1-2 frases do setup do CRM: número de etapas do pipeline e réguas configuradas. Seja específico — mencione o cliente, números reais e a conclusão principal."
+```
+
+Este campo alimenta o Resumo Executivo do portal de entregas. Deve ser objetivo, com dados reais, sem genéricos.

--- a/.claude/skills/account-crm-setup/references/guia-kommo-setup.md
+++ b/.claude/skills/account-crm-setup/references/guia-kommo-setup.md
@@ -1,0 +1,290 @@
+# Guia de Setup Kommo CRM — Pipeline + Automações para PMEs
+
+Referência técnica para configurar o Kommo CRM como padrão V4 Company. Cobre pipeline, campos customizados, Salesbot e integrações.
+
+---
+
+## 1. Visão Geral do Kommo
+
+O Kommo (ex-amoCRM) é o CRM padrão da V4 Company para clientes PME. Pontos fortes:
+- Integração nativa com WhatsApp Business
+- Salesbot visual (automação sem código)
+- Pipeline visual estilo Kanban
+- Integração com Meta Lead Ads e Google Ads
+
+### Acesso e contas
+- URL: https://www.kommo.com
+- Plano recomendado: Avançado (Salesbot ilimitados)
+- 1 conta por cliente, gerenciada pelo consultor V4
+- WhatsApp Business conectado via integração oficial
+
+---
+
+## 2. Configuração do Pipeline
+
+### Pipeline padrão V4 (adaptar por cliente)
+
+```
+Lead Novo → Em Qualificação → Qualificado → Proposta Enviada → Em Negociação → Fechado-Ganho
+                                                                                → Fechado-Perdido
+```
+
+### Variações comuns por segmento
+
+**Serviços (clínica, escritório, consultoria):**
+```
+Agendamento Solicitado → Consulta Marcada → Proposta Apresentada → Em Decisão → Fechado
+```
+
+**E-commerce com vendedor (high-ticket):**
+```
+Lead → Contato Inicial → Demonstração → Proposta → Negociação → Venda
+```
+
+**Restaurante/Delivery:**
+```
+Contato → Primeiro Pedido → Cliente Recorrente → VIP
+```
+
+### Como criar no Kommo
+
+1. Acesse **Leads** no menu lateral
+2. Clique no ícone de engrenagem do pipeline
+3. Renomeie as etapas existentes clicando no nome
+4. Para adicionar etapa: clique em "+" entre etapas
+5. Para remover: arraste a etapa para a lixeira
+6. **Importante:** Configure "Fechado-Perdido" com campo obrigatório de motivo
+
+---
+
+## 3. Campos Customizados
+
+### Campos obrigatórios para todos os clientes
+
+| Campo | Tipo | Opções | Onde |
+|-------|------|--------|------|
+| Origem | Lista | Meta Ads, Google Ads, Indicação, Orgânico, Site, WhatsApp, Outro | Lead |
+| Score SDR | Lista | 1★, 2★, 3★, 4★, 5★ | Lead |
+| Produto de interesse | Lista | [do briefing] | Lead |
+| Temperatura | Lista | Frio, Morno, Quente | Lead |
+| Motivo de perda | Texto | — | Lead (obrigatório em Fechado-Perdido) |
+
+### Como criar campos customizados
+
+1. Acesse **Configurações** > **Campos**
+2. Clique em **Criar campo**
+3. Selecione tipo (lista, texto, número, etc.)
+4. Preencha as opções
+5. Marque "Obrigatório" se necessário (ex: Motivo de perda)
+
+### Critérios de Score SDR
+
+| Score | Critério | Ação recomendada |
+|-------|----------|------------------|
+| 1★ | Curiosidade passiva, sem urgência, budget baixo | Régua de nutrição |
+| 2★ | Interesse demonstrado, mas sem urgência clara | Régua de nutrição |
+| 3★ | Tem o problema, budget indefinido, prazo indefinido | Follow-up manual em 7 dias |
+| 4★ | Tem problema + budget + prazo definido | Contato imediato do vendedor |
+| 5★ | Pronto para comprar, budget confirmado, urgência alta | Prioridade máxima, atender em minutos |
+
+---
+
+## 4. Salesbot — Régua de Boas-Vindas
+
+### Anatomia do Salesbot
+
+```
+TRIGGER (quando dispara)
+  └── CONDIÇÃO (se X, então)
+       └── AÇÃO (enviar mensagem, mover lead, etc.)
+            └── WAIT (esperar X tempo)
+                 └── CONDIÇÃO (verificar resposta)
+                      └── AÇÃO (próximo passo)
+```
+
+### Configuração passo a passo
+
+**1. Criar novo Salesbot:**
+- Acesse **Salesbot** no menu lateral
+- Clique **Criar novo bot**
+- Nomeie: "Boas-Vindas - [Nome do Cliente]"
+
+**2. Configurar trigger:**
+- Tipo: "Quando um novo lead é criado"
+- Condição adicional: Origem = Meta Ads OU Google Ads OU Site
+- (Isso evita disparar para leads de indicação/orgânico que já estão em contato)
+
+**3. Fluxo do Salesbot:**
+
+```
+[Trigger: Novo lead criado]
+  │
+  ├── [Enviar Mensagem 1 via WhatsApp]
+  │     "Olá {nome}! Recebi seu interesse em [produto].
+  │      Sou [nome], consultor(a) da [empresa].
+  │      Em até 2h vou te enviar mais detalhes. 😊"
+  │
+  ├── [Wait: 24 horas]
+  │
+  ├── [Condição: Lead respondeu?]
+  │     ├── SIM → [Mover para "Em Qualificação"] → [Notificar vendedor]
+  │     └── NÃO → [Enviar Mensagem 2]
+  │                  "Oi {nome}! Passando pra compartilhar algo
+  │                   que pode te ajudar: [conteúdo de valor].
+  │                   Quer que eu explique como funciona?"
+  │
+  ├── [Wait: 48 horas]
+  │
+  ├── [Condição: Lead respondeu?]
+  │     ├── SIM → [Mover para "Em Qualificação"]
+  │     └── NÃO → [Enviar Mensagem 3]
+  │                  "Oi {nome}, última mensagem!
+  │                   Se [resultado] é algo que te interessa,
+  │                   é só responder aqui. Se não for o momento,
+  │                   sem problema — fico por aqui se precisar. 👋"
+  │
+  └── [Após Mensagem 3: Mover para "Lead Frio"] → [Entrar na régua de nutrição]
+```
+
+**4. Variáveis disponíveis no Salesbot:**
+- `{nome}` — nome do lead
+- `{empresa}` — empresa do lead (se preenchido)
+- `{email}` — email do lead
+- `{telefone}` — telefone do lead
+- Campos customizados via `{campo_customizado}`
+
+---
+
+## 5. Salesbot — Régua de Nutrição
+
+### Trigger
+- Lead com score 1-3★
+- Parado na mesma etapa há 7+ dias
+- Não respondeu régua de boas-vindas
+
+### Fluxo
+
+```
+[Trigger: Lead frio parado 7+ dias]
+  │
+  ├── [Semana 1: Conteúdo de Valor]
+  │     WhatsApp: dica prática, dado de mercado
+  │     Email: mini-guia ou artigo
+  │
+  ├── [Wait: 7 dias]
+  │
+  ├── [Semana 2: Caso de Sucesso]
+  │     WhatsApp: história curta de resultado
+  │     Email: case study resumido
+  │
+  ├── [Wait: 7 dias]
+  │
+  ├── [Semana 3: Diferencial]
+  │     WhatsApp: o que diferencia o produto/serviço
+  │
+  ├── [Wait: 7 dias]
+  │
+  ├── [Semana 4: Oferta/CTA]
+  │     WhatsApp: oferta direta ou convite
+  │     Email: oferta com CTA claro
+  │
+  └── [Condição: Respondeu em algum momento?]
+        ├── SIM → [Mover para "Em Qualificação"]
+        └── NÃO → [Mover para "Descartado"] + [Tag: "Nutrição concluída sem resposta"]
+```
+
+---
+
+## 6. Integrações Essenciais
+
+### WhatsApp Business
+
+1. Acesse **Integrações** > procure "WhatsApp"
+2. Existem 2 opções:
+   - **WhatsApp Business API** (via provedor como Gupshup, 360dialog): melhor para volume alto, custa mensalidade
+   - **WhatsApp Web** (via extensão): gratuito, funciona para volume baixo
+3. Para maioria dos clientes PME: WhatsApp Web é suficiente no início
+4. Configure para que mensagens recebidas criem leads automaticamente
+
+### Meta Lead Ads
+
+1. Acesse **Integrações** > procure "Facebook"
+2. Conecte a conta de anúncios do cliente
+3. Mapeie os campos do formulário de lead para os campos do Kommo:
+   - Nome → Nome do lead
+   - Email → Email
+   - Telefone → Telefone
+   - Campo customizado → Tag de produto de interesse
+4. Configure para criar lead automaticamente na etapa "Lead Novo"
+5. Tag automática: "Origem: Meta Ads"
+
+### Google Ads
+
+1. Use integração via Make/Zapier (não há integração nativa direta)
+2. Trigger: Google Ads Lead Form submission
+3. Ação: Criar lead no Kommo
+4. Mapeamento de campos similar ao Meta
+
+---
+
+## 7. Boas Práticas para Mensagens de WhatsApp
+
+### Formatação Kommo WhatsApp
+- **Negrito:** `*texto*`
+- **Itálico:** `_texto_`
+- **Riscado:** `~texto~`
+- **Monoespaçado:** `` ```texto``` ``
+- **Links:** Cole direto (WhatsApp gera preview)
+- **Emojis:** Funcionam normalmente
+
+### Regras de mensagem
+- Máximo 3 frases por mensagem (WhatsApp não é email)
+- Sempre personalize com nome: `{nome}`
+- Horário de envio: 9h-18h dias úteis (respeitar horário comercial)
+- Não enviar mais de 1 mensagem por dia (exceto se o lead responder)
+- Linguagem coloquial-profissional (WhatsApp é informal)
+- CTA claro em cada mensagem (o que a pessoa deve fazer)
+
+### Templates que funcionam
+
+**Boas-vindas:**
+```
+Oi {nome}! 😊
+
+Recebi seu contato sobre [produto/serviço]. Que bom que nos procurou!
+
+Nos próximos minutos, [vendedor] vai entrar em contato pra entender melhor o que você precisa. Até já!
+```
+
+**Follow-up leve:**
+```
+Oi {nome}! Passando pra compartilhar algo rápido:
+
+[Dica/dado relevante em 1-2 frases]
+
+Se quiser saber como aplicar isso no seu [negócio/caso], é só responder aqui. 👇
+```
+
+**Última tentativa:**
+```
+Oi {nome}! Última mensagem, prometo 😄
+
+Se [resultado/benefício] é algo que te interessa, me responde "quero" que eu explico como funciona.
+
+Se não for o momento, sem problema — fico por aqui se precisar!
+```
+
+---
+
+## 8. Checklist de Configuração Completa
+
+- [ ] Pipeline criado com etapas personalizadas
+- [ ] Fechado-Perdido com motivo obrigatório
+- [ ] Campos customizados criados (Origem, Score, Produto, Temperatura)
+- [ ] WhatsApp conectado e testado
+- [ ] Salesbot de boas-vindas configurado e ativo
+- [ ] Salesbot de nutrição configurado e ativo
+- [ ] Integração Meta Lead Ads (se usar Meta)
+- [ ] Integração Google Ads via Make/Zapier (se usar Google)
+- [ ] Teste completo com lead fictício
+- [ ] Vendedor treinado no uso do pipeline

--- a/.claude/skills/account-crm-setup/schema.json
+++ b/.claude/skills/account-crm-setup/schema.json
@@ -1,0 +1,290 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "CRM Setup",
+  "description": "Output estruturado da configuração de CRM Kommo: pipeline, tags, réguas de automação e checklist de teste.",
+  "type": "object",
+  "required": [
+    "summary",
+    "pipeline_stages",
+    "tags",
+    "welcome_sequence",
+    "nurture_sequence",
+    "test_checklist",
+    "client_name",
+    "summary_headline",
+    "summary_highlights",
+    "summary_key_findings"
+  ],
+  "properties": {
+    "client_name": {
+      "type": "string",
+      "description": "Nome do cliente — sempre presente em todo output."
+    },
+    "summary": {
+      "type": "string",
+      "description": "Resumo de 1-2 frases do setup do CRM. Inclui número de etapas do pipeline e réguas configuradas."
+    },
+    "summary_headline": {
+      "type": "string",
+      "description": "Manchete em 1 linha (~120 caracteres) com o veredito da skill."
+    },
+    "summary_highlights": {
+      "type": "array",
+      "description": "KPIs em destaque (4-6 itens). Categorias: posicao | competicao | janela | maturidade | oportunidade | risco.",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "label",
+          "value",
+          "tone"
+        ],
+        "properties": {
+          "category": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "subtext": {
+            "type": "string"
+          },
+          "tone": {
+            "type": "string",
+            "enum": [
+              "green",
+              "yellow",
+              "red",
+              "blue",
+              "gray"
+            ]
+          }
+        }
+      }
+    },
+    "summary_key_findings": {
+      "type": "array",
+      "description": "3-5 achados categorizados (vantagem | contexto | ameaca | acao).",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "text"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "vantagem",
+              "contexto",
+              "ameaca",
+              "acao"
+            ]
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "pipeline_stages": {
+      "type": "array",
+      "description": "Etapas do pipeline de vendas no Kommo.",
+      "minItems": 4,
+      "items": {
+        "type": "object",
+        "required": [
+          "order",
+          "name",
+          "description"
+        ],
+        "properties": {
+          "order": {
+            "type": "integer",
+            "description": "Ordem da etapa no pipeline"
+          },
+          "name": {
+            "type": "string",
+            "description": "Nome da etapa (ex: 'Lead', 'Qualificado')"
+          },
+          "description": {
+            "type": "string",
+            "description": "O que significa estar nesta etapa"
+          },
+          "auto_actions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Ações automáticas disparadas nesta etapa"
+          }
+        }
+      }
+    },
+    "tags": {
+      "type": "object",
+      "required": [
+        "origin",
+        "score",
+        "products",
+        "temperature"
+      ],
+      "properties": {
+        "origin": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Tags de origem do lead"
+        },
+        "score": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Níveis de score SDR"
+        },
+        "products": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Produtos/serviços de interesse"
+        },
+        "temperature": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Temperatura do lead"
+        }
+      }
+    },
+    "welcome_sequence": {
+      "type": "array",
+      "description": "Régua de boas-vindas com 3 mensagens automáticas.",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "order",
+          "timing",
+          "channel",
+          "message"
+        ],
+        "properties": {
+          "order": {
+            "type": "integer",
+            "description": "Ordem da mensagem na sequência"
+          },
+          "timing": {
+            "type": "string",
+            "description": "Quando disparar (ex: 'imediata', '24h_sem_resposta')"
+          },
+          "channel": {
+            "type": "string",
+            "enum": [
+              "whatsapp",
+              "email",
+              "whatsapp + email"
+            ],
+            "description": "Canal de envio"
+          },
+          "message": {
+            "type": "string",
+            "description": "Texto completo da mensagem"
+          }
+        }
+      }
+    },
+    "nurture_sequence": {
+      "type": "array",
+      "description": "Régua de nutrição de 30 dias com 4 touchpoints.",
+      "minItems": 4,
+      "maxItems": 4,
+      "items": {
+        "type": "object",
+        "required": [
+          "week",
+          "channel",
+          "message_type"
+        ],
+        "properties": {
+          "week": {
+            "type": "integer",
+            "description": "Semana do touchpoint (1-4)"
+          },
+          "channel": {
+            "type": "string",
+            "enum": [
+              "whatsapp",
+              "email",
+              "whatsapp + email"
+            ],
+            "description": "Canal de envio"
+          },
+          "message_type": {
+            "type": "string",
+            "enum": [
+              "conteudo_de_valor",
+              "caso_de_sucesso",
+              "diferencial_produto",
+              "oferta_cta"
+            ],
+            "description": "Tipo de conteúdo do touchpoint"
+          },
+          "whatsapp_message": {
+            "type": "string",
+            "description": "Texto da mensagem WhatsApp"
+          },
+          "email_subject": {
+            "type": "string",
+            "description": "Assunto do email (quando aplicável)"
+          },
+          "email_body": {
+            "type": "string",
+            "description": "Corpo do email (quando aplicável)"
+          }
+        }
+      }
+    },
+    "test_checklist": {
+      "type": "array",
+      "description": "Checklist de testes para validar a configuração.",
+      "minItems": 5,
+      "items": {
+        "type": "object",
+        "required": [
+          "test",
+          "steps"
+        ],
+        "properties": {
+          "test": {
+            "type": "string",
+            "description": "Nome do teste"
+          },
+          "steps": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Passos do teste"
+          },
+          "passed": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "Se o teste passou (preenchido pelo operador)"
+          }
+        }
+      }
+    }
+  }
+}

--- a/.claude/skills/account-diagnostico-comercial/SKILL.md
+++ b/.claude/skills/account-diagnostico-comercial/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: account-diagnostico-comercial
+description: "Diagnostico comercial e etapas do funil (Inside Sales): funil mensal + funil estendido, estrutura do time, gargalo primario, mapa de objecoes, criterios de qualificacao 1-5 estrelas e SLA por score. Use quando o operador disser 'diagnostico comercial', 'funil de vendas', 'analise comercial', 'gargalo de vendas', ou na Semana 3 do modelo Inside Sales (POP 3.3)."
+area: account
+author: luizfreitasv4
+version: 1.0.0
+dependencies:
+  - geral-persona-icp
+outputs: ["account-diagnostico-comercial.json"]
+week: 3
+modelo_venda: inside-sales
+estimated_time: "2h"
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta versao foi portada do sistema de Estruturacao Estrategica. As regras abaixo tem precedencia sobre caminhos e persistencia citados no fluxo original:
+
+- Trabalhe somente em `squads/{squad}/clientes/{cliente}/`, nunca em um diretorio `clientes/` solto na raiz.
+- Leia primeiro o `CLAUDE.md` ou `AGENTS.md` da KB, `mission-control/`, `calls/`, `docs/` e `campanhas/`.
+- Se `client.json` existir, use-o como fonte complementar. Se nao existir, derive o contexto da KB e do Mission Control; nao exija nem invente esse arquivo.
+- Salve entregaveis em `squads/{squad}/clientes/{cliente}/outputs/`, em JSON e Markdown quando o fluxo pedir ambos.
+- Registre decisoes e progresso no `mission-control/historico-checkins.md` ou no arquivo de historico equivalente encontrado na KB.
+- Resolva recursos empacotados a partir do proprio diretorio desta skill. Se uma integracao externa nao estiver configurada, declare o gap e continue apenas com os dados reais disponiveis.
+
+
+# Diagnóstico Comercial e Etapas do Funil (POP 3.3 — Inside Sales)
+
+Voce e um consultor especializado em processos comerciais e funis de vendas para PMEs brasileiras. Vai conduzir, junto com o operador, um diagnostico completo do funil de vendas do cliente para identificar gargalos, mapear objecoes e definir os criterios de qualificacao que vao calibrar o SDR IA.
+
+> **Posição no fluxo:** Semana 3, cabeça do modelo **Inside Sales** (POP 3.3). Vem depois do CRO Site/LP (3.1) e do Cliente Oculto (3.2), e alimenta a Definição de Métricas/Critérios do Funil (3.4) e o Pipeline + Script Consultivo (3.5).
+> **IMPORTANCIA:** Os criterios de qualificacao definidos aqui sao usados diretamente nos scripts do SDR IA (cauda da Semana 3) e na configuracao do Patagon. Se os criterios estiverem errados, o SDR vai qualificar errado.
+
+## Dados necessários
+
+1. `client.json` (seção `briefing`) — NOME_CLIENTE, PRODUTO_SERVICO, TICKET_MEDIO
+2. `outputs/geral-persona-icp.json` — RESUMO_ICP, dores, comportamento de compra, objecoes
+3. `client.json` (seção `connectors`) — dados de CRM ou funil se disponíveis
+
+Antes de gerar, pergunte ao operador os dados do funil atual TUDO de uma vez:
+
+> Preciso dos dados do funil de vendas atual de {NOME_CLIENTE}. Me passe:
+> - Quantos leads/mes entram?
+> - Taxa de contato (lead → primeira conversa): X%
+> - Taxa de qualificacao (conversa → proposta): X%
+> - Taxa de fechamento (proposta → venda): X%
+> - Ticket medio real: R$
+> - Ciclo medio de venda (dias): X
+> - Quantos vendedores e perfil de cada?
+> - 5 objecoes mais comuns?
+> - Tem script ou roteiro de vendas hoje?
+>
+> Se nao tem dados exatos, estimativas servem — mas sinalize.
+
+Se o operador nao tiver algum dado, registre como "[estimativa]" ou "[nao disponivel]". NAO invente numeros.
+
+---
+
+## Geração
+
+Gere o output COMPLETO de uma vez usando os dados de `client.json` (briefing, connectors), outputs de skills dependentes, e dados do funil informados pelo operador.
+
+Consulte `references/framework-diagnostico-comercial.md` para benchmarks de conversao por segmento.
+
+### Diagnóstico do funil com taxas vs benchmarks
+
+Para cada etapa (Lead→Contato, Contato→Qualificação, Qualificação→Proposta, Proposta→Fechamento):
+- Taxa atual vs benchmark do setor
+- Gap (pontos percentuais)
+- Status: ACIMA / NO / ABAIXO / CRITICO
+- Gargalo + causa raiz + impacto financeiro estimado
+
+**Gargalo principal:** etapa, motivo, impacto se corrigido.
+
+### Funil estendido (Exposição → Retenção)
+
+Além do funil comercial clássico, mapeie o funil estendido para revelar perdas fora do "miolo" de vendas:
+
+`Exposição → Lead → Contato → Qualificação → Proposta → Fechamento → Onboarding → Retenção/Recompra`
+
+- Para cada etapa: taxa/tempo médio (quando houver dado) e onde o lead **vaza**.
+- Marque as etapas sem instrumentação (sem dado) como `null` + motivo — a ausência de medição já é um achado.
+
+### Estrutura do time comercial
+
+O pipeline tem que caber no time real. Mapeie:
+- **Papéis e quantidade** (SDR, closer, híbrido), **tenure** médio, **capacidade** (leads/vendedor/dia)
+- **Ferramentas e rituais** atuais (CRM, cadência, reuniões de pipeline)
+- **Lacunas** entre a capacidade atual e o volume de leads — isso calibra o SLA e o que dá pra automatizar com o SDR IA.
+
+Estruture em `sales_team_structure`: `{roles:[{role, count, tenure, capacity_note}], tools:[], rituals:[], gaps:[]}`.
+
+### Mapa de objeções
+
+Para CADA objeção (das informadas pelo operador + do ICP):
+- Objeção exata
+- Tipo: PRECO / URGENCIA / AUTORIDADE / CONFIANCA / NECESSIDADE / CONCORRENTE
+- Momento no funil
+- Frequência: ALTA / MEDIA / BAIXA
+- Resposta recomendada (vendedor humano)
+- Prevenção pelo SDR IA
+- Exemplo de conversa (lead + SDR)
+
+**Padrão identificado:** tipo mais frequente, momento mais crítico, objeção que mais mata vendas, recomendação principal.
+
+### Critérios de qualificação 1-5 estrelas
+
+Para cada nível:
+- **5★ (Lead Quente):** perfil + 4 sinais obrigatórios (TODOS presentes) + ação: encaminhar IMEDIATAMENTE
+- **4★ (Qualificado):** perfil + sinais (pelo menos 3/4) + ação: encaminhar em Xh
+- **3★ (Morno):** perfil + sinais (pelo menos 2/4) + ação: régua de nutrição
+- **1-2★ (Frio):** perfil + sinais de desqualificação (qualquer um) + ação: nutrição passiva ou descarte
+
+Com exemplos de lead típico para cada nível e regra de ouro para dúvidas.
+
+### SLA de atendimento por score
+
+- Lead 5★: responder em X MINUTOS, vendedor sênior, WhatsApp direto
+- Lead 4★: responder em X HORAS, vendedor designado
+- Lead 3★: régua automática em Xh, SDR IA/automático
+- Lead 1-2★: descarte gentil ou nutrição passiva
+- Alerta crítico se SLA não cumprido → escalar para responsável
+
+### Plano de ação comercial (5 ações priorizadas)
+
+Para cada: ação específica, responsável, prazo, métrica de sucesso, impacto esperado.
+
+## Auto-validação
+
+Antes de mostrar ao operador, verifique:
+
+- [ ] Mencionou o cliente pelo nome?
+- [ ] Usou dados reais do client.json (não inventou)?
+- [ ] Nenhum item genérico (ex: "quer crescer", "qualidade e compromisso")?
+- [ ] Schema da skill validou?
+- [ ] Todos os campos do schema preenchidos (ou com `null` + `unavailable_reason` no pai)?
+- [ ] Nenhuma string vazia (`""`) — substituí por `null` + reason quando o dado não existe?
+- [ ] Estimativas marcadas com `estimated: true` ou `[E]`?
+- [ ] Consistente com outputs anteriores (ICP)?
+- [ ] Benchmarks são do segmento correto?
+- [ ] Critérios de qualificação são mensuráveis (não vagos)?
+- [ ] SLA é realista para capacidade do time?
+
+Se falhou → regenere silenciosamente. Não avise o operador.
+
+## Apresentação e decisões
+
+Apresente o output COMPLETO ao operador.
+
+Revise o output. O que está errado, exagerado ou faltando?
+
+- "O diagnostico faz sentido com o que voce observa no dia a dia?"
+- "O gargalo principal confere com a percepcao do time de vendas?"
+- "As respostas para objecoes fazem sentido para o tom do cliente?"
+- "Os criterios de qualificacao refletem o que diferencia um lead bom de ruim?"
+- "O SLA e realista para a capacidade do time? O cliente consegue responder em X minutos para 5★?"
+- "As acoes do plano sao factiveis com os recursos atuais?"
+
+## Finalização
+
+Operador aprova (com ou sem ajustes).
+1. Salve em `squads/{squad}/clientes/{cliente}/outputs/account-diagnostico-comercial.json` (com campo `summary` no topo)
+2. Atualize `client.json`: progress.skills → completed, version++, append em history[]
+3. Salve também uma versão Markdown do entregável na mesma pasta de outputs.
+4. Sugira a próxima skill com base nas dependências do frontmatter e no estado da KB
+   - "Diagnostico comercial salvo. Alimenta: etapa de métricas do funil (ainda não portada) (3.4), etapa de pipeline comercial (ainda não portada) (3.5) e os scripts do SDR IA (cauda)."
+   - Sugira: `etapa de métricas do funil (ainda não portada)` (formalizar MQL/SQL/SAL + scoring determinístico).

--- a/.claude/skills/account-diagnostico-comercial/references/framework-diagnostico-comercial.md
+++ b/.claude/skills/account-diagnostico-comercial/references/framework-diagnostico-comercial.md
@@ -1,0 +1,207 @@
+# Framework de Diagnostico Comercial para PMEs Brasileiras
+
+## Benchmarks de Conversao por Segmento
+
+Os benchmarks abaixo sao baseados em dados agregados de PMEs brasileiras atendidas em programas de aceleracao comercial, pesquisas do SEBRAE, RD Station e Resultados Digitais. Use como referencia — ajuste conforme a realidade do segmento e regiao do cliente.
+
+### Servicos Profissionais (Consultorias, Contabilidade, Advocacia, TI)
+| Etapa | Benchmark (mediana) | Faixa aceitavel | Sinal de alerta |
+|-------|---------------------|-----------------|-----------------|
+| Lead → Primeiro Contato | 60-70% | 50-80% | < 45% |
+| Primeiro Contato → Qualificacao | 40-50% | 30-60% | < 25% |
+| Qualificacao → Proposta | 50-65% | 40-70% | < 35% |
+| Proposta → Fechamento | 25-35% | 20-45% | < 15% |
+| **Conversao geral (lead → venda)** | **3-8%** | **2-12%** | **< 1.5%** |
+| Ciclo medio de venda | 15-30 dias | 7-60 dias | > 90 dias |
+
+### E-commerce / Varejo Online
+| Etapa | Benchmark (mediana) | Faixa aceitavel | Sinal de alerta |
+|-------|---------------------|-----------------|-----------------|
+| Visitante → Lead (formulario/WhatsApp) | 2-5% | 1-8% | < 0.8% |
+| Lead → Primeiro Contato | 70-85% | 60-90% | < 50% |
+| Primeiro Contato → Qualificacao | 30-40% | 20-50% | < 15% |
+| Qualificacao → Venda | 15-25% | 10-35% | < 8% |
+| **Conversao geral (lead → venda)** | **3-8%** | **2-12%** | **< 1%** |
+| Ciclo medio de venda | 1-7 dias | mesmo dia-14 dias | > 21 dias |
+
+### Saude e Estetica (Clinicas, Dentistas, Personal Trainers)
+| Etapa | Benchmark (mediana) | Faixa aceitavel | Sinal de alerta |
+|-------|---------------------|-----------------|-----------------|
+| Lead → Primeiro Contato | 65-80% | 55-90% | < 50% |
+| Primeiro Contato → Agendamento | 35-50% | 25-60% | < 20% |
+| Agendamento → Comparecimento | 70-85% | 60-90% | < 55% |
+| Comparecimento → Fechamento | 40-60% | 30-70% | < 25% |
+| **Conversao geral (lead → venda)** | **6-15%** | **4-20%** | **< 3%** |
+| Ciclo medio de venda | 3-14 dias | 1-30 dias | > 45 dias |
+
+### Educacao (Cursos, Escolas, Treinamentos)
+| Etapa | Benchmark (mediana) | Faixa aceitavel | Sinal de alerta |
+|-------|---------------------|-----------------|-----------------|
+| Lead → Primeiro Contato | 55-70% | 45-80% | < 40% |
+| Primeiro Contato → Qualificacao | 35-45% | 25-55% | < 20% |
+| Qualificacao → Proposta/Matricula | 40-55% | 30-65% | < 25% |
+| Proposta → Fechamento | 30-45% | 20-55% | < 15% |
+| **Conversao geral (lead → venda)** | **2-8%** | **1.5-12%** | **< 1%** |
+| Ciclo medio de venda | 7-30 dias | 3-60 dias | > 90 dias |
+
+### Imobiliario (Construtoras, Imobiliarias, Corretores)
+| Etapa | Benchmark (mediana) | Faixa aceitavel | Sinal de alerta |
+|-------|---------------------|-----------------|-----------------|
+| Lead → Primeiro Contato | 50-65% | 40-75% | < 35% |
+| Primeiro Contato → Visita | 20-30% | 15-40% | < 10% |
+| Visita → Proposta | 30-45% | 20-55% | < 15% |
+| Proposta → Fechamento | 15-25% | 10-35% | < 8% |
+| **Conversao geral (lead → venda)** | **0.5-3%** | **0.3-5%** | **< 0.2%** |
+| Ciclo medio de venda | 30-90 dias | 15-180 dias | > 240 dias |
+
+### Alimentacao (Restaurantes, Delivery, Food Service)
+| Etapa | Benchmark (mediana) | Faixa aceitavel | Sinal de alerta |
+|-------|---------------------|-----------------|-----------------|
+| Lead → Primeiro Contato | 75-90% | 65-95% | < 60% |
+| Primeiro Contato → Pedido/Reserva | 40-55% | 30-65% | < 25% |
+| Pedido → Recompra (30 dias) | 25-40% | 15-50% | < 10% |
+| **Conversao geral (lead → primeira compra)** | **20-40%** | **15-50%** | **< 10%** |
+| Ciclo medio de venda | mesmo dia-3 dias | mesmo dia-7 dias | > 14 dias |
+
+### SaaS / Tecnologia B2B
+| Etapa | Benchmark (mediana) | Faixa aceitavel | Sinal de alerta |
+|-------|---------------------|-----------------|-----------------|
+| Lead → MQL | 15-25% | 10-35% | < 8% |
+| MQL → SQL (SDR qualifica) | 30-40% | 20-50% | < 15% |
+| SQL → Demo/Trial | 50-65% | 40-75% | < 35% |
+| Demo → Proposta | 40-55% | 30-65% | < 25% |
+| Proposta → Fechamento | 20-30% | 15-40% | < 12% |
+| **Conversao geral (lead → venda)** | **1-3%** | **0.5-5%** | **< 0.3%** |
+| Ciclo medio de venda | 30-60 dias | 14-120 dias | > 180 dias |
+
+### Servicos Gerais (Dedetizacao, Limpeza, Manutencao, Reformas)
+| Etapa | Benchmark (mediana) | Faixa aceitavel | Sinal de alerta |
+|-------|---------------------|-----------------|-----------------|
+| Lead → Primeiro Contato | 70-85% | 60-90% | < 55% |
+| Primeiro Contato → Orcamento | 45-60% | 35-70% | < 30% |
+| Orcamento → Fechamento | 25-40% | 15-50% | < 12% |
+| **Conversao geral (lead → venda)** | **8-18%** | **5-25%** | **< 4%** |
+| Ciclo medio de venda | 1-7 dias | mesmo dia-14 dias | > 21 dias |
+
+---
+
+## Segmentos Nao Listados
+
+Se o segmento do cliente nao esta acima, use os seguintes benchmarks genericos para PMEs brasileiras e ajuste:
+
+| Etapa | Benchmark generico PME Brasil |
+|-------|-------------------------------|
+| Lead → Primeiro Contato | 60-75% |
+| Primeiro Contato → Qualificacao | 30-45% |
+| Qualificacao → Proposta | 40-55% |
+| Proposta → Fechamento | 20-35% |
+| **Conversao geral** | **3-8%** |
+
+---
+
+## Como Interpretar os Gaps
+
+### Status por gap
+
+| Gap vs benchmark | Status | Acao recomendada |
+|------------------|--------|------------------|
+| +5pp ou mais | Acima do benchmark | Manter e otimizar |
+| -5pp a +5pp | No benchmark | Monitorar, buscar melhoria incremental |
+| -5pp a -15pp | Abaixo do benchmark | Investigar causa raiz, plano de acao |
+| -15pp ou mais | Critico | Acao urgente, prioridade 1 |
+
+### Como calcular impacto financeiro
+
+Formula por etapa:
+```
+Leads perdidos = Volume da etapa x (Benchmark - Taxa atual) / 100
+Receita perdida = Leads perdidos x Taxa conversao restante x Ticket medio
+```
+
+Exemplo:
+- 100 leads/mes, taxa contato atual 45%, benchmark 65%
+- Leads perdidos: 100 x (65-45)/100 = 20 leads
+- Se a conversao restante (contato→venda) e 12% e ticket medio R$2.000
+- Receita perdida: 20 x 0.12 x 2.000 = R$4.800/mes
+
+---
+
+## Classificacao de Objecoes (Taxonomia)
+
+### Tipos de objecao
+
+| Tipo | Descricao | Sinal tipico | Abordagem recomendada |
+|------|-----------|--------------|----------------------|
+| **Preco** | "Ta caro", "Nao tenho orcamento", "O concorrente e mais barato" | Questionamento sobre valores antes de entender a proposta | Demonstrar ROI, comparar custo da inacao, parcelar |
+| **Urgencia** | "Agora nao e o momento", "Vou pensar", "Me liga mes que vem" | Adiamento sem motivo concreto | Criar senso de urgencia real (escassez, sazonalidade, custo de esperar) |
+| **Autoridade** | "Preciso falar com meu socio/esposa", "Quem decide e o diretor" | Envolver terceiro no final do processo | Identificar decisor cedo, pedir para incluir na proxima conversa |
+| **Confianca** | "Nao conheco voces", "Como sei que funciona?", "Tem garantia?" | Ceticismo sobre capacidade/resultado | Cases, depoimentos, garantia, prova social, trial |
+| **Necessidade** | "Nao preciso disso agora", "Ja tenho algo parecido" | Nao reconhece o problema como prioritario | Aprofundar nas dores, mostrar custo da inacao, comparar com alternativa atual |
+| **Concorrente** | "Estou vendo com a empresa X", "Ja uso o concorrente Y" | Comparacao direta com alternativa | Diferenciar sem depreciar, focar no que so voce oferece |
+
+### Momento no funil
+
+| Momento | Objecoes tipicas | Estrategia |
+|---------|------------------|-----------|
+| Primeiro Contato | Necessidade, Confianca | Gerar interesse, nao vender ainda |
+| Qualificacao | Urgencia, Autoridade | Validar timing e decisor |
+| Proposta | Preco, Concorrente | Demonstrar valor e diferenciacao |
+| Negociacao | Preco, Urgencia | Fechar com condicao especial ou prazo |
+
+---
+
+## SLA Recomendado por Tipo de Negocio
+
+### Negocios de ciclo curto (< 7 dias: varejo, alimentacao, servicos)
+| Score | SLA | Justificativa |
+|-------|-----|---------------|
+| 5 estrelas | 5 minutos | Lead quente esfria em minutos |
+| 4 estrelas | 1 hora | Ainda esta comparando, precisa ser rapido |
+| 3 estrelas | 4 horas | Regua automatica suficiente |
+
+### Negocios de ciclo medio (7-30 dias: saude, educacao, servicos profissionais)
+| Score | SLA | Justificativa |
+|-------|-----|---------------|
+| 5 estrelas | 15 minutos | Demonstra profissionalismo e urgencia |
+| 4 estrelas | 2 horas | Mesmo turno, preferencialmente |
+| 3 estrelas | 12 horas | Regua automatica com conteudo de valor |
+
+### Negocios de ciclo longo (> 30 dias: imobiliario, SaaS, B2B)
+| Score | SLA | Justificativa |
+|-------|-----|---------------|
+| 5 estrelas | 30 minutos | Rapido, mas o processo e mais consultivo |
+| 4 estrelas | 4 horas | Mesmo dia, com abordagem personalizada |
+| 3 estrelas | 24 horas | Nutricao com conteudo educativo |
+
+---
+
+## Perguntas de Diagnostico para o Operador
+
+Use estas perguntas para extrair dados quando o cliente nao tem metricas formais:
+
+### Volume
+- Quantos leads novos entram por mes (WhatsApp, formulario, telefone, indicacao)?
+- De onde vem a maioria? (trafego pago, organico, indicacao, Google)
+- Esse volume e estavel ou varia muito?
+
+### Processo
+- Quando chega um lead, quem responde? Em quanto tempo (real, nao ideal)?
+- Existe script ou roteiro? Ou cada vendedor faz do seu jeito?
+- Como decidem se um lead e bom ou ruim?
+- Usam CRM ou planilha? Ou nada?
+
+### Conversao
+- De cada 10 leads que entram, quantos viram cliente? (estimativa grosseira serve)
+- Qual a maior dificuldade: conseguir leads, conseguir responder rapido, ou conseguir fechar?
+- Qual o ultimo lead bom que fechou? O que tinha de diferente?
+- Qual o ultimo lead bom que perdeu? O que aconteceu?
+
+### Objecoes
+- Qual a frase que mais ouvem quando perdem uma venda?
+- O preco e o principal problema ou e outra coisa?
+- Quando o lead some (ghosting), em que momento da conversa geralmente acontece?
+
+### Time
+- Quantas pessoas vendem?
+- Existe alguem que vende muito mais que os outros? O que essa pessoa faz de diferente?
+- O time tem meta? Bate?

--- a/.claude/skills/account-diagnostico-comercial/schema.json
+++ b/.claude/skills/account-diagnostico-comercial/schema.json
@@ -1,0 +1,554 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DiagnosticoComercial",
+  "description": "Output estruturado da skill diagnostico-comercial: diagnostico do funil de vendas com benchmarks, mapa de objecoes, criterios de qualificacao e SLA.",
+  "type": "object",
+  "required": [
+    "summary",
+    "funnel_diagnosis",
+    "objection_map",
+    "qualification_criteria",
+    "sla",
+    "action_plan",
+    "client_name",
+    "summary_headline",
+    "summary_highlights",
+    "summary_key_findings"
+  ],
+  "properties": {
+    "client_name": {
+      "type": "string",
+      "description": "Nome do cliente — sempre presente em todo output."
+    },
+    "summary": {
+      "type": "string",
+      "description": "Resumo executivo de 2-3 frases do diagnostico. Inclui gargalo principal, criterio 5 estrelas resumido e SLA de 5 estrelas."
+    },
+    "summary_headline": {
+      "type": "string",
+      "description": "Manchete em 1 linha (~120 caracteres) com o veredito da skill."
+    },
+    "summary_highlights": {
+      "type": "array",
+      "description": "KPIs em destaque (4-6 itens). Categorias: posicao | competicao | janela | maturidade | oportunidade | risco.",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "label",
+          "value",
+          "tone"
+        ],
+        "properties": {
+          "category": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "subtext": {
+            "type": "string"
+          },
+          "tone": {
+            "type": "string",
+            "enum": [
+              "green",
+              "yellow",
+              "red",
+              "blue",
+              "gray"
+            ]
+          }
+        }
+      }
+    },
+    "summary_key_findings": {
+      "type": "array",
+      "description": "3-5 achados categorizados (vantagem | contexto | ameaca | acao).",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "text"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "vantagem",
+              "contexto",
+              "ameaca",
+              "acao"
+            ]
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "funnel_diagnosis": {
+      "type": "array",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "stage",
+          "current_rate",
+          "benchmark",
+          "bottleneck",
+          "root_cause"
+        ],
+        "properties": {
+          "stage": {
+            "type": "string",
+            "description": "Nome da etapa do funil (ex: 'Lead para Primeiro Contato', 'Qualificacao para Proposta')."
+          },
+          "current_rate": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 100,
+            "description": "Taxa de conversao atual em percentual."
+          },
+          "benchmark": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 100,
+            "description": "Taxa de conversao benchmark do setor em percentual."
+          },
+          "gap": {
+            "type": "number",
+            "description": "Diferenca entre a taxa atual e o benchmark (positivo = acima, negativo = abaixo)."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "above_benchmark",
+              "at_benchmark",
+              "below_benchmark",
+              "critical"
+            ],
+            "description": "Classificacao do desempenho da etapa."
+          },
+          "bottleneck": {
+            "type": "string",
+            "description": "Descricao especifica do gargalo identificado nesta etapa."
+          },
+          "root_cause": {
+            "type": "string",
+            "description": "Causa raiz mais provavel do gargalo."
+          },
+          "financial_impact_monthly": {
+            "type": "number",
+            "description": "Impacto financeiro estimado em reais por mes (receita perdida)."
+          }
+        }
+      },
+      "description": "Diagnostico de cada etapa do funil com taxas de conversao vs benchmarks."
+    },
+    "funnel_extended": {
+      "type": "array",
+      "description": "Funil estendido em 6-7 etapas para visualizacao no estilo 'Destrava Receita' (R->L). Opcional. Quando presente, o portal renderiza chevrons em vez do funil tradicional.",
+      "minItems": 4,
+      "maxItems": 8,
+      "items": {
+        "type": "object",
+        "required": ["stage", "volume", "rate_label"],
+        "properties": {
+          "stage": {
+            "type": "string",
+            "description": "Nome da etapa (ex: Exposicao, Atencao, Interesse, Qualificacao, Compromisso, Decisao, Retencao)."
+          },
+          "volume": {
+            "type": "number",
+            "description": "Volume absoluto na etapa (mensal — todas as etapas devem usar o mesmo recorte)."
+          },
+          "volume_label": {
+            "type": "string",
+            "description": "Label de volume formatado (ex: '52.929/mês'). Se ausente, o renderer formata automaticamente."
+          },
+          "rate_label": {
+            "type": "string",
+            "description": "Label de taxa formatado (ex: '2,01% CTR', '24%', 'base', '100% [E]')."
+          },
+          "subtext": {
+            "type": "string",
+            "description": "Subtexto curto explicativo (fonte do dado, ressalva metodologica, etc.)."
+          },
+          "status": {
+            "type": ["string", "null"],
+            "enum": ["above_benchmark", "at_benchmark", "below_benchmark", "critical", null],
+            "description": "Status da etapa (mesma taxonomia do funnel_diagnosis). Null para etapas sem benchmark mapeado."
+          },
+          "estimated": {
+            "type": "boolean",
+            "description": "True se o valor é estimativa (renderer aplica tratamento visual diferenciado)."
+          },
+          "is_active_constraint": {
+            "type": "boolean",
+            "description": "True para a etapa que representa a 'Restrição Ativa' (gargalo principal). Apenas uma etapa deve ser true."
+          }
+        }
+      }
+    },
+    "primary_bottleneck": {
+      "type": "object",
+      "properties": {
+        "stage": {
+          "type": "string",
+          "description": "Etapa do funil onde esta o gargalo principal."
+        },
+        "description": {
+          "type": "string",
+          "description": "Descricao do gargalo principal."
+        },
+        "estimated_improvement": {
+          "type": "string",
+          "description": "Estimativa de melhoria se corrigido (ex: '+15% na conversao geral = +R$12.000/mes')."
+        }
+      }
+    },
+    "objection_map": {
+      "type": "array",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "objection",
+          "type",
+          "funnel_moment",
+          "recommended_response",
+          "sdr_prevention"
+        ],
+        "properties": {
+          "objection": {
+            "type": "string",
+            "description": "A objecao exata como o lead a expressa."
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "price",
+              "urgency",
+              "authority",
+              "trust",
+              "need",
+              "competitor"
+            ],
+            "description": "Tipo da objecao segundo classificacao BANT+."
+          },
+          "funnel_moment": {
+            "type": "string",
+            "enum": [
+              "first_contact",
+              "qualification",
+              "proposal",
+              "negotiation"
+            ],
+            "description": "Em que momento do funil a objecao tipicamente aparece."
+          },
+          "frequency": {
+            "type": "string",
+            "enum": [
+              "high",
+              "medium",
+              "low"
+            ],
+            "description": "Frequencia estimada com que essa objecao aparece."
+          },
+          "recommended_response": {
+            "type": "string",
+            "description": "Script curto de resposta recomendada para o vendedor humano (2-3 frases)."
+          },
+          "sdr_prevention": {
+            "type": "string",
+            "description": "Como o SDR IA deve abordar preventivamente para evitar que a objecao surja."
+          },
+          "example_dialogue": {
+            "type": "object",
+            "properties": {
+              "lead_says": {
+                "type": "string",
+                "description": "Frase tipica do lead ao apresentar a objecao."
+              },
+              "sdr_responds": {
+                "type": "string",
+                "description": "Resposta do SDR IA para a objecao."
+              }
+            }
+          }
+        }
+      },
+      "description": "Mapa completo de objecoes com tipo, momento, resposta e prevencao."
+    },
+    "objection_pattern": {
+      "type": "object",
+      "properties": {
+        "most_frequent_type": {
+          "type": "string",
+          "description": "Tipo de objecao mais frequente."
+        },
+        "most_critical_moment": {
+          "type": "string",
+          "description": "Momento do funil mais critico para objecoes."
+        },
+        "deal_killer_objection": {
+          "type": "string",
+          "description": "Objecao que mais mata vendas."
+        },
+        "main_recommendation": {
+          "type": "string",
+          "description": "Recomendacao principal para reduzir objecoes."
+        }
+      }
+    },
+    "qualification_criteria": {
+      "type": "object",
+      "required": [
+        "five_star",
+        "four_star",
+        "three_star",
+        "one_two_star"
+      ],
+      "properties": {
+        "five_star": {
+          "type": "object",
+          "required": [
+            "profile",
+            "mandatory_signals",
+            "action",
+            "example"
+          ],
+          "properties": {
+            "profile": {
+              "type": "string",
+              "description": "Descricao curta do perfil 5 estrelas."
+            },
+            "mandatory_signals": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Sinais obrigatorios — TODOS devem estar presentes."
+            },
+            "action": {
+              "type": "string",
+              "description": "Acao imediata ao identificar este lead."
+            },
+            "example": {
+              "type": "string",
+              "description": "Exemplo concreto de um lead 5 estrelas tipico."
+            }
+          }
+        },
+        "four_star": {
+          "type": "object",
+          "required": [
+            "profile",
+            "signals",
+            "min_signals",
+            "action",
+            "example"
+          ],
+          "properties": {
+            "profile": {
+              "type": "string",
+              "description": "Descricao curta do perfil 4 estrelas."
+            },
+            "signals": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Sinais possiveis — pelo menos min_signals devem estar presentes."
+            },
+            "min_signals": {
+              "type": "integer",
+              "description": "Quantidade minima de sinais presentes para 4 estrelas."
+            },
+            "action": {
+              "type": "string",
+              "description": "Acao ao identificar este lead."
+            },
+            "example": {
+              "type": "string",
+              "description": "Exemplo concreto de um lead 4 estrelas tipico."
+            }
+          }
+        },
+        "three_star": {
+          "type": "object",
+          "required": [
+            "profile",
+            "signals",
+            "min_signals",
+            "action",
+            "example"
+          ],
+          "properties": {
+            "profile": {
+              "type": "string",
+              "description": "Descricao curta do perfil 3 estrelas."
+            },
+            "signals": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Sinais possiveis para 3 estrelas."
+            },
+            "min_signals": {
+              "type": "integer",
+              "description": "Quantidade minima de sinais presentes para 3 estrelas."
+            },
+            "action": {
+              "type": "string",
+              "description": "Acao ao identificar este lead."
+            },
+            "example": {
+              "type": "string",
+              "description": "Exemplo concreto de um lead 3 estrelas tipico."
+            }
+          }
+        },
+        "one_two_star": {
+          "type": "object",
+          "required": [
+            "profile",
+            "disqualification_signals",
+            "action",
+            "example"
+          ],
+          "properties": {
+            "profile": {
+              "type": "string",
+              "description": "Descricao curta do perfil 1-2 estrelas."
+            },
+            "disqualification_signals": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Sinais de desqualificacao — qualquer um e suficiente."
+            },
+            "action": {
+              "type": "string",
+              "description": "Acao ao identificar este lead."
+            },
+            "example": {
+              "type": "string",
+              "description": "Exemplo concreto de um lead 1-2 estrelas tipico."
+            }
+          }
+        },
+        "tiebreaker_rules": {
+          "type": "object",
+          "properties": {
+            "three_vs_four": {
+              "type": "string",
+              "description": "Regra de desempate entre 3 e 4 estrelas."
+            },
+            "two_vs_three": {
+              "type": "string",
+              "description": "Regra de desempate entre 2 e 3 estrelas."
+            }
+          }
+        }
+      }
+    },
+    "sla": {
+      "type": "object",
+      "required": [
+        "five_star_minutes",
+        "four_star_hours",
+        "three_star_hours"
+      ],
+      "properties": {
+        "five_star_minutes": {
+          "type": "integer",
+          "description": "Tempo maximo de resposta em minutos para leads 5 estrelas."
+        },
+        "five_star_responsible": {
+          "type": "string",
+          "description": "Responsavel por atender leads 5 estrelas."
+        },
+        "five_star_channel": {
+          "type": "string",
+          "description": "Canal de contato para leads 5 estrelas."
+        },
+        "four_star_hours": {
+          "type": "number",
+          "description": "Tempo maximo de resposta em horas para leads 4 estrelas."
+        },
+        "four_star_responsible": {
+          "type": "string",
+          "description": "Responsavel por atender leads 4 estrelas."
+        },
+        "three_star_hours": {
+          "type": "number",
+          "description": "Tempo maximo para leads 3 estrelas entrarem em regua automatica (em horas)."
+        },
+        "escalation_5star_minutes": {
+          "type": "integer",
+          "description": "Tempo em minutos apos o qual escalar se lead 5 estrelas nao foi contatado."
+        },
+        "escalation_4star_hours": {
+          "type": "number",
+          "description": "Tempo em horas apos o qual escalar se lead 4 estrelas nao foi contatado."
+        },
+        "escalation_responsible": {
+          "type": "string",
+          "description": "Para quem escalar se o SLA for violado."
+        }
+      }
+    },
+    "action_plan": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 5,
+      "items": {
+        "type": "object",
+        "required": [
+          "action",
+          "responsible",
+          "timeline",
+          "measurement"
+        ],
+        "properties": {
+          "priority": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 5,
+            "description": "Prioridade da acao (1 = maior impacto)."
+          },
+          "action": {
+            "type": "string",
+            "description": "Descricao especifica da acao."
+          },
+          "responsible": {
+            "type": "string",
+            "description": "Quem e responsavel pela execucao (vendedor, SDR IA, gestor, consultor)."
+          },
+          "timeline": {
+            "type": "string",
+            "description": "Prazo realista para implementacao."
+          },
+          "measurement": {
+            "type": "string",
+            "description": "Como medir se a acao deu resultado."
+          },
+          "expected_impact": {
+            "type": "string",
+            "description": "Estimativa quantitativa do impacto esperado."
+          }
+        }
+      },
+      "description": "Plano de acao comercial com 3-5 acoes priorizadas por impacto."
+    }
+  }
+}

--- a/.claude/skills/account-sdr-ia-config/SKILL.md
+++ b/.claude/skills/account-sdr-ia-config/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: account-sdr-ia-config
+description: "Configuracao do SDR IA no Patagon + integracao Kommo: setup do agente, field mapping, alertas para vendedor e teste com 5 leads simulados. Use quando o operador disser 'configurar patagon', 'setup sdr', 'integrar kommo', 'colocar o agente no ar', ou apos copy-scripts-sdr."
+area: account
+author: luizfreitasv4
+version: 1.0.0
+dependencies:
+  - copy-scripts-sdr
+  - account-crm-setup
+outputs: ["account-sdr-ia-config.json"]
+week: 4
+estimated_time: "4h"
+semi_manual: true
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta versao foi portada do sistema de Estruturacao Estrategica. As regras abaixo tem precedencia sobre caminhos e persistencia citados no fluxo original:
+
+- Trabalhe somente em `squads/{squad}/clientes/{cliente}/`, nunca em um diretorio `clientes/` solto na raiz.
+- Leia primeiro o `CLAUDE.md` ou `AGENTS.md` da KB, `mission-control/`, `calls/`, `docs/` e `campanhas/`.
+- Se `client.json` existir, use-o como fonte complementar. Se nao existir, derive o contexto da KB e do Mission Control; nao exija nem invente esse arquivo.
+- Salve entregaveis em `squads/{squad}/clientes/{cliente}/outputs/`, em JSON e Markdown quando o fluxo pedir ambos.
+- Registre decisoes e progresso no `mission-control/historico-checkins.md` ou no arquivo de historico equivalente encontrado na KB.
+- Resolva recursos empacotados a partir do proprio diretorio desta skill. Se uma integracao externa nao estiver configurada, declare o gap e continue apenas com os dados reais disponiveis.
+
+
+# Configuracao do SDR IA (Patagon + Kommo) — POP 3.7
+
+> **Posição no fluxo:** Semana 4 — Identidade de Comunicação e Plano de Mídia (**comum** a todos os modelos) a todos os modelos. Coloca o agente do `copy-scripts-sdr` no ar, integrado ao CRM (account-crm-setup). Sobe ao vivo só após validar o scoring com leads reais.
+
+Voce e um guia tecnico para configuracao do agente SDR IA no Patagon com integracao Kommo CRM. Esta skill e SEMI-MANUAL: voce gera as instrucoes passo a passo e o operador executa no Patagon e Kommo. Apos cada etapa, o operador confirma que executou.
+
+> **IMPORTANCIA:** Esta e a skill que coloca o SDR IA no ar. Tudo das semanas anteriores converge aqui. Erro na configuração = leads mal qualificados ou alertas que não chegam.
+
+> **PRE-REQUISITOS:**
+> - WhatsApp Business do cliente conectado ao Patagon
+> - Kommo CRM configurado com pipeline (account-crm-setup)
+> - Scripts SDR aprovados pelo cliente (copy-scripts-sdr)
+> - Brandbook com tom de voz aprovado
+
+## Dados necessários
+
+1. `client.json` (seção `briefing`) — NOME_CLIENTE, PRODUTO_SERVICO
+2. `outputs/copy-scripts-sdr.json` — TODOS os scripts, perguntas, fluxos, objeções
+3. `outputs/account-diagnostico-comercial.json` — critérios 1-5 estrelas, SLA
+4. `outputs/designer-manual-marca.json` — TOM_DE_VOZ, nome do agente
+5. `outputs/account-crm-setup.json` — pipeline configurado no Kommo
+
+Se alguma dependência não estiver completa:
+
+> BLOQUEIO: A skill {NOME_SKILL} precisa estar completa antes de configurar o SDR IA.
+> Execute `/{skill}` antes de continuar.
+
+Confirme com o operador:
+
+> Vamos configurar o SDR IA de {NOME_CLIENTE}.
+> - WhatsApp Business conectado ao Patagon? [sim/nao]
+> - Kommo configurado com pipeline? [sim/nao]
+> - Scripts aprovados pelo cliente? [sim/nao]
+> - Vendedor para alertas: Nome e WhatsApp?
+>
+> Se algum item for "nao", precisamos resolver antes.
+
+---
+
+## Geração
+
+Gere o output COMPLETO de uma vez: guia de configuração Patagon + integração Kommo + alertas + teste com 5 leads. Use os dados de `client.json` (briefing) e outputs de skills dependentes em `outputs/`.
+
+Consulte `references/guia-patagon-kommo.md` para detalhes técnicos.
+
+### Configuração do agente no Patagon (passo a passo)
+
+**PASSO 1:** Criar agente (nome, descrição)
+**PASSO 2:** Configurar persona (personalidade completa, tom de voz, regras: máx 3 frases, nunca revelar IA, etc.)
+**PASSO 3:** Configurar mensagem de boas-vindas (colar mensagem aprovada)
+**PASSO 4:** Configurar perguntas de qualificação (Q1-Q5, abertas, obrigatórias)
+**PASSO 5:** Configurar regras de scoring (critérios por estrela + ação para cada score)
+**PASSO 6:** Configurar tratamento de objeções (cada objeção + resposta + genérica)
+**PASSO 7:** Configurar follow-ups (1h, 24h, 3d + máx 3)
+**PASSO 8:** Configurar handoff (mensagem de transferência + destinatário)
+**PASSO 9:** Salvar (NÃO ativar ainda — esperar testes)
+
+### Integração Patagon → Kommo
+
+**PASSO 1:** Conectar (Settings → Integrations → Kommo, API key)
+**PASSO 2:** Field mapping (nome, telefone, score, produto, UTMs, histórico, resumo)
+**PASSO 3:** Configurar pipeline destino (score 4-5★ → Qualificados, 3★ → Nutrição, 1-2★ → Frios)
+**PASSO 4:** Tags automáticas (por score e por origem/UTM)
+**PASSO 5:** Testar conexão (enviar lead teste, verificar campos e tags)
+
+### Alertas para vendedor
+
+**PASSO 1:** Definir destinatários (vendedor principal + backup)
+**PASSO 2:** Template do alerta (nome, score, interesse, resumo, link Kommo, SLA)
+**PASSO 3:** Condições de disparo (score >= 4★, qualificação concluída, dentro do horário comercial)
+**PASSO 4:** Escalamento (se vendedor não responder em X min → backup → mensagem automática ao lead)
+**PASSO 5:** Relatório diário opcional
+
+### Teste com 5 leads simulados
+
+**Lead 1 — 5★ (quente):** urgente, decisor, com budget → resultado esperado: score 5★, alerta, Kommo "Qualificado"
+**Lead 2 — 4★ (qualificado):** interessado, sem urgência → resultado esperado: score 4★, alerta
+**Lead 3 — 3★ (morno):** curioso, pesquisando → resultado esperado: score 3★, sem alerta, "Nutrição"
+**Lead 4 — 1-2★ (frio):** não é ICP → resultado esperado: score baixo, tag "Frio"
+**Lead 5 — Com objeção forte:** interessado + objeção de preço → testar tratamento
+
+**Checklist por lead:**
+- [ ] Resposta < 5 segundos
+- [ ] Boas-vindas correta
+- [ ] Qualificação na ordem
+- [ ] Score correto
+- [ ] Kommo com campos preenchidos
+- [ ] Tag correta
+- [ ] Etapa do pipeline correta
+- [ ] Alerta enviado (se 4-5★)
+- [ ] Tom consistente com brandbook
+- [ ] Nada pareceu robótico
+
+**Tabela de resultados:**
+
+| Lead | Score esperado | Score real | Kommo OK | Alerta OK | Tempo | Status |
+|------|---------------|------------|----------|-----------|-------|--------|
+
+Se houver falhas: instruções de debug (score incorreto, campo não mapeado, alerta não chegou, tom inconsistente).
+
+## Auto-validação
+
+Antes de mostrar ao operador, verifique:
+
+- [ ] Todos os scripts aprovados foram incluídos nas instruções?
+- [ ] Field mapping cobre todos os campos necessários?
+- [ ] SLA nos alertas é consistente com o diagnóstico comercial?
+- [ ] 5 cenários de teste cobrem todos os fluxos (5★, 4★, 3★, 1-2★, objeção)?
+
+Se falhou → regenere silenciosamente.
+
+## Apresentação e decisões
+
+Apresente o output COMPLETO ao operador — guia completo de configuração.
+
+O operador executa cada etapa sequencialmente no Patagon e Kommo. Após cada bloco, confirma execução:
+
+1. "Agente criado no Patagon? Alguma tela diferente?"
+2. "Integração Kommo funcionando? Lead teste chegou com campos?"
+3. "Alertas configurados? Vendedor recebeu teste?"
+4. "5 testes executados — resultados?"
+
+Se todos os testes passaram → go-live. Se houver falhas → debug e reteste.
+
+## Finalização
+
+Operador aprova (todos os testes passam).
+1. Salve em `squads/{squad}/clientes/{cliente}/outputs/account-sdr-ia-config.json` (com campo `summary` no topo)
+2. Atualize `client.json`: progress.skills → completed, version++, append em history[]
+3. Salve também uma versão Markdown do entregável na mesma pasta de outputs.
+4. **Ative o agente no Patagon** (com aprovação do operador e do cliente)
+5. Informe:
+   - "SDR IA configurado, testado e no ar!"
+   - "Recomendações pós go-live:"
+   - "  1. Monitorar os primeiros 20 leads reais (ajustar scoring se necessário)"
+   - "  2. Coletar feedback do vendedor sobre qualidade dos leads"
+   - "  3. Revisar métricas após 7 dias: qualificação, SLA, conversão"
+   - "  4. Ajustar scripts com base nos dados reais"
+
+**ALERTA:** O agente está no ar. Leads reais sendo qualificados. Monitore de perto nas primeiras 48h.

--- a/.claude/skills/account-sdr-ia-config/references/guia-patagon-kommo.md
+++ b/.claude/skills/account-sdr-ia-config/references/guia-patagon-kommo.md
@@ -1,0 +1,403 @@
+# Guia de Configuracao: Patagon AI + Kommo CRM
+
+Guia tecnico passo a passo para configurar um agente SDR IA no Patagon com integracao ao Kommo CRM. Escrito para operadores que podem nao ter experiencia tecnica profunda.
+
+---
+
+## Visao Geral da Arquitetura
+
+```
+Lead envia mensagem no WhatsApp
+        |
+        v
+  [Patagon AI Agent]
+  - Recebe mensagem
+  - Executa fluxo de qualificacao
+  - Atribui score 1-5 estrelas
+  - Trata objecoes
+  - Envia follow-ups
+        |
+        v
+  [Integracao Patagon → Kommo]
+  - Cria contato no Kommo
+  - Preenche campos mapeados
+  - Aplica tags automaticas
+  - Move para etapa correta do pipeline
+        |
+        v
+  [Alerta para Vendedor]
+  - Se score >= 4: WhatsApp para vendedor
+  - Se score < 4: regua automatica
+```
+
+---
+
+## Parte 1: Patagon AI — Configuracao do Agente
+
+### 1.1 Acesso e Criacao
+
+1. Acesse [app.patagon.ai](https://app.patagon.ai)
+2. Faca login com a conta do operador
+3. No dashboard, clique em **"+ Novo Agente"**
+4. Preencha:
+   - **Nome do agente:** Nome humano (ex: "Ana da Empresa X"). Esse nome aparece para o lead.
+   - **Descricao:** Texto interno para identificacao (ex: "SDR IA - Qualificacao WhatsApp")
+   - **Canal:** WhatsApp Business
+   - **Numero:** Selecione o numero do cliente (deve estar previamente conectado)
+
+### 1.2 Conectar WhatsApp Business
+
+**Pre-requisito:** O cliente precisa ter um numero de WhatsApp Business. Numero pessoal NAO funciona.
+
+1. No Patagon: **Settings → Channels → WhatsApp**
+2. Clique em **"Conectar WhatsApp"**
+3. Escaneie o QR code com o WhatsApp Business do cliente
+4. Aguarde a confirmacao de conexao (pode levar ate 2 minutos)
+5. Teste enviando uma mensagem do seu celular para o numero conectado
+6. Se o Patagon mostrar a mensagem recebida, a conexao esta OK
+
+**Problemas comuns:**
+- QR code expirado: atualize a pagina e escaneie novamente
+- Numero ja conectado em outro servico: desconecte primeiro
+- WhatsApp Business API vs App: ambos funcionam, mas API tem mais recursos
+
+### 1.3 Configurar Personalidade do Agente
+
+No Patagon, va em **Agent Settings → Personality/Instructions**.
+
+O campo de instrucoes e onde voce define COMO o agente se comporta. Cole o texto gerado pela skill copy-scripts-sdr, adaptado para o formato do Patagon.
+
+**Estrutura recomendada das instrucoes:**
+
+```
+IDENTIDADE:
+Voce e [NOME_AGENTE], [funcao] da [EMPRESA].
+Seu trabalho e atender pessoas que entram em contato pelo WhatsApp.
+
+PERSONALIDADE:
+[Descricao do tom de voz baseada no designer-manual-marca]
+- Ex: "Voce e amigavel, direta e profissional. Usa linguagem simples."
+- Ex: "Voce nao usa gíria, mas tambem nao e formal demais."
+
+REGRAS ABSOLUTAS:
+1. Maximo 3 frases por mensagem
+2. Use o nome da pessoa sempre que possivel
+3. Nunca prometa preco, prazo ou condicao especifica
+4. Se nao souber responder, passe para [NOME_VENDEDOR]
+5. Nunca revele que e uma inteligencia artificial
+6. Nunca use mais de 1 emoji por mensagem
+7. Responda sempre em portugues brasileiro
+
+CONHECIMENTO DO PRODUTO:
+[Resumo do produto/servico]
+[Principais beneficios]
+[O que NAO pode prometer]
+
+PROCESSO:
+1. Cumprimente e se apresente
+2. Faca as perguntas de qualificacao (uma por vez)
+3. Classifique o lead
+4. Se qualificado: encaminhe para vendedor
+5. Se nao qualificado: ofereça conteudo e nutra
+```
+
+### 1.4 Configurar Fluxo de Qualificacao
+
+No Patagon: **Agent Settings → Conversation Flow**
+
+Aqui voce define as perguntas que o agente faz em sequencia:
+
+1. **Adicione cada pergunta** como um "step" no fluxo
+2. Para cada pergunta, configure:
+   - **Texto da pergunta:** A pergunta exata
+   - **Tipo:** "Aberta" (o lead responde livremente)
+   - **Obrigatoria:** Sim (o agente deve obter resposta antes de avancar)
+   - **Regras de score:** Como a resposta influencia a classificacao
+3. **Ordene** as perguntas na sequencia definida pela skill copy-scripts-sdr
+4. **Configure transicoes:** O que o agente diz entre uma pergunta e outra
+
+**Dica:** Nao use perguntas de multipla escolha no WhatsApp. Perguntas abertas soam mais naturais. O agente de IA interpreta a resposta.
+
+### 1.5 Configurar Regras de Scoring
+
+No Patagon: **Agent Settings → Scoring Rules**
+
+Configure os criterios de cada faixa de score:
+
+| Score | Criterios | Acao automatica |
+|-------|-----------|-----------------|
+| 5 estrelas | Todos os sinais positivos presentes | Alerta imediato + Kommo "Qualificados" |
+| 4 estrelas | Maioria dos sinais positivos | Alerta + Kommo "Qualificados" |
+| 3 estrelas | Sinais mistos | Kommo "Nutricao" + regua |
+| 2 estrelas | Poucos sinais positivos | Kommo "Frios" + tag |
+| 1 estrela | Sinais de desqualificacao | Kommo "Frios" + despedida |
+
+**Como o Patagon calcula o score:**
+O Patagon usa IA para interpretar as respostas do lead e classificar conforme os criterios que voce definiu. Quanto mais especificos os criterios, mais precisa a classificacao.
+
+**Exemplo de criterio bem escrito:**
+"Lead 5 estrelas: demonstra necessidade urgente (prazo definido), e o decisor ou tem autonomia, orcamento compativel com ticket medio, e ja pesquisou alternativas."
+
+**Exemplo de criterio mal escrito:**
+"Lead bom." (vago demais, o agente nao sabe como classificar)
+
+### 1.6 Configurar Respostas para Objecoes
+
+No Patagon: **Agent Settings → Objection Handling**
+
+Para cada objecao, adicione:
+1. **Trigger:** A objecao como o lead a expressa (pode ter variações)
+2. **Resposta:** O script do SDR IA para essa objecao
+3. **Se insistir:** Segunda resposta ou escalamento
+
+**Dica:** Adicione variações da mesma objecao. Ex: "ta caro", "achei caro", "nao tenho dinheiro pra isso", "meu orcamento e menor" podem ser agrupadas como objecao de preco.
+
+### 1.7 Configurar Follow-ups
+
+No Patagon: **Agent Settings → Follow-ups**
+
+1. **Ative follow-ups automaticos**
+2. Configure cada intervalo:
+   - Apos 1 hora sem resposta: [mensagem]
+   - Apos 24 horas sem resposta: [mensagem]
+   - Apos 3 dias sem resposta: [mensagem — ultimo]
+3. **Max follow-ups:** 3 (nao mais que isso)
+4. **Horario permitido:** Definir janela de horario comercial
+
+### 1.8 Configurar Handoff para Humano
+
+No Patagon: **Agent Settings → Human Handoff**
+
+1. **Mensagem de transicao:** A mensagem que o agente envia ao lead antes de transferir
+2. **Destinatario:** Nome e WhatsApp do vendedor
+3. **Triggers de handoff:**
+   - Score 4-5 estrelas (apos qualificacao)
+   - Lead pede para falar com humano
+   - Agente nao consegue responder (2 tentativas)
+   - Lead demonstra frustacao
+4. **Contexto enviado ao vendedor:** Resumo da conversa, score, dados coletados
+
+---
+
+## Parte 2: Kommo CRM — Integracao
+
+### 2.1 Obter API Key do Kommo
+
+1. No Kommo: **Settings → Integrations**
+2. Clique em **"API"**
+3. Se nao houver chave, clique em **"Generate API Key"**
+4. Copie a chave (ela sera usada no Patagon)
+5. **IMPORTANTE:** Guarde a chave em local seguro. Nao compartilhe.
+
+### 2.2 Conectar no Patagon
+
+1. No Patagon: **Settings → Integrations → Kommo**
+2. Clique em **"Conectar"**
+3. Cole a API key do Kommo
+4. Clique em **"Testar Conexao"**
+5. Se mostrar "Conexao bem sucedida", avance
+6. Se der erro, verifique: a chave esta correta? O Kommo esta ativo?
+
+### 2.3 Field Mapping (Mapeamento de Campos)
+
+Apos conectar, configure o mapeamento:
+
+**Campos padrao (ja existem no Kommo):**
+
+| Campo Patagon | Campo Kommo | Notas |
+|---------------|-------------|-------|
+| Nome do lead | Nome | Campo padrao, obrigatorio |
+| Telefone | Telefone | Campo padrao |
+| Email | Email | Se coletado |
+
+**Campos personalizados (criar no Kommo primeiro):**
+
+Para criar campos personalizados no Kommo:
+1. Va em **Settings → Fields**
+2. Clique em **"Add Field"**
+3. Preencha nome e tipo
+4. Salve
+
+Campos personalizados recomendados:
+
+| Nome do campo | Tipo | Descricao |
+|---------------|------|-----------|
+| Score | Tag | Score 1-5 estrelas |
+| Produto Interesse | Texto | Produto que o lead demonstrou interesse |
+| Origem (UTM Source) | Texto | De onde o lead veio |
+| Midia (UTM Medium) | Texto | Canal de midia |
+| Campanha (UTM Campaign) | Texto | Nome da campanha |
+| Resumo SDR | Texto longo | Resumo da qualificacao pelo SDR IA |
+
+**Campo de notas:**
+
+O historico da conversa completa deve ser salvo como nota no contato:
+1. No mapeamento, selecione "Historico da conversa"
+2. Mapeie para "Nota automatica" no Kommo
+3. Isso cria uma nota no contato com toda a conversa
+
+### 2.4 Configurar Pipeline de Destino
+
+No mapeamento, defina para qual etapa do pipeline cada score vai:
+
+1. **Score 4-5 estrelas:** Etapa "Qualificados" (ou equivalente)
+2. **Score 3 estrelas:** Etapa "Nutricao" (ou equivalente)
+3. **Score 1-2 estrelas:** Etapa "Frios" (ou equivalente)
+
+**NOTA:** As etapas do pipeline devem existir no Kommo. Se nao existirem, crie antes:
+1. No Kommo: **Pipeline → Edit Pipeline**
+2. Adicione as etapas necessarias
+3. Salve
+
+### 2.5 Configurar Tags Automaticas
+
+No Patagon, na secao de integracao Kommo:
+
+1. **Tags por score:**
+   - 5 estrelas: "Lead Quente", "5 estrelas"
+   - 4 estrelas: "Lead Qualificado", "4 estrelas"
+   - 3 estrelas: "Lead Morno", "Nutricao"
+   - 1-2 estrelas: "Lead Frio"
+
+2. **Tags por origem (UTM):**
+   Configure regras baseadas no UTM source:
+   - Se `utm_source` contem "google" → tag "Google Ads"
+   - Se `utm_source` contem "meta" ou "facebook" → tag "Meta Ads"
+   - Se `utm_source` contem "instagram" → tag "Instagram Organico"
+   - Se `utm_source` contem "indicacao" → tag "Indicacao"
+
+---
+
+## Parte 3: Alertas para Vendedor
+
+### 3.1 Configurar no Patagon
+
+No Patagon: **Settings → Alerts**
+
+1. Clique em **"New Alert"**
+2. **Condicao de disparo:**
+   - Tipo: "Lead qualificado"
+   - Score minimo: 4 estrelas
+   - Momento: apos qualificacao concluida
+3. **Canal:** WhatsApp
+4. **Destinatario:** Numero do vendedor
+5. **Template:** Use o template definido na skill
+
+### 3.2 Template do Alerta
+
+O alerta deve conter tudo que o vendedor precisa para agir rapidamente:
+
+```
+LEAD QUALIFICADO: [Nome do lead]
+Score: [X] estrelas
+Interesse: [Produto que demonstrou interesse]
+Resumo: [2 frases sobre o que o lead precisa]
+Ver no Kommo: [link direto para o contato]
+SLA: responder em [X] minutos
+```
+
+### 3.3 Escalamento
+
+Configure o que acontece se o vendedor nao responder:
+
+1. **Timer 1:** Apos [SLA] minutos sem resposta do vendedor
+   - Acao: enviar alerta para backup
+   - Tag no Kommo: "SLA Violado"
+
+2. **Timer 2:** Apos [SLA x 2] minutos sem resposta de ninguem
+   - Acao: enviar mensagem automatica ao lead (desculpando a demora)
+   - Tag no Kommo: "Atendimento Atrasado"
+
+---
+
+## Parte 4: Testes
+
+### 4.1 Checklist Pre-Teste
+
+Antes de testar, verifique:
+
+- [ ] Agente criado no Patagon com todas as configuracoes
+- [ ] WhatsApp Business conectado
+- [ ] Instrucoes de personalidade preenchidas
+- [ ] Perguntas de qualificacao configuradas
+- [ ] Regras de scoring definidas
+- [ ] Respostas de objecoes adicionadas
+- [ ] Follow-ups configurados
+- [ ] Handoff configurado
+- [ ] Integracao Kommo ativa e testada
+- [ ] Field mapping completo
+- [ ] Tags automaticas configuradas
+- [ ] Alertas configurados
+- [ ] Vendedor informado sobre os testes
+
+### 4.2 Protocolo de Teste
+
+Para cada lead simulado:
+
+1. **Envie a mensagem inicial** de um numero diferente
+2. **Aguarde a resposta** do agente (deve ser < 5 segundos)
+3. **Siga o roteiro** do perfil de teste (quente, morno, frio, etc.)
+4. **Responda as perguntas** conforme o perfil
+5. **Verifique no Patagon:** score atribuido
+6. **Verifique no Kommo:** contato criado, campos preenchidos, tag aplicada, etapa correta
+7. **Verifique no WhatsApp do vendedor:** alerta recebido (se aplicavel)
+8. **Registre o resultado**
+
+### 4.3 O que verificar em cada teste
+
+| Item | Como verificar | Criterio de sucesso |
+|------|---------------|---------------------|
+| Tempo de resposta | Cronometrar | < 5 segundos |
+| Mensagem de boas-vindas | Ler a mensagem | Igual ao configurado |
+| Perguntas na ordem | Acompanhar a conversa | Sequencia correta |
+| Tom de voz | Avaliar linguagem | Consistente com designer-manual-marca |
+| Score | Verificar no Patagon | Corresponde ao perfil |
+| Kommo — contato | Verificar no CRM | Contato criado |
+| Kommo — campos | Verificar campos | Todos preenchidos |
+| Kommo — tag | Verificar tags | Tag correta aplicada |
+| Kommo — etapa | Verificar pipeline | Etapa correta |
+| Alerta | Verificar WhatsApp vendedor | Recebido (se 4-5 estrelas) |
+
+### 4.4 Problemas Comuns e Solucoes
+
+| Problema | Causa provavel | Solucao |
+|----------|---------------|---------|
+| Agente nao responde | WhatsApp desconectado | Reconectar no Patagon |
+| Score incorreto | Criterios vagos | Reescrever criterios com mais especificidade |
+| Lead nao aparece no Kommo | API key invalida | Gerar nova key no Kommo |
+| Campos vazios no Kommo | Mapeamento incompleto | Revisar field mapping |
+| Tag errada | Regra de tag incorreta | Corrigir condicoes de tag |
+| Alerta nao chega | Numero errado ou fora do horario | Verificar numero e horario |
+| Tom robotico | Instrucoes muito rigidas | Flexibilizar instrucoes, adicionar exemplos |
+| Agente revela que e IA | Instrucoes incompletas | Adicionar regra explicita de nao revelar |
+| Follow-up de madrugada | Horario comercial nao configurado | Definir janela de horario |
+
+---
+
+## Parte 5: Pos Go-Live
+
+### 5.1 Primeiras 48 horas
+
+Monitore de perto:
+- Quantos leads entraram?
+- Scores atribuidos estao fazendo sentido?
+- Vendedor esta recebendo alertas e respondendo no SLA?
+- Algum lead reclamou ou demonstrou estranheza?
+- Tom de voz esta consistente?
+
+### 5.2 Primeira semana
+
+Colete metricas:
+- Leads qualificados vs total: X%
+- SLA cumprido: X%
+- Leads que pediram humano: X%
+- Objecoes mais frequentes (novas que nao estavam mapeadas?)
+- Feedback do vendedor sobre qualidade dos leads
+
+### 5.3 Ajustes comuns apos go-live
+
+1. **Criterios de scoring muito frouxos:** Muitos leads 4-5 estrelas que nao sao bons → apertar criterios
+2. **Criterios muito rígidos:** Poucos leads qualificados, vendedor ocioso → afrouxar
+3. **Nova objecao apareceu:** Adicionar no Patagon
+4. **Tom nao esta bom:** Ajustar instrucoes de personalidade
+5. **Follow-up nao funciona:** Testar diferentes abordagens

--- a/.claude/skills/account-sdr-ia-config/schema.json
+++ b/.claude/skills/account-sdr-ia-config/schema.json
@@ -1,0 +1,539 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "SDRIAConfig",
+  "description": "Output estruturado da skill sdr-ia-config: configuracao do Patagon, integracao Kommo, alertas e resultados dos testes.",
+  "type": "object",
+  "required": [
+    "summary",
+    "patagon_config",
+    "kommo_integration",
+    "alerts_config",
+    "test_results",
+    "client_name",
+    "summary_headline",
+    "summary_highlights",
+    "summary_key_findings"
+  ],
+  "properties": {
+    "client_name": {
+      "type": "string",
+      "description": "Nome do cliente — sempre presente em todo output."
+    },
+    "summary": {
+      "type": "string",
+      "description": "Resumo executivo de 2-3 frases: agente configurado, integracao ativa, resultado dos testes."
+    },
+    "summary_headline": {
+      "type": "string",
+      "description": "Manchete em 1 linha (~120 caracteres) com o veredito da skill."
+    },
+    "summary_highlights": {
+      "type": "array",
+      "description": "KPIs em destaque (4-6 itens). Categorias: posicao | competicao | janela | maturidade | oportunidade | risco.",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "label",
+          "value",
+          "tone"
+        ],
+        "properties": {
+          "category": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "subtext": {
+            "type": "string"
+          },
+          "tone": {
+            "type": "string",
+            "enum": [
+              "green",
+              "yellow",
+              "red",
+              "blue",
+              "gray"
+            ]
+          }
+        }
+      }
+    },
+    "summary_key_findings": {
+      "type": "array",
+      "description": "3-5 achados categorizados (vantagem | contexto | ameaca | acao).",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "text"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "vantagem",
+              "contexto",
+              "ameaca",
+              "acao"
+            ]
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "patagon_config": {
+      "type": "object",
+      "required": [
+        "agent_name",
+        "scoring_rules"
+      ],
+      "properties": {
+        "agent_name": {
+          "type": "string",
+          "description": "Nome do agente SDR IA no Patagon (ex: 'Ana da Empresa X')."
+        },
+        "agent_description": {
+          "type": "string",
+          "description": "Descricao interna do agente no Patagon."
+        },
+        "persona_instructions": {
+          "type": "string",
+          "description": "Texto completo das instrucoes de personalidade configuradas no Patagon."
+        },
+        "welcome_message": {
+          "type": "string",
+          "description": "Mensagem de boas-vindas configurada no Patagon."
+        },
+        "qualification_questions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "order": {
+                "type": "integer",
+                "description": "Ordem da pergunta."
+              },
+              "question": {
+                "type": "string",
+                "description": "Texto da pergunta configurada."
+              },
+              "required": {
+                "type": "boolean",
+                "description": "Se a pergunta e obrigatoria."
+              }
+            }
+          },
+          "description": "Perguntas de qualificacao configuradas no fluxo."
+        },
+        "scoring_rules": {
+          "type": "object",
+          "required": [
+            "five_star",
+            "four_star",
+            "three_star",
+            "two_star",
+            "one_star"
+          ],
+          "properties": {
+            "five_star": {
+              "type": "object",
+              "properties": {
+                "criteria": {
+                  "type": "string",
+                  "description": "Criterios para score 5 estrelas."
+                },
+                "action": {
+                  "type": "string",
+                  "description": "Acao automatica para 5 estrelas."
+                }
+              }
+            },
+            "four_star": {
+              "type": "object",
+              "properties": {
+                "criteria": {
+                  "type": "string",
+                  "description": "Criterios para score 4 estrelas."
+                },
+                "action": {
+                  "type": "string",
+                  "description": "Acao automatica para 4 estrelas."
+                }
+              }
+            },
+            "three_star": {
+              "type": "object",
+              "properties": {
+                "criteria": {
+                  "type": "string",
+                  "description": "Criterios para score 3 estrelas."
+                },
+                "action": {
+                  "type": "string",
+                  "description": "Acao automatica para 3 estrelas."
+                }
+              }
+            },
+            "two_star": {
+              "type": "object",
+              "properties": {
+                "criteria": {
+                  "type": "string",
+                  "description": "Criterios para score 2 estrelas."
+                },
+                "action": {
+                  "type": "string",
+                  "description": "Acao automatica para 2 estrelas."
+                }
+              }
+            },
+            "one_star": {
+              "type": "object",
+              "properties": {
+                "criteria": {
+                  "type": "string",
+                  "description": "Criterios para score 1 estrela."
+                },
+                "action": {
+                  "type": "string",
+                  "description": "Acao automatica para 1 estrela."
+                }
+              }
+            }
+          },
+          "description": "Regras de scoring configuradas no Patagon."
+        },
+        "objection_responses": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "objection": {
+                "type": "string",
+                "description": "Objecao configurada."
+              },
+              "response": {
+                "type": "string",
+                "description": "Resposta configurada."
+              }
+            }
+          },
+          "description": "Respostas de objecoes configuradas no Patagon."
+        },
+        "followup_config": {
+          "type": "object",
+          "properties": {
+            "after_1h": {
+              "type": "string"
+            },
+            "after_24h": {
+              "type": "string"
+            },
+            "after_3d": {
+              "type": "string"
+            },
+            "max_followups": {
+              "type": "integer"
+            }
+          },
+          "description": "Configuracao de follow-ups automaticos."
+        },
+        "handoff_config": {
+          "type": "object",
+          "properties": {
+            "handoff_message": {
+              "type": "string",
+              "description": "Mensagem de transicao para humano."
+            },
+            "destination_name": {
+              "type": "string",
+              "description": "Nome do vendedor destino."
+            },
+            "destination_whatsapp": {
+              "type": "string",
+              "description": "WhatsApp do vendedor destino."
+            }
+          }
+        }
+      }
+    },
+    "kommo_integration": {
+      "type": "object",
+      "required": [
+        "field_mapping",
+        "api_configured"
+      ],
+      "properties": {
+        "api_configured": {
+          "type": "boolean",
+          "description": "Se a API key do Kommo foi configurada e a conexao testada com sucesso."
+        },
+        "pipeline_name": {
+          "type": "string",
+          "description": "Nome do pipeline no Kommo onde os leads entram."
+        },
+        "field_mapping": {
+          "type": "array",
+          "minItems": 5,
+          "items": {
+            "type": "object",
+            "required": [
+              "patagon_field",
+              "kommo_field"
+            ],
+            "properties": {
+              "patagon_field": {
+                "type": "string",
+                "description": "Nome do campo no Patagon."
+              },
+              "kommo_field": {
+                "type": "string",
+                "description": "Nome do campo no Kommo."
+              },
+              "field_type": {
+                "type": "string",
+                "description": "Tipo do campo (texto, telefone, tag, nota, data)."
+              },
+              "is_custom_field": {
+                "type": "boolean",
+                "description": "Se o campo no Kommo e personalizado (criado para esta integracao)."
+              }
+            }
+          },
+          "description": "Mapeamento de campos entre Patagon e Kommo."
+        },
+        "stage_mapping": {
+          "type": "object",
+          "properties": {
+            "qualified_stage": {
+              "type": "string",
+              "description": "Etapa do pipeline para leads 4-5 estrelas."
+            },
+            "nurture_stage": {
+              "type": "string",
+              "description": "Etapa do pipeline para leads 3 estrelas."
+            },
+            "cold_stage": {
+              "type": "string",
+              "description": "Etapa do pipeline para leads 1-2 estrelas."
+            }
+          }
+        },
+        "auto_tags": {
+          "type": "object",
+          "properties": {
+            "by_score": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "description": "Tags automaticas por score (ex: {'5_star': ['Lead Quente', '5 estrelas']})."
+            },
+            "by_source": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Tags automaticas por UTM source (ex: {'google': 'Google Ads'})."
+            }
+          }
+        }
+      }
+    },
+    "alerts_config": {
+      "type": "object",
+      "required": [
+        "template",
+        "seller_whatsapp",
+        "sla_minutes"
+      ],
+      "properties": {
+        "template": {
+          "type": "string",
+          "description": "Template da mensagem de alerta enviada ao vendedor."
+        },
+        "seller_name": {
+          "type": "string",
+          "description": "Nome do vendedor que recebe alertas."
+        },
+        "seller_whatsapp": {
+          "type": "string",
+          "description": "Numero de WhatsApp do vendedor."
+        },
+        "backup_name": {
+          "type": "string",
+          "description": "Nome do backup caso vendedor nao responda no SLA."
+        },
+        "backup_whatsapp": {
+          "type": "string",
+          "description": "Numero de WhatsApp do backup."
+        },
+        "sla_minutes": {
+          "type": "integer",
+          "description": "Tempo maximo em minutos para o vendedor responder ao lead."
+        },
+        "escalation_minutes": {
+          "type": "integer",
+          "description": "Tempo em minutos apos o qual escalar para backup."
+        },
+        "business_hours": {
+          "type": "object",
+          "properties": {
+            "start": {
+              "type": "string",
+              "description": "Horario de inicio do atendimento (ex: '08:00')."
+            },
+            "end": {
+              "type": "string",
+              "description": "Horario de fim do atendimento (ex: '19:00')."
+            }
+          }
+        },
+        "trigger_conditions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Condicoes para disparar alerta (ex: 'score >= 4', 'qualificacao concluida')."
+        }
+      }
+    },
+    "test_results": {
+      "type": "array",
+      "minItems": 5,
+      "maxItems": 5,
+      "items": {
+        "type": "object",
+        "required": [
+          "lead_number",
+          "score",
+          "kommo_entry",
+          "alert_sent",
+          "response_time"
+        ],
+        "properties": {
+          "lead_number": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 5,
+            "description": "Numero do lead de teste (1-5)."
+          },
+          "profile_description": {
+            "type": "string",
+            "description": "Descricao curta do perfil simulado."
+          },
+          "expected_score": {
+            "type": "string",
+            "description": "Score esperado para este perfil."
+          },
+          "score": {
+            "type": "string",
+            "description": "Score real atribuido pelo agente."
+          },
+          "score_correct": {
+            "type": "boolean",
+            "description": "Se o score real correspondeu ao esperado."
+          },
+          "kommo_entry": {
+            "type": "boolean",
+            "description": "Se o lead entrou corretamente no Kommo."
+          },
+          "kommo_fields_complete": {
+            "type": "boolean",
+            "description": "Se todos os campos foram preenchidos no Kommo."
+          },
+          "kommo_stage_correct": {
+            "type": "boolean",
+            "description": "Se o lead entrou na etapa correta do pipeline."
+          },
+          "alert_sent": {
+            "type": "boolean",
+            "description": "Se o alerta foi enviado ao vendedor (quando aplicavel)."
+          },
+          "response_time": {
+            "type": "string",
+            "description": "Tempo de resposta do agente (ex: '3s', '5s')."
+          },
+          "tone_consistent": {
+            "type": "boolean",
+            "description": "Se o tom de voz estava consistente com o brandbook."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pass",
+              "fail",
+              "partial"
+            ],
+            "description": "Status do teste: pass, fail ou partial."
+          },
+          "issues": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Problemas encontrados neste teste (vazio se pass)."
+          }
+        }
+      },
+      "description": "Resultados dos 5 testes de leads simulados."
+    },
+    "overall_test_result": {
+      "type": "string",
+      "enum": [
+        "approved",
+        "needs_adjustments",
+        "failed"
+      ],
+      "description": "Resultado geral dos testes."
+    },
+    "issues_found": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Lista de problemas encontrados nos testes (vazio se todos passaram)."
+    },
+    "adjustments_made": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Ajustes feitos apos problemas encontrados nos testes."
+    },
+    "go_live": {
+      "type": "object",
+      "properties": {
+        "approved": {
+          "type": "boolean",
+          "description": "Se o go-live foi aprovado pelo operador e cliente."
+        },
+        "activated_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Data/hora de ativacao do agente (ISO 8601)."
+        },
+        "monitoring_plan": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Plano de monitoramento pos go-live."
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## O que é

Cinco skills de account, cobrindo o diagnóstico comercial e a montagem do Inside Sales.

| Skill | Faz |
|---|---|
| `account-auditoria-comunicacao` | Audita site, Instagram, anúncios, GMB e WhatsApp e monta matriz de gaps com quick wins |
| `account-diagnostico-comercial` | Funil mensal e estendido, estrutura do time, gargalo primário, mapa de objeções, qualificação 1-5 estrelas com SLA por score |
| `account-cliente-oculto` | Cliente oculto: perfil de comprador fictício, operador executa no canal real, análise da conversa com nota 0-10 |
| `account-crm-setup` | Configura pipeline no Kommo, réguas de boas-vindas e nutrição, testa com lead fictício |
| `account-sdr-ia-config` | SDR IA no Patagon + integração Kommo: setup, field mapping, alertas e teste com 5 leads simulados |

As três últimas são semi-manuais — a IA prepara e analisa, quem executa na ferramenta é o operador.

## Checagens

- Duplo-write verificado
- `REGISTRY.md` fora do PR — a Action regenera no merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)