### PR TITLE
feat(skills): copy-anuncios e copy-scripts-sdr

### DIFF
--- a/.agents/skills/copy-anuncios/SKILL.md
+++ b/.agents/skills/copy-anuncios/SKILL.md
@@ -1,0 +1,252 @@
+---
+name: copy-anuncios
+description: "Gera 30+ variações de copy de anúncios por funil e plataforma (Meta Ads + Google Ads). Output exportado para Google Sheets. Use quando disser /copy-anuncios ou 'copy de ads' ou 'textos de anúncio' ou 'copy para Meta'."
+area: copy
+author: luizfreitasv4
+version: 1.0.0
+dependencies:
+  - designer-manual-marca
+  - geral-persona-icp
+  - geral-posicionamento-estrategico
+inputs:
+  - client.json (briefing)
+  - designer-manual-marca.json
+  - geral-persona-icp.json
+  - geral-posicionamento-estrategico.json
+output: copy-anuncios.json
+export: google-sheets
+week: 4
+type: automated
+estimated_time: "2h"
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta versao foi portada do sistema de Estruturacao Estrategica. As regras abaixo tem precedencia sobre caminhos e persistencia citados no fluxo original:
+
+- Trabalhe somente em `squads/{squad}/clientes/{cliente}/`, nunca em um diretorio `clientes/` solto na raiz.
+- Leia primeiro o `CLAUDE.md` ou `AGENTS.md` da KB, `mission-control/`, `calls/`, `docs/` e `campanhas/`.
+- Se `client.json` existir, use-o como fonte complementar. Se nao existir, derive o contexto da KB e do Mission Control; nao exija nem invente esse arquivo.
+- Salve entregaveis em `squads/{squad}/clientes/{cliente}/outputs/`, em JSON e Markdown quando o fluxo pedir ambos.
+- Registre decisoes e progresso no `mission-control/historico-checkins.md` ou no arquivo de historico equivalente encontrado na KB.
+- Resolva recursos empacotados a partir do proprio diretorio desta skill. Se uma integracao externa nao estiver configurada, declare o gap e continue apenas com os dados reais disponiveis.
+
+
+# Copy de Anúncios — 30+ Variações por Funil × Plataforma (POP 3.10)
+
+> **Posição no fluxo:** Semana 4 — Identidade de Comunicação e Plano de Mídia (**comum** a todos os modelos) (e-commerce / inside-sales / pdv). Hook ancorado em dor/diferencial confirmado (não característica). A/B variando 1 elemento por vez.
+
+Você é um copywriter especializado em mídia paga para PMEs brasileiras. Vai criar a planilha completa de copy para anúncios prontas para subir no Meta Ads Manager e Google Ads.
+
+## Dados necessários
+
+1. `client.json` (seção `briefing`) — nome, segmento, produto/serviço, oferta, plataformas de mídia
+2. `outputs/designer-manual-marca.json` — tom de voz, vocabulário, headlines, CTAs, do's/don'ts
+3. `outputs/geral-persona-icp.json` — ICP, dores, desejos, objeções, linguagem
+4. `outputs/geral-posicionamento-estrategico.json` — PUV, diferenciais, posicionamento
+5. `client.json` (seção `history`) — decisões anteriores
+
+---
+
+## Geração
+
+Gere o output COMPLETO de uma vez usando os dados de `client.json` (briefing) e outputs de skills dependentes em `outputs/`.
+
+Consulte `references/regras-copy-performance.md` para limites de caracteres e regras de cada plataforma.
+
+### 30+ variações por fase do funil
+
+**TOPO DE FUNIL — Consciência do problema**
+Tom: educativo, empático, sem vender.
+- Meta Ads: texto principal (3 var, máx. 125 chars) + título (3 var, máx. 40 chars) + descrição (2 var, máx. 30 chars)
+- Google Ads Responsivo: títulos (5, máx. 30 chars) + descrições (3, máx. 90 chars)
+
+**MEIO DE FUNIL — Consideração**
+Tom: educativo + prova social.
+- Meta Ads: texto principal (3 var, com dado/resultado) + título (3 var)
+- Google Ads: títulos (5) + descrições (3)
+
+**FUNDO DE FUNIL — Conversão**
+Tom: direto, urgência real, benefício claro.
+- Meta Ads: texto principal (3 var, hooks: dor/resultado/urgência) + título (3 var) + descrição (2 var)
+- Google Ads: títulos com intenção de compra (5) + descrições com CTA direto (3)
+
+**REMARKETING**
+- Texto principal (2 var, diferente da copy fria) + título (2 var)
+
+**REGRAS DE COPY APLICADAS:** Liste as 5 principais regras aplicadas para que o consultor entenda a lógica.
+
+### Convenção de contagem (`total_variations` + `variations_breakdown`)
+
+`total_variations` conta **anúncios completos prontos pra subir**, não elementos textuais. A regra:
+
+- **1 Meta Ad** = 1 variação (texto + headline + descrição + CTA — entregue inteiro).
+- **1 Google RSA** = 1 variação (mesmo tendo 5 headlines + 3 descriptions dentro — o algoritmo rotaciona, mas é 1 anúncio).
+
+Sempre incluir `variations_breakdown` para desambiguar, exemplo:
+```json
+"total_variations": 14,
+"variations_breakdown": {
+  "meta_ads": 11,
+  "google_ads_rsa": 3,
+  "google_ads_textual_elements": 24,
+  "note": "1 Meta = 1 anúncio; 1 RSA = 1 anúncio com múltiplos elementos rotacionados."
+}
+```
+
+**Por quê:** versões anteriores contavam cada headline/description Google como variação separada — número inflado (35 em vez de 14) confundia o cliente, que abria o portal procurando 35 cards e via 14. Manter a contagem honesta evita que o cliente "perca" anúncios mentalmente.
+
+### Pareamento copy ↔ criativo (`pair_with_creative`)
+
+Se a skill `designer-criativos-anuncios` já gerou `produced_creatives` (PNGs prontos com IDs `feed-0N` / `story-0N`), adicione em cada variação Meta Ads o array `pair_with_creative` com os IDs dos criativos que casam com aquela copy. Exemplo:
+
+```json
+{ "hook_type": "prova_social", "text": "70% da base é tutora de gato. ...", "pair_with_creative": ["feed-01", "feed-04"] }
+```
+
+**Regra:** parear pelo hook_type (criativo `linked_variation` deve casar com a copy `hook_type`). Quando não houver criativo dedicado, **não invente** — omita o campo (o portal vai instruir o gestor a usar criativo neutro do funil).
+
+### Bloco didático `how_to_read_this_doc`
+
+Inclua no topo do JSON um bloco que explica ao cliente como ler o documento. É o que o portal renderiza como primeira seção da skill — vira manual de uso, não só dump de dados.
+
+```json
+"how_to_read_this_doc": {
+  "title": "Como usar este manual de copy",
+  "intro": "1 parágrafo explicando o que o doc entrega e como ele se conecta com criativos.",
+  "structure": [
+    { "section": "funnel_stages", "what": "...", "why": "..." },
+    { "section": "variations[].pair_with_creative", "what": "...", "why": "..." },
+    { "section": "char_limits_reference", "what": "...", "why": "..." },
+    { "section": "test_strategy", "what": "...", "why": "..." },
+    { "section": "copy_rules_applied", "what": "...", "why": "..." }
+  ],
+  "workflow_recommended": [
+    "1) Validar destination_url e CTA padrão.",
+    "2) Exportar para Sheets e revisar com gestor de tráfego.",
+    "3) Subir no Meta em adsets separados por hook_type.",
+    "4) Parear copy + criativo conforme pair_with_creative.",
+    "5) Rodar 7 dias com test_strategy.kpis_kill_criteria diários."
+  ]
+}
+```
+
+**Por quê:** o cliente que abre o portal não é copywriter. Sem essa seção, ele lê 35 textos sem saber a lógica de uso. Com ela, ele entende em 30s o sistema antes de mergulhar no detalhe.
+
+### Revisão em formato de planilha
+
+Apresente todas organizadas:
+```
+FASE       | PLATAFORMA | TIPO        | TEXTO                    | CHARS
+Topo       | Meta       | Principal   | "Você sabia que..."      | 98/125
+```
+
+### Exportação para Google Sheets
+
+Crie via GOG CLI:
+```bash
+gog sheets create --title "Copy Anúncios - {NOME_CLIENTE}" --no-input
+```
+4 abas: Topo, Meio, Fundo, Remarketing. Coluna "Status" para o consultor marcar como Aprovada/Rejeitada/Em teste.
+
+## Auto-validação
+
+Antes de mostrar ao operador, verifique:
+
+- [ ] Mencionou o cliente pelo nome?
+- [ ] Usou dados reais do client.json (não inventou)?
+- [ ] Nenhum item genérico (ex: "quer crescer", "qualidade e compromisso")?
+- [ ] Schema da skill validou?
+- [ ] Todos os campos do schema preenchidos (ou com `null` + `unavailable_reason` no pai)?
+- [ ] Nenhuma string vazia (`""`) — substituí por `null` + reason quando o dado não existe?
+- [ ] Estimativas marcadas com `estimated: true` ou `[E]`?
+- [ ] Consistente com outputs anteriores (brandbook, posicionamento)?
+- [ ] Nenhuma copy ultrapassa limite de caracteres da plataforma?
+- [ ] Copy do topo fala do PROBLEMA sem mencionar o produto?
+- [ ] Remarketing é diferente da copy fria (não repetição)?
+
+Se falhou → regenere silenciosamente. Não avise o operador.
+
+## Apresentação e decisões
+
+Apresente o output COMPLETO ao operador.
+
+Revise o output. O que está errado, exagerado ou faltando?
+
+- "A copy do topo fala do PROBLEMA sem mencionar o produto?"
+- "O fundo de funil tem CTA claro e específico?"
+- "O remarketing é diferente da copy fria?"
+- "Os limites de caracteres estão respeitados?"
+- "O tom é consistente com o brandbook?"
+- "Quer exportar para Google Sheets?"
+
+## Finalização
+
+Operador aprova (com ou sem ajustes).
+1. Salve em `squads/{squad}/clientes/{cliente}/outputs/copy-anuncios.json` (com campo `summary` no topo, incluindo link Sheets)
+2. Atualize `client.json`: progress.skills → completed, version++, append em history[]
+3. Salve também uma versão Markdown do entregável na mesma pasta de outputs.
+4. Sugira próxima skill do dependency_graph
+
+## Formato do output (copy-anuncios.json)
+
+```json
+{
+  "summary": "string",
+  "how_to_read_this_doc": {
+    "title": "string",
+    "intro": "string",
+    "structure": [{ "section": "string", "what": "string", "why": "string" }],
+    "workflow_recommended": ["string"]
+  },
+  "funnel_stages": [
+    {
+      "name": "topo_de_funil",
+      "objective": "Consciência do problema",
+      "tone": "Educativo, empático, sem vender",
+      "platforms": [
+        {
+          "name": "meta_ads",
+          "variations": [{
+            "type": "text_primary",
+            "hook_type": "dor",
+            "text": "string",
+            "headline": "string",
+            "description": "string",
+            "cta": "string",
+            "char_count": { "text": 98, "headline": 34, "description": 28 },
+            "pair_with_creative": ["feed-05", "story-01"]
+          }]
+        },
+        {
+          "name": "google_ads",
+          "variations": [{ "type": "responsive_search", "match_intent": "string", "headlines": ["string x5"], "descriptions": ["string x3"], "char_count_headlines": [29,25,26,28,23], "char_count_descriptions": [85,84,80] }]
+        }
+      ]
+    }
+  ],
+  "copy_rules_applied": ["string — 5 regras aplicadas"],
+  "char_limits_reference": {
+    "meta_ads": { "primary_text_max": 125, "headline_max": 40, "description_max": 30, "note": "string" },
+    "google_ads": { "headline_max": 30, "description_max": 90, "note": "string" }
+  },
+  "test_strategy": {
+    "duration_min_days": 7,
+    "min_budget_per_adset_brl": 30,
+    "kpis_kill_criteria": ["string"],
+    "kpis_winners": ["string"]
+  },
+  "total_variations": 30,
+  "sheets_url": "string — link do Google Sheets"
+}
+```
+
+
+## Campo obrigatório: summary
+
+Sempre inclua no JSON de saída:
+```json
+"summary": "Resumo de 1-2 frases do copy de anúncios: número de variações geradas e principais ganchos usados. Seja específico — mencione o cliente, números reais e a conclusão principal."
+```
+
+Este campo alimenta o Resumo Executivo do portal de entregas. Deve ser objetivo, com dados reais, sem genéricos.

--- a/.agents/skills/copy-anuncios/references/regras-copy-performance.md
+++ b/.agents/skills/copy-anuncios/references/regras-copy-performance.md
@@ -1,0 +1,157 @@
+# Regras de Copy para Performance — Limites e Boas Práticas por Plataforma
+
+Referência técnica para garantir que toda copy respeite limites de caracteres, regras de política e padrões de alta performance.
+
+---
+
+## Meta Ads (Facebook + Instagram)
+
+### Limites de caracteres
+
+| Campo | Limite técnico | Recomendado | Nota |
+|-------|---------------|-------------|------|
+| Texto principal (primary text) | 2.200 chars | 125 chars | Após 125, texto é truncado com "...ver mais" |
+| Título (headline) | 255 chars | 40 chars | Truncado em mobile após ~40 chars |
+| Descrição (description) | 255 chars | 30 chars | Só aparece no feed desktop, truncada em mobile |
+| Nome do botão CTA | Pré-definido | — | Saiba mais / Cadastre-se / Comprar / Fale conosco / etc. |
+
+### Regras de política (que causam reprovação)
+
+- **Afirmações pessoais diretas:** "Você está acima do peso?" → REPROVADO. Use "Muitas pessoas enfrentam dificuldade para..."
+- **Antes/depois:** Imagens de transformação física → REPROVADO em quase todos os casos
+- **Promessas absolutas:** "Garantimos 100% de resultado" → REPROVADO. Use "Nosso compromisso é..."
+- **Referência a atributos pessoais:** Raça, orientação, religião, condição financeira → REPROVADO
+- **Menção à plataforma:** "Viu esse anúncio no Facebook?" → REPROVADO
+- **Caps lock excessivo:** "OFERTA IMPERDÍVEL SOMENTE HOJE" → Pode ser reprovado ou ter alcance limitado
+- **Emojis no título:** Pode reduzir alcance (depende do período, Meta varia)
+
+### O que funciona em Meta Ads Brasil
+
+1. **Hook nos primeiros 3-5 palavras** — é o que aparece antes do truncamento
+2. **Pergunta na primeira frase** — gera curiosidade e engajamento
+3. **Números específicos** — "347 clientes em BH" > "centenas de clientes"
+4. **Emojis com parcimônia** — 1-2 no texto principal, 0 no título
+5. **CTA no texto + no botão** — redundância intencional funciona
+6. **Copy curta para fundo de funil** — quem já conhece não precisa de educação
+7. **Copy média para topo** — educa e gera interesse, mas não enrola
+
+### Estrutura de texto principal (Meta)
+
+**Topo de funil (educativo):**
+```
+[Pergunta ou dado impactante]
+[1-2 frases de contexto/empatia]
+[CTA leve: "Saiba mais no link"]
+```
+
+**Meio de funil (prova social):**
+```
+[Resultado concreto de cliente]
+[Como foi alcançado em 1 frase]
+[CTA: "Veja como funciona"]
+```
+
+**Fundo de funil (conversão):**
+```
+[Oferta direta com benefício]
+[Urgência real ou escassez]
+[CTA forte: "Fale com a gente agora"]
+```
+
+---
+
+## Google Ads (Search — Responsive Search Ads)
+
+### Limites de caracteres
+
+| Campo | Limite | Quantidade |
+|-------|--------|-----------|
+| Título (headline) | 30 caracteres cada | Até 15 títulos (mín. 3) |
+| Descrição | 90 caracteres cada | Até 4 descrições (mín. 2) |
+| URL de exibição (paths) | 15 caracteres cada | 2 paths |
+
+### Como o responsivo funciona
+
+O Google combina seus títulos e descrições automaticamente. Por isso:
+- **Cada título deve funcionar sozinho** (não depender de outro para fazer sentido)
+- **Não repita a mesma mensagem** em títulos diferentes (Google penaliza redundância)
+- **Fixe (pin)** apenas se necessário: Título 1 fixo = nome da marca ou oferta principal
+- **Diversifique os hooks:** dor, resultado, autoridade, oferta, CTA
+
+### Regras de política Google Ads
+
+- **Pontuação excessiva:** "Melhor preço!!!" → REPROVADO. Máx. 1 ponto de exclamação por anúncio
+- **Caps lock:** "MELHOR PREÇO" → REPROVADO. Use capitalização normal
+- **Superlativos sem prova:** "O melhor do Brasil" → Precisa de certificação de terceiros
+- **Marca registrada:** Usar nome de concorrente → Pode ser contestado
+- **Símbolos não padrão:** Setas unicode (→, ►) → Podem ser reprovadas
+- **Espaçamento abusivo:** "M E L H O R" → REPROVADO
+
+### O que funciona em Google Ads Brasil
+
+1. **Palavra-chave no Título 1** — corresponde à busca do usuário
+2. **Número no Título 2** — "R$ 99/mês" ou "Em 7 dias" (específico)
+3. **CTA na Descrição 1** — "Solicite um orçamento gratuito"
+4. **Prova social na Descrição 2** — "+500 clientes em SP"
+5. **Paths descritivos** — exemplo.com/orcamento/gratuito
+6. **Extensões** — sempre adicione: sitelinks, callouts, snippets, preço
+
+### Tipos de título por intenção
+
+**Informacional (topo):**
+- "O que é [serviço] e por que importa"
+- "Guia completo de [tema]"
+- "[Número] dicas para [resultado]"
+
+**Comercial (meio):**
+- "[Serviço] em [Cidade] - Orçamento"
+- "Compare opções de [serviço]"
+- "[Número] clientes confiam em nós"
+
+**Transacional (fundo):**
+- "Contrate [serviço] - Sem contrato"
+- "[Serviço] a partir de R$ [valor]"
+- "Orçamento grátis em 24h"
+
+---
+
+## Regras universais de copy de performance
+
+### 1. Hierarquia de hooks (do mais ao menos efetivo)
+
+1. **Dor específica do ICP** — "Perdendo leads por falta de follow-up?"
+2. **Resultado com número** — "340 restaurantes já economizam R$ 3.000/mês"
+3. **Curiosidade/pergunta** — "Você sabia que 73% dos leads não recebem resposta em 24h?"
+4. **Prova social** — "Avaliado com 4.9★ por +200 clientes"
+5. **Urgência real** — "Últimas 5 vagas para onboarding em abril"
+6. **Oferta direta** — "Diagnóstico gratuito: descubra por que seus anúncios não convertem"
+
+### 2. Fórmulas de copy comprovadas
+
+**PAS (Problem → Agitation → Solution):**
+Problema: "Seus leads somem depois do primeiro contato?"
+Agitação: "Cada lead ignorado é dinheiro jogado fora. E quanto mais demora, menos vale."
+Solução: "Automatize o follow-up com [produto]. Resposta em segundos, 24/7."
+
+**AIDA (Attention → Interest → Desire → Action):**
+Atenção: "R$ 12.000 em comissões economizadas"
+Interesse: "A Cantina Mineira trocou o iFood por delivery próprio"
+Desejo: "Sem comissão, sem intermediário, ticket 35% maior"
+Ação: "Monte seu delivery direto em 7 dias"
+
+**BAB (Before → After → Bridge):**
+Antes: "Dependendo 100% de indicação para novos clientes"
+Depois: "30 leads qualificados por mês no seu WhatsApp"
+Ponte: "[Produto] conecta você aos clientes que já buscam o que você vende"
+
+### 3. Checklist antes de aprovar
+
+- [ ] Limite de caracteres respeitado em TODAS as variações
+- [ ] Hook nos primeiros 3-5 palavras
+- [ ] Nenhuma copy do topo menciona produto/marca
+- [ ] Fundo de funil tem urgência REAL (não fake)
+- [ ] Remarketing é diferente da copy fria
+- [ ] Tom consistente com designer-manual-marca (vocabulário, tratamento)
+- [ ] Nenhuma violação de política de plataforma
+- [ ] Mínimo 30 variações no total
+- [ ] Cada variação testa um hook/ângulo diferente (não paráfrases do mesmo)

--- a/.agents/skills/copy-anuncios/schema.json
+++ b/.agents/skills/copy-anuncios/schema.json
@@ -1,0 +1,387 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Copy de Anúncios",
+  "description": "Output estruturado de copy de anúncios: variações por fase de funil e plataforma, com limites de caracteres.",
+  "type": "object",
+  "required": [
+    "summary",
+    "funnel_stages",
+    "copy_rules_applied",
+    "total_variations",
+    "client_name",
+    "summary_headline",
+    "summary_highlights",
+    "summary_key_findings"
+  ],
+  "properties": {
+    "client_name": {
+      "type": "string",
+      "description": "Nome do cliente — sempre presente em todo output."
+    },
+    "summary": {
+      "type": "string",
+      "description": "Resumo de 1-2 frases da copy de anúncios. Inclui número de variações geradas e principais ganchos usados."
+    },
+    "summary_headline": {
+      "type": "string",
+      "description": "Manchete em 1 linha (~120 caracteres) com o veredito da skill."
+    },
+    "summary_highlights": {
+      "type": "array",
+      "description": "KPIs em destaque (4-6 itens). Categorias: posicao | competicao | janela | maturidade | oportunidade | risco.",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "label",
+          "value",
+          "tone"
+        ],
+        "properties": {
+          "category": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "subtext": {
+            "type": "string"
+          },
+          "tone": {
+            "type": "string",
+            "enum": [
+              "green",
+              "yellow",
+              "red",
+              "blue",
+              "gray"
+            ]
+          }
+        }
+      }
+    },
+    "summary_key_findings": {
+      "type": "array",
+      "description": "3-5 achados categorizados (vantagem | contexto | ameaca | acao).",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "text"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "vantagem",
+              "contexto",
+              "ameaca",
+              "acao"
+            ]
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "funnel_stages": {
+      "type": "array",
+      "description": "Fases do funil com variações de copy por plataforma.",
+      "minItems": 4,
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "objective",
+          "tone",
+          "platforms"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "enum": [
+              "topo_de_funil",
+              "meio_de_funil",
+              "fundo_de_funil",
+              "remarketing"
+            ],
+            "description": "Fase do funil"
+          },
+          "objective": {
+            "type": "string",
+            "description": "Objetivo da fase"
+          },
+          "tone": {
+            "type": "string",
+            "description": "Tom recomendado para esta fase"
+          },
+          "platforms": {
+            "type": "array",
+            "description": "Plataformas de mídia com variações.",
+            "items": {
+              "type": "object",
+              "required": [
+                "name",
+                "variations"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "enum": [
+                    "meta_ads",
+                    "google_ads"
+                  ],
+                  "description": "Plataforma de mídia"
+                },
+                "variations": {
+                  "type": "array",
+                  "description": "Variações de copy para esta plataforma.",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "type"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "description": "Tipo de variação (text_primary, responsive_search, etc.)"
+                      },
+                      "text": {
+                        "type": "string",
+                        "description": "Texto principal do anúncio"
+                      },
+                      "headline": {
+                        "type": "string",
+                        "description": "Título do anúncio"
+                      },
+                      "description": {
+                        "type": "string",
+                        "description": "Descrição do anúncio"
+                      },
+                      "cta": {
+                        "type": "string",
+                        "description": "Call-to-action do botão"
+                      },
+                      "headlines": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Títulos para Google Ads responsivo"
+                      },
+                      "descriptions": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Descrições para Google Ads responsivo"
+                      },
+                      "char_count": {
+                        "type": "object",
+                        "description": "Contagem de caracteres por campo",
+                        "properties": {
+                          "text": {
+                            "type": "integer"
+                          },
+                          "headline": {
+                            "type": "integer"
+                          },
+                          "description": {
+                            "type": "integer"
+                          }
+                        }
+                      },
+                      "hook_type": {
+                        "type": "string",
+                        "description": "Ângulo emocional/argumentativo do copy (dor, prova_social, oferta_direta, etc). Cruza com 'linked_variation' do produced_creatives."
+                      },
+                      "match_intent": {
+                        "type": "string",
+                        "description": "(Google Ads) Intenção de busca alvo desta RSA — informacional, comparativa, transacional."
+                      },
+                      "char_count_headlines": {
+                        "type": "array",
+                        "items": {
+                          "type": "integer"
+                        },
+                        "description": "(Google Ads) Contagem de chars por headline, na ordem do array."
+                      },
+                      "char_count_descriptions": {
+                        "type": "array",
+                        "items": {
+                          "type": "integer"
+                        },
+                        "description": "(Google Ads) Contagem de chars por description, na ordem do array."
+                      },
+                      "pair_with_creative": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "IDs dos criativos visuais (feed-0N / story-0N) que devem rodar com esta copy. Cruza com produced_creatives.feed_instagram[].id e .stories_instagram[].id em designer-criativos-anuncios. Omitir quando não houver criativo dedicado."
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "copy_rules_applied": {
+      "type": "array",
+      "description": "5 regras de copy aplicadas neste conjunto.",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 5
+    },
+    "total_variations": {
+      "type": "integer",
+      "description": "Total de ANÚNCIOS COMPLETOS prontos pra subir (não conta cada elemento textual). 1 Meta = 1 anúncio. 1 Google RSA = 1 anúncio (mesmo tendo 5 headlines + 3 descriptions dentro). Use 'variations_breakdown' para detalhar a composição.",
+      "minimum": 1
+    },
+    "variations_breakdown": {
+      "type": "object",
+      "description": "Quebra detalhada da contagem de total_variations — desambigua 'anúncio completo' vs 'elemento textual'.",
+      "properties": {
+        "meta_ads": {
+          "type": "integer",
+          "description": "Quantidade de anúncios Meta (cada um é uma variação completa)."
+        },
+        "google_ads_rsa": {
+          "type": "integer",
+          "description": "Quantidade de RSAs Google (cada uma é 1 anúncio que rotaciona internamente)."
+        },
+        "google_ads_textual_elements": {
+          "type": "integer",
+          "description": "Soma dos headlines + descriptions DENTRO das RSAs (informativo — não conta como anúncio separado)."
+        },
+        "note": {
+          "type": "string",
+          "description": "Explicação curta da convenção de contagem."
+        }
+      }
+    },
+    "sheets_url": {
+      "type": "string",
+      "format": "uri",
+      "description": "URL da planilha Google Sheets exportada"
+    },
+    "how_to_read_this_doc": {
+      "type": "object",
+      "description": "Bloco didático que explica ao cliente como ler e usar este documento. Renderizado como primeira seção da skill no portal.",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "intro": {
+          "type": "string",
+          "description": "1 parágrafo — o que o doc entrega e como conecta com criativos."
+        },
+        "structure": {
+          "type": "array",
+          "description": "Explicação seção-a-seção do JSON. Cada item: section (nome do campo), what (o que é), why (por que está aqui).",
+          "items": {
+            "type": "object",
+            "required": [
+              "section",
+              "what",
+              "why"
+            ],
+            "properties": {
+              "section": {
+                "type": "string"
+              },
+              "what": {
+                "type": "string"
+              },
+              "why": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "workflow_recommended": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Passos numerados de uso prático (validar → exportar → subir → parear → testar)."
+        }
+      }
+    },
+    "char_limits_reference": {
+      "type": "object",
+      "description": "Limites oficiais de caracteres por plataforma — referência rápida ao lado das variações.",
+      "properties": {
+        "meta_ads": {
+          "type": "object",
+          "properties": {
+            "primary_text_max": {
+              "type": "integer"
+            },
+            "headline_max": {
+              "type": "integer"
+            },
+            "description_max": {
+              "type": "integer"
+            },
+            "note": {
+              "type": "string"
+            }
+          }
+        },
+        "google_ads": {
+          "type": "object",
+          "properties": {
+            "headline_max": {
+              "type": "integer"
+            },
+            "description_max": {
+              "type": "integer"
+            },
+            "note": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "test_strategy": {
+      "type": "object",
+      "description": "Critérios para rodar A/B com essas copies — duração, budget e KPIs de kill/winner.",
+      "properties": {
+        "duration_min_days": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "min_budget_per_adset_brl": {
+          "type": "number",
+          "minimum": 0
+        },
+        "kpis_kill_criteria": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Quando pausar (ex: CTR <1% após 1k impressões)."
+        },
+        "kpis_winners": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Quando escalar (ex: CTR ≥1,8%)."
+        }
+      }
+    }
+  }
+}

--- a/.agents/skills/copy-scripts-sdr/SKILL.md
+++ b/.agents/skills/copy-scripts-sdr/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: copy-scripts-sdr
+description: "Cria scripts completos do SDR IA para WhatsApp: boas-vindas, qualificacao com scoring, fluxo por score, tratamento de objecoes e follow-up. Use quando o operador disser 'scripts sdr', 'script do agente', 'mensagens do sdr', 'fluxo de qualificacao', ou na cauda da Semana 3 (POP 3.7)."
+area: copy
+author: luizfreitasv4
+version: 1.0.0
+dependencies:
+  - designer-manual-marca
+outputs: ["copy-scripts-sdr.json"]
+week: 4
+estimated_time: "3h"
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta versao foi portada do sistema de Estruturacao Estrategica. As regras abaixo tem precedencia sobre caminhos e persistencia citados no fluxo original:
+
+- Trabalhe somente em `squads/{squad}/clientes/{cliente}/`, nunca em um diretorio `clientes/` solto na raiz.
+- Leia primeiro o `CLAUDE.md` ou `AGENTS.md` da KB, `mission-control/`, `calls/`, `docs/` e `campanhas/`.
+- Se `client.json` existir, use-o como fonte complementar. Se nao existir, derive o contexto da KB e do Mission Control; nao exija nem invente esse arquivo.
+- Salve entregaveis em `squads/{squad}/clientes/{cliente}/outputs/`, em JSON e Markdown quando o fluxo pedir ambos.
+- Registre decisoes e progresso no `mission-control/historico-checkins.md` ou no arquivo de historico equivalente encontrado na KB.
+- Resolva recursos empacotados a partir do proprio diretorio desta skill. Se uma integracao externa nao estiver configurada, declare o gap e continue apenas com os dados reais disponiveis.
+
+
+# Scripts e Fluxos de Qualificacao do SDR IA (POP 3.7)
+
+> **Posição no fluxo:** Semana 4 — Identidade de Comunicação e Plano de Mídia (**comum** a todos os modelos) a todos os modelos. Consome o diagnóstico comercial **do modelo** quando existe (inside-sales → account-diagnostico-comercial; e-commerce → funil/recuperação; pdv → base ativa/experiência) para calibrar a qualificação; o tom vem do Manual de Marca.
+
+Voce e um especialista em scripts de vendas conversacionais para WhatsApp. Vai criar, junto com o operador, todos os scripts e fluxos que o SDR IA vai usar para qualificar leads no WhatsApp. Os scripts devem ser naturais, curtos e alinhados ao tom de voz da marca.
+
+> **REGRAS FUNDAMENTAIS (aplicam a TODOS os scripts):**
+> - Maximo 3 frases por mensagem (WhatsApp nao e email)
+> - Tom deve seguir EXATAMENTE o Manual de Marca do cliente (designer-manual-marca)
+> - Linguagem natural, nunca robotica — o lead nao pode perceber que e IA
+> - Nunca prometer preco, prazo ou condicao sem autorizacao
+> - Nunca usar emojis em excesso (maximo 1 por mensagem, se coerente com tom)
+> - Nunca enviar bloco de texto — quebre em mensagens curtas
+> - Use o nome do lead sempre que disponivel
+
+## Dados necessários
+
+1. `client.json` (seção `briefing`) — NOME_CLIENTE, PRODUTO_SERVICO, TICKET_MEDIO
+2. `outputs/geral-persona-icp.json` — RESUMO_ICP, dores, comportamento, canais
+3. `outputs/account-diagnostico-comercial.json` — criterios 1-5 estrelas, objecoes mapeadas, SLA
+4. `outputs/designer-manual-marca.json` — TOM_DE_VOZ, personalidade, vocabulario, palavras proibidas
+5. `outputs/account-cliente-oculto.json` — se existir, pontos criticos identificados
+
+Confirme com o operador:
+
+> Vou criar os scripts do SDR IA para {NOME_CLIENTE}.
+> Nome do agente SDR: {se definido, ou pergunte — deve ser nome humano}
+> Tom de voz: {do brandbook}
+> Criterios de qualificacao: {resumo 5/4/3/1-2 estrelas}
+> Objecoes a tratar: {lista}
+
+Consulte `references/exemplos-scripts-sdr-whatsapp.md` para padroes de scripts naturais.
+
+---
+
+## Geração
+
+Gere o output COMPLETO de uma vez: boas-vindas + qualificação + fluxos por score + objeções + follow-up + handoff. Use os dados de `client.json` (briefing) e outputs de skills dependentes em `outputs/`.
+
+### Mensagem de boas-vindas (3 opções)
+
+**Opção A (Direta):** apresentação + objetivo + primeira pergunta
+**Opção B (Empática):** empatia com dor + oferta de ajuda
+**Opção C (Curiosa):** pergunta aberta sobre o desafio
+
+Para cada: a mensagem (máx 3 frases) + melhor contexto de uso. Recomendação com justificativa baseada no brandbook.
+
+### Perguntas de qualificação com lógica de scoring (4-5 perguntas)
+
+Para cada pergunta:
+- Pergunta natural (nunca "interrogatório")
+- O que revela sobre o lead
+- Influência no score: +2 / +1 / 0 / -1 (com descrição de cada resposta)
+- Transição natural para a próxima pergunta
+
+**Tabela de scoring:** total 8-10 → 5★, 5-7 → 4★, 2-4 → 3★, 0-1 → 2★, negativo → 1★
+
+**Regras de conversa:** adaptar tom, não fazer 2 perguntas por vez, responder perguntas do lead antes de continuar.
+
+### Fluxo de resposta por score
+
+**Lead 4-5★ (qualificado):** 3 mensagens (valoriza → informa próximo passo → cria expectativa com SLA) + encaminhar para vendedor
+**Lead 3★ (morno):** 2 mensagens (mantém interesse → oferece valor sem vender) + régua de nutrição
+**Lead 1-2★ (frio):** 1-2 mensagens (agradece sem queimar → oferece algo leve) + nutrição passiva
+
+### Tratamento de objeções
+
+Para CADA objeção do diagnóstico:
+- Objeção exata + tipo
+- Resposta do SDR IA (máx 3 frases, natural)
+- Se insistir: segunda resposta ou escalar para humano
+
+**Objeções não mapeadas:** resposta genérica de reconhecimento + escalamento
+**Regra de escalamento:** 2x mesma objeção → humano. Irritação → imediato. "Pessoa de verdade" → imediato.
+
+### Follow-up
+
+- 1h sem resposta: mensagem leve
+- 24h sem resposta: conteúdo de valor
+- 3 dias sem resposta: encerramento gentil
+
+**Regras:** máx 3 follow-ups, nunca antes de 1h (exceto 5★: 30min), respeitar "não me contacte", horário 9h-19h.
+
+### Handoff para humano
+
+- Quando qualificado (4-5★): transição natural para vendedor
+- Quando lead pede: transição respeitosa
+- Quando SDR não sabe: transição por limitação
+
+**REGRA:** A transição NUNCA revela que é IA. Natural como atendente passando para especialista.
+
+## Auto-validação
+
+Antes de mostrar ao operador, verifique:
+
+- [ ] Mencionou o cliente pelo nome?
+- [ ] Usou dados reais do client.json (não inventou)?
+- [ ] Nenhum item genérico?
+- [ ] Schema validou?
+- [ ] Consistente com brandbook (tom, vocabulário, palavras proibidas)?
+- [ ] Todas as mensagens têm máx 3 frases?
+- [ ] Perguntas soam naturais (não interrogatório)?
+- [ ] Lógica de scoring é consistente com critérios do diagnóstico?
+
+Se falhou → regenere silenciosamente.
+
+## Apresentação e decisões
+
+Apresente o output COMPLETO ao operador.
+
+**DECISÃO 1:** Mensagem de boas-vindas — qual opção?
+- Opção A: "[mensagem direta]"
+- Opção B: "[mensagem empática]"
+- Opção C: "[mensagem curiosa]"
+
+**RECOMENDAÇÃO:** Opção [X]. [Justificativa baseada no brandbook e ICP.]
+
+**PROVOCAÇÃO:** [Ex: "Essa mensagem funciona quando o lead vem de um anúncio de dor? E quando vem de um de resultado?"]
+
+Valide também:
+- "As perguntas soam naturais? O lead nao vai sentir interrogatório?"
+- "A logica de scoring faz sentido com os criterios de qualificacao?"
+- "Os fluxos por score fazem sentido para a realidade do time?"
+- "As respostas de objecoes estao naturais?"
+- "O nome do vendedor para handoff e {NOME} — correto?"
+- "Os follow-ups estão no tom certo? Nenhum soa como spam?"
+
+**IMPORTANTE:** Estes scripts devem ser aprovados pelo CLIENTE antes de configurar no Patagon.
+
+## Finalização
+
+Operador aprova (com ou sem ajustes).
+1. Salve em `squads/{squad}/clientes/{cliente}/outputs/copy-scripts-sdr.json` (com campo `summary` no topo)
+2. Atualize `client.json`: progress.skills → completed, version++, append em history[]
+3. Salve também uma versão Markdown do entregável na mesma pasta de outputs.
+4. Sugira próxima skill do dependency_graph
+   - "Scripts SDR IA salvos. Agente: {nome}. {N} perguntas de qualificação. {N} objeções tratadas."
+   - Sugira: `/account-sdr-ia-config` para configurar no Patagon e integrar com Kommo

--- a/.agents/skills/copy-scripts-sdr/references/exemplos-scripts-sdr-whatsapp.md
+++ b/.agents/skills/copy-scripts-sdr/references/exemplos-scripts-sdr-whatsapp.md
@@ -1,0 +1,313 @@
+# Exemplos de Scripts SDR para WhatsApp
+
+Referencia de scripts naturais para SDR IA em WhatsApp. Todos os exemplos seguem as regras: max 3 frases por mensagem, linguagem natural, sem parecer robo.
+
+---
+
+## Principios de Scripts para WhatsApp
+
+### O que diferencia WhatsApp de outros canais
+
+1. **Informalidade esperada:** WhatsApp e pessoal. O lead espera conversa, nao pitch.
+2. **Mensagens curtas:** Blocos de texto longos sao ignorados. Max 3 frases por balao.
+3. **Velocidade:** Lead espera resposta em segundos/minutos, nao horas.
+4. **Contexto:** O lead pode estar no onibus, no almoco, na fila. Facilite a resposta.
+5. **Audio:** Muitos leads preferem audio. O SDR IA deve funcionar em texto.
+6. **Emojis com moderacao:** 1 emoji por mensagem no maximo. Nenhum e preferivel para tom profissional.
+
+### Erros fatais em scripts de WhatsApp
+
+| Erro | Exemplo ruim | Alternativa |
+|------|-------------|-------------|
+| Mensagem longa | "Ola! Obrigado por entrar em contato com a [empresa]. Somos especialistas em [area] e oferecemos [lista de servicos]. Nossos diferenciais sao [lista]. Gostaria de agendar uma reuniao para conversarmos melhor sobre como podemos ajuda-lo?" | "Oi, [nome]! Sou a Ana da [empresa]. Me conta, o que te motivou a procurar a gente?" |
+| Tom robotico | "Prezado(a), recebemos sua solicitacao. Um de nossos consultores entrara em contato em breve." | "E ai, [nome]! Vi sua mensagem agora. Me fala mais sobre o que voce precisa?" |
+| Interrogatorio | "Qual seu nome? Qual sua empresa? Qual seu orcamento? Quando precisa?" | Distribuir as perguntas ao longo da conversa, uma por vez |
+| Forcar venda cedo | "Temos uma promocao incrivel! So ate sexta! Quer aproveitar?" | "Entendi seu caso. Posso te mostrar como outros [perfil similar] resolveram isso?" |
+| Ignorar o que o lead disse | Lead: "Preciso de ajuda com X" / Atendente: "Nossos planos sao A, B e C" | Repetir o que o lead disse: "Entendi, voce precisa de ajuda com X. Me conta mais..." |
+
+---
+
+## Exemplos por Segmento
+
+### Saude e Estetica (Clinica, Dentista, Personal)
+
+**Boas-vindas:**
+```
+Oi, [nome]! Aqui e a Bia da [clinica].
+Vi que voce se interessou pelo [tratamento/servico].
+Posso te ajudar com algumas informacoes — me conta, e pra voce ou pra alguem da familia?
+```
+
+**Qualificacao (necessidade):**
+```
+Entendi! E a primeira vez que voce faz esse tipo de tratamento ou ja fez antes em outro lugar?
+```
+
+**Qualificacao (urgencia):**
+```
+E voce ta querendo comecar logo ou ainda ta pesquisando opcoes?
+```
+
+**Qualificacao (orcamento — indireta):**
+```
+Perfeito! Pra eu te passar as melhores opcoes, voce ja tem uma ideia de quanto pretende investir nesse momento?
+```
+
+**Objecao de preco:**
+```
+Entendo, [nome]. O investimento realmente precisa fazer sentido.
+O que muitos pacientes me dizem e que o resultado compensa — a Maria, por exemplo, fez o mesmo tratamento e ficou super satisfeita.
+Quer que eu te mostre as opcoes de parcelamento?
+```
+
+### Educacao (Curso, Escola, Treinamento)
+
+**Boas-vindas:**
+```
+Oi, [nome]! Sou o Lucas da [escola].
+Que bom que voce se interessou pelo [curso]!
+Me conta uma coisa: voce ja trabalha na area ou ta querendo comecar?
+```
+
+**Qualificacao (necessidade):**
+```
+Legal! E o que te fez procurar o curso agora? Teve algum motivo especifico?
+```
+
+**Qualificacao (urgencia):**
+```
+Entendi! E voce quer comecar na proxima turma ou ta planejando pra mais pra frente?
+```
+
+**Qualificacao (autoridade):**
+```
+Massa! E essa decisao e so sua ou voce precisa combinar com alguem? Pergunto porque as vagas sao limitadas e quero garantir a sua.
+```
+
+**Objecao de preco:**
+```
+Entendo a preocupacao com o valor, [nome].
+Uma forma de pensar: quanto voce deixa de ganhar por mes sem essa qualificacao? O curso se paga em [X] meses com o aumento que nossos alunos conseguem.
+Quer que eu te mostre o parcelamento?
+```
+
+### Servicos B2B (Consultoria, Agencia, SaaS)
+
+**Boas-vindas:**
+```
+Oi, [nome]! Aqui e a Ana da [empresa].
+Vi que voce se interessou pelo nosso [servico].
+Me conta um pouco sobre o seu negocio — o que ta te travando hoje?
+```
+
+**Qualificacao (necessidade):**
+```
+Interessante. E como voce esta lidando com isso hoje? Tem alguem ou alguma ferramenta cuidando disso ou esta tudo manual?
+```
+
+**Qualificacao (urgencia):**
+```
+Faz sentido. E isso e algo que voce precisa resolver esse mes ou ta planejando pro proximo trimestre?
+```
+
+**Qualificacao (autoridade):**
+```
+Perfeito! Pra eu te dar a melhor solucao: alem de voce, tem mais alguem que participa dessa decisao na empresa?
+```
+
+**Qualificacao (orcamento — indireta):**
+```
+Legal! Pra eu entender melhor: voces ja investem em algo parecido hoje? Quanto mais ou menos?
+```
+
+**Objecao de preco:**
+```
+Entendo, [nome]. Investimento precisa ter retorno claro.
+Posso te mostrar o caso do [cliente similar] que comecou parecido com voces e em [tempo] conseguiu [resultado mensuravel]?
+Normalmente isso ajuda a visualizar o ROI.
+```
+
+### Servicos Locais (Reformas, Manutencao, Dedetizacao)
+
+**Boas-vindas:**
+```
+Oi, [nome]! Sou o Carlos da [empresa].
+Vi que voce precisa de [servico].
+Me fala um pouco: e pra casa ou empresa? E em que bairro/regiao?
+```
+
+**Qualificacao (urgencia):**
+```
+Entendi! E voce precisa disso pra quando? Tem alguma urgencia ou pode ser agendado?
+```
+
+**Qualificacao (orcamento — indireta):**
+```
+Beleza! Voce ja fez orcamento com alguem ou estamos no inicio?
+```
+
+**Objecao de preco:**
+```
+Entendo, [nome]. So pra voce ter seguranca: nosso servico inclui [diferencial 1] e [diferencial 2], que normalmente nao vem nos orcamentos mais baratos.
+Quer que eu detalhe o que ta incluido?
+```
+
+---
+
+## Padroes de Perguntas de Qualificacao
+
+### Perguntas que FUNCIONAM (naturais, uma por vez)
+
+| Dimensao | Pergunta natural | Alternativa |
+|----------|-----------------|-------------|
+| Necessidade | "Me conta, o que te motivou a procurar isso agora?" | "O que ta te incomodando mais em relacao a [tema]?" |
+| Urgencia | "Voce quer resolver isso logo ou ta mais no modo pesquisa?" | "Tem algum prazo ou evento que te motivou a buscar agora?" |
+| Autoridade | "Alem de voce, tem mais alguem que participa dessa decisao?" | "Voce decide isso sozinho ou precisa alinhar com alguem?" |
+| Orcamento | "Voce ja investe em algo parecido hoje?" | "Voce ja tem uma faixa de investimento em mente?" |
+| Experiencia | "Voce ja tentou resolver isso antes? Como foi?" | "Ja trabalhou com alguma empresa parecida com a gente?" |
+
+### Perguntas que NAO funcionam (roboticas, invasivas)
+
+| Evitar | Por que nao funciona |
+|--------|---------------------|
+| "Qual seu orcamento?" | Muito direto, parece que so quer vender |
+| "Voce e o decisor?" | Jargao corporativo, assusta lead pequeno |
+| "Qual seu faturamento?" | Invasivo demais no primeiro contato |
+| "Pode me passar seu email?" | Parece que vai mandar spam |
+| "Tem CNPJ?" | Burocracia antes de criar conexao |
+
+---
+
+## Padroes de Tratamento de Objecoes
+
+### Framework LPRA (Listen, Pause, Respond, Advance)
+
+1. **Listen (Ouca):** Repita o que o lead disse para mostrar que entendeu
+2. **Pause:** Nao responda imediatamente com argumento (1-2 frases antes)
+3. **Respond:** Ofereça perspectiva ou prova social (nao argumente)
+4. **Advance:** Proponha proximo passo concreto
+
+### Exemplos por tipo de objecao
+
+**PRECO:**
+```
+Lead: "Achei caro, o outro orcamento foi metade disso"
+
+SDR: "Entendo, [nome]. Preco e importante mesmo.
+Uma coisa que nossos clientes sempre falam: eles tentaram o mais barato antes e acabaram gastando o dobro pra refazer.
+Quer que eu te mostre o que ta incluido no nosso pra voce comparar de verdade?"
+```
+
+**URGENCIA ("vou pensar"):**
+```
+Lead: "Vou pensar e te dou um retorno semana que vem"
+
+SDR: "Sem problema, [nome]! Pensar com calma e importante.
+So te aviso que [condicao/escassez real, se houver].
+Posso te mandar um resumo por aqui pra facilitar quando voce for decidir?"
+```
+
+**AUTORIDADE ("preciso falar com meu socio"):**
+```
+Lead: "Preciso conversar com meu socio primeiro"
+
+SDR: "Faz total sentido, [nome]! Decisao em conjunto e mais segura.
+Quer que eu prepare um resumo que voce possa mostrar pra ele?
+Ou, se preferir, posso incluir ele numa conversa rapida de 10 minutos."
+```
+
+**CONFIANCA ("nao conheco voces"):**
+```
+Lead: "Nunca ouvi falar de voces, como sei que funciona?"
+
+SDR: "Boa pergunta, [nome]! Normal querer seguranca.
+A [empresa] ja atendeu [numero] clientes em [regiao/segmento] — posso te mandar alguns depoimentos de quem e parecido com voce?
+E se quiser, pode ligar pra [referencia] que e nosso cliente."
+```
+
+**NECESSIDADE ("ja tenho algo parecido"):**
+```
+Lead: "Ja uso o [concorrente/alternativa]"
+
+SDR: "Legal que voce ja tem uma solucao, [nome]!
+Me conta: o que te fez procurar outra opcao? Geralmente e porque [dor comum].
+Se for isso, posso te mostrar como resolvemos isso de um jeito diferente."
+```
+
+---
+
+## Mensagens de Follow-up que Funcionam
+
+### Depois de 1 hora
+
+**Bom:**
+```
+Oi, [nome]! Sei que o dia ta corrido.
+Quando puder, me responde aqui que eu te ajudo rapidinho!
+```
+
+**Ruim:**
+```
+Ola, verificamos que voce nao respondeu. Ainda tem interesse?
+```
+
+### Depois de 24 horas
+
+**Bom:**
+```
+E ai, [nome]! Lembrei da nossa conversa de ontem.
+Separei [conteudo/caso/informacao] que pode te ajudar com [dor].
+Quer que eu te mande?
+```
+
+**Ruim:**
+```
+Bom dia! Estou entrando em contato novamente para dar continuidade.
+```
+
+### Depois de 3 dias (ultimo)
+
+**Bom:**
+```
+[nome], so passando pra dizer que fico por aqui se precisar!
+Quando quiser retomar, e so me chamar.
+Bom restinho de semana!
+```
+
+**Ruim:**
+```
+ULTIMA TENTATIVA DE CONTATO. Temos uma proposta especial para voce.
+```
+
+---
+
+## Mensagem de Handoff (SDR IA para Humano)
+
+### Transicao natural — lead nao percebe a troca
+
+**Bom:**
+```
+Perfeito, [nome]! Pelo que voce me contou, o [nome_vendedor] e a pessoa certa pra te ajudar com isso.
+Ele ja vai ter todo o contexto da nossa conversa.
+Te chama nos proximos minutos!
+```
+
+**Ruim:**
+```
+Vou te transferir para o setor comercial. Aguarde.
+```
+
+### Quando o lead pede para falar com humano
+
+**Bom:**
+```
+Claro, [nome]! Vou chamar o [nome_vendedor] — ele cuida pessoalmente dos novos clientes.
+Voce nao vai precisar repetir nada, ele ja tem todas as infos.
+```
+
+**Ruim:**
+```
+Entendo. Infelizmente sou um chatbot e nao consigo ajudar com isso. Vou transferir.
+```
+
+REGRA DE OURO: A transicao NUNCA deve revelar que era IA. Deve parecer que um atendente esta passando para o especialista.

--- a/.agents/skills/copy-scripts-sdr/schema.json
+++ b/.agents/skills/copy-scripts-sdr/schema.json
@@ -1,0 +1,410 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ScriptsSDR",
+  "description": "Output estruturado da skill scripts-sdr: scripts completos do SDR IA para WhatsApp incluindo boas-vindas, qualificacao, fluxos por score, objecoes e follow-up.",
+  "type": "object",
+  "required": [
+    "summary",
+    "welcome_message",
+    "qualification_questions",
+    "score_flows",
+    "objection_responses",
+    "followup_messages",
+    "human_handoff_message",
+    "client_name",
+    "summary_headline",
+    "summary_highlights",
+    "summary_key_findings"
+  ],
+  "properties": {
+    "client_name": {
+      "type": "string",
+      "description": "Nome do cliente — sempre presente em todo output."
+    },
+    "summary": {
+      "type": "string",
+      "description": "Resumo executivo de 2-3 frases: nome do agente, numero de perguntas, numero de objecoes tratadas, tom de voz."
+    },
+    "summary_headline": {
+      "type": "string",
+      "description": "Manchete em 1 linha (~120 caracteres) com o veredito da skill."
+    },
+    "summary_highlights": {
+      "type": "array",
+      "description": "KPIs em destaque (4-6 itens). Categorias: posicao | competicao | janela | maturidade | oportunidade | risco.",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "label",
+          "value",
+          "tone"
+        ],
+        "properties": {
+          "category": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "subtext": {
+            "type": "string"
+          },
+          "tone": {
+            "type": "string",
+            "enum": [
+              "green",
+              "yellow",
+              "red",
+              "blue",
+              "gray"
+            ]
+          }
+        }
+      }
+    },
+    "summary_key_findings": {
+      "type": "array",
+      "description": "3-5 achados categorizados (vantagem | contexto | ameaca | acao).",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "text"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "vantagem",
+              "contexto",
+              "ameaca",
+              "acao"
+            ]
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "agent_name": {
+      "type": "string",
+      "description": "Nome humano do agente SDR IA (ex: 'Ana da Empresa X')."
+    },
+    "tone_of_voice": {
+      "type": "string",
+      "description": "Tom de voz definido pelo brandbook que guia todos os scripts."
+    },
+    "welcome_message": {
+      "type": "string",
+      "description": "Mensagem de boas-vindas aprovada (max 3 frases). Primeira mensagem enviada ao lead."
+    },
+    "welcome_alternatives": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "approach": {
+            "type": "string",
+            "description": "Tipo de abordagem (direta, empatica, curiosa)."
+          },
+          "message": {
+            "type": "string",
+            "description": "Texto da mensagem alternativa."
+          }
+        }
+      },
+      "description": "Opcoes alternativas de mensagem de boas-vindas (incluindo a escolhida)."
+    },
+    "qualification_questions": {
+      "type": "array",
+      "minItems": 4,
+      "maxItems": 5,
+      "items": {
+        "type": "object",
+        "required": [
+          "question",
+          "reveals",
+          "score_influence"
+        ],
+        "properties": {
+          "order": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 5,
+            "description": "Ordem da pergunta na sequencia de qualificacao."
+          },
+          "question": {
+            "type": "string",
+            "description": "A pergunta em linguagem natural para WhatsApp."
+          },
+          "reveals": {
+            "type": "string",
+            "description": "O que a resposta do lead revela sobre a qualificacao."
+          },
+          "dimension": {
+            "type": "string",
+            "enum": [
+              "need",
+              "urgency",
+              "authority",
+              "budget",
+              "final_qualification"
+            ],
+            "description": "Dimensao de qualificacao que a pergunta avalia."
+          },
+          "score_influence": {
+            "type": "object",
+            "properties": {
+              "plus_2": {
+                "type": "string",
+                "description": "Resposta que adiciona +2 ao score."
+              },
+              "plus_1": {
+                "type": "string",
+                "description": "Resposta que adiciona +1 ao score."
+              },
+              "zero": {
+                "type": "string",
+                "description": "Resposta neutra (0 pontos)."
+              },
+              "minus_1": {
+                "type": "string",
+                "description": "Resposta que subtrai -1 do score."
+              }
+            },
+            "description": "Como a resposta influencia o score total."
+          },
+          "transition_phrase": {
+            "type": "string",
+            "description": "Frase natural de transicao para a proxima pergunta."
+          }
+        }
+      },
+      "description": "Perguntas de qualificacao com logica de scoring."
+    },
+    "scoring_table": {
+      "type": "object",
+      "properties": {
+        "five_star_range": {
+          "type": "string",
+          "description": "Faixa de pontos para 5 estrelas (ex: '8-10')."
+        },
+        "four_star_range": {
+          "type": "string",
+          "description": "Faixa de pontos para 4 estrelas (ex: '5-7')."
+        },
+        "three_star_range": {
+          "type": "string",
+          "description": "Faixa de pontos para 3 estrelas (ex: '2-4')."
+        },
+        "two_star_range": {
+          "type": "string",
+          "description": "Faixa de pontos para 2 estrelas (ex: '0-1')."
+        },
+        "one_star_range": {
+          "type": "string",
+          "description": "Faixa de pontos para 1 estrela (ex: 'negativo')."
+        }
+      }
+    },
+    "score_flows": {
+      "type": "object",
+      "required": [
+        "qualified",
+        "warm",
+        "cold"
+      ],
+      "properties": {
+        "qualified": {
+          "type": "object",
+          "required": [
+            "script",
+            "next_step"
+          ],
+          "properties": {
+            "score_range": {
+              "type": "string",
+              "description": "Faixa de score para este fluxo (ex: '4-5 estrelas')."
+            },
+            "script": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Sequencia de mensagens do SDR para lead qualificado (cada item = 1 mensagem)."
+            },
+            "next_step": {
+              "type": "string",
+              "description": "Acao seguinte (ex: 'Encaminhar para vendedor + alerta WhatsApp')."
+            }
+          }
+        },
+        "warm": {
+          "type": "object",
+          "required": [
+            "script",
+            "nurture_action"
+          ],
+          "properties": {
+            "score_range": {
+              "type": "string",
+              "description": "Faixa de score para este fluxo (ex: '3 estrelas')."
+            },
+            "script": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Sequencia de mensagens do SDR para lead morno."
+            },
+            "nurture_action": {
+              "type": "string",
+              "description": "Acao de nutricao (ex: 'Regua automatica: 1 conteudo/semana por 4 semanas')."
+            }
+          }
+        },
+        "cold": {
+          "type": "object",
+          "required": [
+            "script",
+            "nurture_action"
+          ],
+          "properties": {
+            "score_range": {
+              "type": "string",
+              "description": "Faixa de score para este fluxo (ex: '1-2 estrelas')."
+            },
+            "script": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Sequencia de mensagens do SDR para lead frio."
+            },
+            "nurture_action": {
+              "type": "string",
+              "description": "Acao de nutricao passiva (ex: 'Email mensal + sem follow-up ativo')."
+            }
+          }
+        }
+      }
+    },
+    "objection_responses": {
+      "type": "array",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "objection",
+          "response"
+        ],
+        "properties": {
+          "objection": {
+            "type": "string",
+            "description": "A objecao como o lead a expressa."
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "price",
+              "urgency",
+              "authority",
+              "trust",
+              "need",
+              "competitor"
+            ],
+            "description": "Tipo da objecao."
+          },
+          "response": {
+            "type": "string",
+            "description": "Resposta do SDR IA (max 3 frases, tom natural)."
+          },
+          "escalation_response": {
+            "type": "string",
+            "description": "Segunda resposta se o lead insistir (ou escalar para humano)."
+          }
+        }
+      },
+      "description": "Respostas do SDR IA para cada objecao mapeada."
+    },
+    "unmapped_objection_response": {
+      "type": "string",
+      "description": "Resposta generica para objecoes nao mapeadas (reconhecimento + escalamento)."
+    },
+    "escalation_rules": {
+      "type": "object",
+      "properties": {
+        "after_2_insistences": {
+          "type": "string",
+          "description": "Acao quando lead insiste 2x na mesma objecao."
+        },
+        "on_frustration": {
+          "type": "string",
+          "description": "Acao quando lead demonstra irritacao."
+        },
+        "on_human_request": {
+          "type": "string",
+          "description": "Acao quando lead pede para falar com humano."
+        }
+      }
+    },
+    "followup_messages": {
+      "type": "object",
+      "required": [
+        "after_1h",
+        "after_24h",
+        "after_3d"
+      ],
+      "properties": {
+        "after_1h": {
+          "type": "string",
+          "description": "Mensagem de follow-up apos 1 hora sem resposta."
+        },
+        "after_24h": {
+          "type": "string",
+          "description": "Mensagem de follow-up apos 24 horas sem resposta."
+        },
+        "after_3d": {
+          "type": "string",
+          "description": "Mensagem de follow-up final apos 3 dias sem resposta."
+        },
+        "rules": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Regras de follow-up (max tentativas, horarios, opt-out)."
+        }
+      }
+    },
+    "human_handoff_message": {
+      "type": "object",
+      "required": [
+        "qualified_handoff",
+        "requested_handoff",
+        "limitation_handoff"
+      ],
+      "properties": {
+        "qualified_handoff": {
+          "type": "string",
+          "description": "Mensagem de transicao quando lead qualificado e encaminhado para vendedor."
+        },
+        "requested_handoff": {
+          "type": "string",
+          "description": "Mensagem quando o lead pede para falar com humano."
+        },
+        "limitation_handoff": {
+          "type": "string",
+          "description": "Mensagem quando o SDR IA nao sabe responder algo."
+        }
+      }
+    }
+  }
+}

--- a/.claude/skills/copy-anuncios/SKILL.md
+++ b/.claude/skills/copy-anuncios/SKILL.md
@@ -1,0 +1,252 @@
+---
+name: copy-anuncios
+description: "Gera 30+ variações de copy de anúncios por funil e plataforma (Meta Ads + Google Ads). Output exportado para Google Sheets. Use quando disser /copy-anuncios ou 'copy de ads' ou 'textos de anúncio' ou 'copy para Meta'."
+area: copy
+author: luizfreitasv4
+version: 1.0.0
+dependencies:
+  - designer-manual-marca
+  - geral-persona-icp
+  - geral-posicionamento-estrategico
+inputs:
+  - client.json (briefing)
+  - designer-manual-marca.json
+  - geral-persona-icp.json
+  - geral-posicionamento-estrategico.json
+output: copy-anuncios.json
+export: google-sheets
+week: 4
+type: automated
+estimated_time: "2h"
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta versao foi portada do sistema de Estruturacao Estrategica. As regras abaixo tem precedencia sobre caminhos e persistencia citados no fluxo original:
+
+- Trabalhe somente em `squads/{squad}/clientes/{cliente}/`, nunca em um diretorio `clientes/` solto na raiz.
+- Leia primeiro o `CLAUDE.md` ou `AGENTS.md` da KB, `mission-control/`, `calls/`, `docs/` e `campanhas/`.
+- Se `client.json` existir, use-o como fonte complementar. Se nao existir, derive o contexto da KB e do Mission Control; nao exija nem invente esse arquivo.
+- Salve entregaveis em `squads/{squad}/clientes/{cliente}/outputs/`, em JSON e Markdown quando o fluxo pedir ambos.
+- Registre decisoes e progresso no `mission-control/historico-checkins.md` ou no arquivo de historico equivalente encontrado na KB.
+- Resolva recursos empacotados a partir do proprio diretorio desta skill. Se uma integracao externa nao estiver configurada, declare o gap e continue apenas com os dados reais disponiveis.
+
+
+# Copy de Anúncios — 30+ Variações por Funil × Plataforma (POP 3.10)
+
+> **Posição no fluxo:** Semana 4 — Identidade de Comunicação e Plano de Mídia (**comum** a todos os modelos) (e-commerce / inside-sales / pdv). Hook ancorado em dor/diferencial confirmado (não característica). A/B variando 1 elemento por vez.
+
+Você é um copywriter especializado em mídia paga para PMEs brasileiras. Vai criar a planilha completa de copy para anúncios prontas para subir no Meta Ads Manager e Google Ads.
+
+## Dados necessários
+
+1. `client.json` (seção `briefing`) — nome, segmento, produto/serviço, oferta, plataformas de mídia
+2. `outputs/designer-manual-marca.json` — tom de voz, vocabulário, headlines, CTAs, do's/don'ts
+3. `outputs/geral-persona-icp.json` — ICP, dores, desejos, objeções, linguagem
+4. `outputs/geral-posicionamento-estrategico.json` — PUV, diferenciais, posicionamento
+5. `client.json` (seção `history`) — decisões anteriores
+
+---
+
+## Geração
+
+Gere o output COMPLETO de uma vez usando os dados de `client.json` (briefing) e outputs de skills dependentes em `outputs/`.
+
+Consulte `references/regras-copy-performance.md` para limites de caracteres e regras de cada plataforma.
+
+### 30+ variações por fase do funil
+
+**TOPO DE FUNIL — Consciência do problema**
+Tom: educativo, empático, sem vender.
+- Meta Ads: texto principal (3 var, máx. 125 chars) + título (3 var, máx. 40 chars) + descrição (2 var, máx. 30 chars)
+- Google Ads Responsivo: títulos (5, máx. 30 chars) + descrições (3, máx. 90 chars)
+
+**MEIO DE FUNIL — Consideração**
+Tom: educativo + prova social.
+- Meta Ads: texto principal (3 var, com dado/resultado) + título (3 var)
+- Google Ads: títulos (5) + descrições (3)
+
+**FUNDO DE FUNIL — Conversão**
+Tom: direto, urgência real, benefício claro.
+- Meta Ads: texto principal (3 var, hooks: dor/resultado/urgência) + título (3 var) + descrição (2 var)
+- Google Ads: títulos com intenção de compra (5) + descrições com CTA direto (3)
+
+**REMARKETING**
+- Texto principal (2 var, diferente da copy fria) + título (2 var)
+
+**REGRAS DE COPY APLICADAS:** Liste as 5 principais regras aplicadas para que o consultor entenda a lógica.
+
+### Convenção de contagem (`total_variations` + `variations_breakdown`)
+
+`total_variations` conta **anúncios completos prontos pra subir**, não elementos textuais. A regra:
+
+- **1 Meta Ad** = 1 variação (texto + headline + descrição + CTA — entregue inteiro).
+- **1 Google RSA** = 1 variação (mesmo tendo 5 headlines + 3 descriptions dentro — o algoritmo rotaciona, mas é 1 anúncio).
+
+Sempre incluir `variations_breakdown` para desambiguar, exemplo:
+```json
+"total_variations": 14,
+"variations_breakdown": {
+  "meta_ads": 11,
+  "google_ads_rsa": 3,
+  "google_ads_textual_elements": 24,
+  "note": "1 Meta = 1 anúncio; 1 RSA = 1 anúncio com múltiplos elementos rotacionados."
+}
+```
+
+**Por quê:** versões anteriores contavam cada headline/description Google como variação separada — número inflado (35 em vez de 14) confundia o cliente, que abria o portal procurando 35 cards e via 14. Manter a contagem honesta evita que o cliente "perca" anúncios mentalmente.
+
+### Pareamento copy ↔ criativo (`pair_with_creative`)
+
+Se a skill `designer-criativos-anuncios` já gerou `produced_creatives` (PNGs prontos com IDs `feed-0N` / `story-0N`), adicione em cada variação Meta Ads o array `pair_with_creative` com os IDs dos criativos que casam com aquela copy. Exemplo:
+
+```json
+{ "hook_type": "prova_social", "text": "70% da base é tutora de gato. ...", "pair_with_creative": ["feed-01", "feed-04"] }
+```
+
+**Regra:** parear pelo hook_type (criativo `linked_variation` deve casar com a copy `hook_type`). Quando não houver criativo dedicado, **não invente** — omita o campo (o portal vai instruir o gestor a usar criativo neutro do funil).
+
+### Bloco didático `how_to_read_this_doc`
+
+Inclua no topo do JSON um bloco que explica ao cliente como ler o documento. É o que o portal renderiza como primeira seção da skill — vira manual de uso, não só dump de dados.
+
+```json
+"how_to_read_this_doc": {
+  "title": "Como usar este manual de copy",
+  "intro": "1 parágrafo explicando o que o doc entrega e como ele se conecta com criativos.",
+  "structure": [
+    { "section": "funnel_stages", "what": "...", "why": "..." },
+    { "section": "variations[].pair_with_creative", "what": "...", "why": "..." },
+    { "section": "char_limits_reference", "what": "...", "why": "..." },
+    { "section": "test_strategy", "what": "...", "why": "..." },
+    { "section": "copy_rules_applied", "what": "...", "why": "..." }
+  ],
+  "workflow_recommended": [
+    "1) Validar destination_url e CTA padrão.",
+    "2) Exportar para Sheets e revisar com gestor de tráfego.",
+    "3) Subir no Meta em adsets separados por hook_type.",
+    "4) Parear copy + criativo conforme pair_with_creative.",
+    "5) Rodar 7 dias com test_strategy.kpis_kill_criteria diários."
+  ]
+}
+```
+
+**Por quê:** o cliente que abre o portal não é copywriter. Sem essa seção, ele lê 35 textos sem saber a lógica de uso. Com ela, ele entende em 30s o sistema antes de mergulhar no detalhe.
+
+### Revisão em formato de planilha
+
+Apresente todas organizadas:
+```
+FASE       | PLATAFORMA | TIPO        | TEXTO                    | CHARS
+Topo       | Meta       | Principal   | "Você sabia que..."      | 98/125
+```
+
+### Exportação para Google Sheets
+
+Crie via GOG CLI:
+```bash
+gog sheets create --title "Copy Anúncios - {NOME_CLIENTE}" --no-input
+```
+4 abas: Topo, Meio, Fundo, Remarketing. Coluna "Status" para o consultor marcar como Aprovada/Rejeitada/Em teste.
+
+## Auto-validação
+
+Antes de mostrar ao operador, verifique:
+
+- [ ] Mencionou o cliente pelo nome?
+- [ ] Usou dados reais do client.json (não inventou)?
+- [ ] Nenhum item genérico (ex: "quer crescer", "qualidade e compromisso")?
+- [ ] Schema da skill validou?
+- [ ] Todos os campos do schema preenchidos (ou com `null` + `unavailable_reason` no pai)?
+- [ ] Nenhuma string vazia (`""`) — substituí por `null` + reason quando o dado não existe?
+- [ ] Estimativas marcadas com `estimated: true` ou `[E]`?
+- [ ] Consistente com outputs anteriores (brandbook, posicionamento)?
+- [ ] Nenhuma copy ultrapassa limite de caracteres da plataforma?
+- [ ] Copy do topo fala do PROBLEMA sem mencionar o produto?
+- [ ] Remarketing é diferente da copy fria (não repetição)?
+
+Se falhou → regenere silenciosamente. Não avise o operador.
+
+## Apresentação e decisões
+
+Apresente o output COMPLETO ao operador.
+
+Revise o output. O que está errado, exagerado ou faltando?
+
+- "A copy do topo fala do PROBLEMA sem mencionar o produto?"
+- "O fundo de funil tem CTA claro e específico?"
+- "O remarketing é diferente da copy fria?"
+- "Os limites de caracteres estão respeitados?"
+- "O tom é consistente com o brandbook?"
+- "Quer exportar para Google Sheets?"
+
+## Finalização
+
+Operador aprova (com ou sem ajustes).
+1. Salve em `squads/{squad}/clientes/{cliente}/outputs/copy-anuncios.json` (com campo `summary` no topo, incluindo link Sheets)
+2. Atualize `client.json`: progress.skills → completed, version++, append em history[]
+3. Salve também uma versão Markdown do entregável na mesma pasta de outputs.
+4. Sugira próxima skill do dependency_graph
+
+## Formato do output (copy-anuncios.json)
+
+```json
+{
+  "summary": "string",
+  "how_to_read_this_doc": {
+    "title": "string",
+    "intro": "string",
+    "structure": [{ "section": "string", "what": "string", "why": "string" }],
+    "workflow_recommended": ["string"]
+  },
+  "funnel_stages": [
+    {
+      "name": "topo_de_funil",
+      "objective": "Consciência do problema",
+      "tone": "Educativo, empático, sem vender",
+      "platforms": [
+        {
+          "name": "meta_ads",
+          "variations": [{
+            "type": "text_primary",
+            "hook_type": "dor",
+            "text": "string",
+            "headline": "string",
+            "description": "string",
+            "cta": "string",
+            "char_count": { "text": 98, "headline": 34, "description": 28 },
+            "pair_with_creative": ["feed-05", "story-01"]
+          }]
+        },
+        {
+          "name": "google_ads",
+          "variations": [{ "type": "responsive_search", "match_intent": "string", "headlines": ["string x5"], "descriptions": ["string x3"], "char_count_headlines": [29,25,26,28,23], "char_count_descriptions": [85,84,80] }]
+        }
+      ]
+    }
+  ],
+  "copy_rules_applied": ["string — 5 regras aplicadas"],
+  "char_limits_reference": {
+    "meta_ads": { "primary_text_max": 125, "headline_max": 40, "description_max": 30, "note": "string" },
+    "google_ads": { "headline_max": 30, "description_max": 90, "note": "string" }
+  },
+  "test_strategy": {
+    "duration_min_days": 7,
+    "min_budget_per_adset_brl": 30,
+    "kpis_kill_criteria": ["string"],
+    "kpis_winners": ["string"]
+  },
+  "total_variations": 30,
+  "sheets_url": "string — link do Google Sheets"
+}
+```
+
+
+## Campo obrigatório: summary
+
+Sempre inclua no JSON de saída:
+```json
+"summary": "Resumo de 1-2 frases do copy de anúncios: número de variações geradas e principais ganchos usados. Seja específico — mencione o cliente, números reais e a conclusão principal."
+```
+
+Este campo alimenta o Resumo Executivo do portal de entregas. Deve ser objetivo, com dados reais, sem genéricos.

--- a/.claude/skills/copy-anuncios/references/regras-copy-performance.md
+++ b/.claude/skills/copy-anuncios/references/regras-copy-performance.md
@@ -1,0 +1,157 @@
+# Regras de Copy para Performance — Limites e Boas Práticas por Plataforma
+
+Referência técnica para garantir que toda copy respeite limites de caracteres, regras de política e padrões de alta performance.
+
+---
+
+## Meta Ads (Facebook + Instagram)
+
+### Limites de caracteres
+
+| Campo | Limite técnico | Recomendado | Nota |
+|-------|---------------|-------------|------|
+| Texto principal (primary text) | 2.200 chars | 125 chars | Após 125, texto é truncado com "...ver mais" |
+| Título (headline) | 255 chars | 40 chars | Truncado em mobile após ~40 chars |
+| Descrição (description) | 255 chars | 30 chars | Só aparece no feed desktop, truncada em mobile |
+| Nome do botão CTA | Pré-definido | — | Saiba mais / Cadastre-se / Comprar / Fale conosco / etc. |
+
+### Regras de política (que causam reprovação)
+
+- **Afirmações pessoais diretas:** "Você está acima do peso?" → REPROVADO. Use "Muitas pessoas enfrentam dificuldade para..."
+- **Antes/depois:** Imagens de transformação física → REPROVADO em quase todos os casos
+- **Promessas absolutas:** "Garantimos 100% de resultado" → REPROVADO. Use "Nosso compromisso é..."
+- **Referência a atributos pessoais:** Raça, orientação, religião, condição financeira → REPROVADO
+- **Menção à plataforma:** "Viu esse anúncio no Facebook?" → REPROVADO
+- **Caps lock excessivo:** "OFERTA IMPERDÍVEL SOMENTE HOJE" → Pode ser reprovado ou ter alcance limitado
+- **Emojis no título:** Pode reduzir alcance (depende do período, Meta varia)
+
+### O que funciona em Meta Ads Brasil
+
+1. **Hook nos primeiros 3-5 palavras** — é o que aparece antes do truncamento
+2. **Pergunta na primeira frase** — gera curiosidade e engajamento
+3. **Números específicos** — "347 clientes em BH" > "centenas de clientes"
+4. **Emojis com parcimônia** — 1-2 no texto principal, 0 no título
+5. **CTA no texto + no botão** — redundância intencional funciona
+6. **Copy curta para fundo de funil** — quem já conhece não precisa de educação
+7. **Copy média para topo** — educa e gera interesse, mas não enrola
+
+### Estrutura de texto principal (Meta)
+
+**Topo de funil (educativo):**
+```
+[Pergunta ou dado impactante]
+[1-2 frases de contexto/empatia]
+[CTA leve: "Saiba mais no link"]
+```
+
+**Meio de funil (prova social):**
+```
+[Resultado concreto de cliente]
+[Como foi alcançado em 1 frase]
+[CTA: "Veja como funciona"]
+```
+
+**Fundo de funil (conversão):**
+```
+[Oferta direta com benefício]
+[Urgência real ou escassez]
+[CTA forte: "Fale com a gente agora"]
+```
+
+---
+
+## Google Ads (Search — Responsive Search Ads)
+
+### Limites de caracteres
+
+| Campo | Limite | Quantidade |
+|-------|--------|-----------|
+| Título (headline) | 30 caracteres cada | Até 15 títulos (mín. 3) |
+| Descrição | 90 caracteres cada | Até 4 descrições (mín. 2) |
+| URL de exibição (paths) | 15 caracteres cada | 2 paths |
+
+### Como o responsivo funciona
+
+O Google combina seus títulos e descrições automaticamente. Por isso:
+- **Cada título deve funcionar sozinho** (não depender de outro para fazer sentido)
+- **Não repita a mesma mensagem** em títulos diferentes (Google penaliza redundância)
+- **Fixe (pin)** apenas se necessário: Título 1 fixo = nome da marca ou oferta principal
+- **Diversifique os hooks:** dor, resultado, autoridade, oferta, CTA
+
+### Regras de política Google Ads
+
+- **Pontuação excessiva:** "Melhor preço!!!" → REPROVADO. Máx. 1 ponto de exclamação por anúncio
+- **Caps lock:** "MELHOR PREÇO" → REPROVADO. Use capitalização normal
+- **Superlativos sem prova:** "O melhor do Brasil" → Precisa de certificação de terceiros
+- **Marca registrada:** Usar nome de concorrente → Pode ser contestado
+- **Símbolos não padrão:** Setas unicode (→, ►) → Podem ser reprovadas
+- **Espaçamento abusivo:** "M E L H O R" → REPROVADO
+
+### O que funciona em Google Ads Brasil
+
+1. **Palavra-chave no Título 1** — corresponde à busca do usuário
+2. **Número no Título 2** — "R$ 99/mês" ou "Em 7 dias" (específico)
+3. **CTA na Descrição 1** — "Solicite um orçamento gratuito"
+4. **Prova social na Descrição 2** — "+500 clientes em SP"
+5. **Paths descritivos** — exemplo.com/orcamento/gratuito
+6. **Extensões** — sempre adicione: sitelinks, callouts, snippets, preço
+
+### Tipos de título por intenção
+
+**Informacional (topo):**
+- "O que é [serviço] e por que importa"
+- "Guia completo de [tema]"
+- "[Número] dicas para [resultado]"
+
+**Comercial (meio):**
+- "[Serviço] em [Cidade] - Orçamento"
+- "Compare opções de [serviço]"
+- "[Número] clientes confiam em nós"
+
+**Transacional (fundo):**
+- "Contrate [serviço] - Sem contrato"
+- "[Serviço] a partir de R$ [valor]"
+- "Orçamento grátis em 24h"
+
+---
+
+## Regras universais de copy de performance
+
+### 1. Hierarquia de hooks (do mais ao menos efetivo)
+
+1. **Dor específica do ICP** — "Perdendo leads por falta de follow-up?"
+2. **Resultado com número** — "340 restaurantes já economizam R$ 3.000/mês"
+3. **Curiosidade/pergunta** — "Você sabia que 73% dos leads não recebem resposta em 24h?"
+4. **Prova social** — "Avaliado com 4.9★ por +200 clientes"
+5. **Urgência real** — "Últimas 5 vagas para onboarding em abril"
+6. **Oferta direta** — "Diagnóstico gratuito: descubra por que seus anúncios não convertem"
+
+### 2. Fórmulas de copy comprovadas
+
+**PAS (Problem → Agitation → Solution):**
+Problema: "Seus leads somem depois do primeiro contato?"
+Agitação: "Cada lead ignorado é dinheiro jogado fora. E quanto mais demora, menos vale."
+Solução: "Automatize o follow-up com [produto]. Resposta em segundos, 24/7."
+
+**AIDA (Attention → Interest → Desire → Action):**
+Atenção: "R$ 12.000 em comissões economizadas"
+Interesse: "A Cantina Mineira trocou o iFood por delivery próprio"
+Desejo: "Sem comissão, sem intermediário, ticket 35% maior"
+Ação: "Monte seu delivery direto em 7 dias"
+
+**BAB (Before → After → Bridge):**
+Antes: "Dependendo 100% de indicação para novos clientes"
+Depois: "30 leads qualificados por mês no seu WhatsApp"
+Ponte: "[Produto] conecta você aos clientes que já buscam o que você vende"
+
+### 3. Checklist antes de aprovar
+
+- [ ] Limite de caracteres respeitado em TODAS as variações
+- [ ] Hook nos primeiros 3-5 palavras
+- [ ] Nenhuma copy do topo menciona produto/marca
+- [ ] Fundo de funil tem urgência REAL (não fake)
+- [ ] Remarketing é diferente da copy fria
+- [ ] Tom consistente com designer-manual-marca (vocabulário, tratamento)
+- [ ] Nenhuma violação de política de plataforma
+- [ ] Mínimo 30 variações no total
+- [ ] Cada variação testa um hook/ângulo diferente (não paráfrases do mesmo)

--- a/.claude/skills/copy-anuncios/schema.json
+++ b/.claude/skills/copy-anuncios/schema.json
@@ -1,0 +1,387 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Copy de Anúncios",
+  "description": "Output estruturado de copy de anúncios: variações por fase de funil e plataforma, com limites de caracteres.",
+  "type": "object",
+  "required": [
+    "summary",
+    "funnel_stages",
+    "copy_rules_applied",
+    "total_variations",
+    "client_name",
+    "summary_headline",
+    "summary_highlights",
+    "summary_key_findings"
+  ],
+  "properties": {
+    "client_name": {
+      "type": "string",
+      "description": "Nome do cliente — sempre presente em todo output."
+    },
+    "summary": {
+      "type": "string",
+      "description": "Resumo de 1-2 frases da copy de anúncios. Inclui número de variações geradas e principais ganchos usados."
+    },
+    "summary_headline": {
+      "type": "string",
+      "description": "Manchete em 1 linha (~120 caracteres) com o veredito da skill."
+    },
+    "summary_highlights": {
+      "type": "array",
+      "description": "KPIs em destaque (4-6 itens). Categorias: posicao | competicao | janela | maturidade | oportunidade | risco.",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "label",
+          "value",
+          "tone"
+        ],
+        "properties": {
+          "category": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "subtext": {
+            "type": "string"
+          },
+          "tone": {
+            "type": "string",
+            "enum": [
+              "green",
+              "yellow",
+              "red",
+              "blue",
+              "gray"
+            ]
+          }
+        }
+      }
+    },
+    "summary_key_findings": {
+      "type": "array",
+      "description": "3-5 achados categorizados (vantagem | contexto | ameaca | acao).",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "text"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "vantagem",
+              "contexto",
+              "ameaca",
+              "acao"
+            ]
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "funnel_stages": {
+      "type": "array",
+      "description": "Fases do funil com variações de copy por plataforma.",
+      "minItems": 4,
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "objective",
+          "tone",
+          "platforms"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "enum": [
+              "topo_de_funil",
+              "meio_de_funil",
+              "fundo_de_funil",
+              "remarketing"
+            ],
+            "description": "Fase do funil"
+          },
+          "objective": {
+            "type": "string",
+            "description": "Objetivo da fase"
+          },
+          "tone": {
+            "type": "string",
+            "description": "Tom recomendado para esta fase"
+          },
+          "platforms": {
+            "type": "array",
+            "description": "Plataformas de mídia com variações.",
+            "items": {
+              "type": "object",
+              "required": [
+                "name",
+                "variations"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "enum": [
+                    "meta_ads",
+                    "google_ads"
+                  ],
+                  "description": "Plataforma de mídia"
+                },
+                "variations": {
+                  "type": "array",
+                  "description": "Variações de copy para esta plataforma.",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "type"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "description": "Tipo de variação (text_primary, responsive_search, etc.)"
+                      },
+                      "text": {
+                        "type": "string",
+                        "description": "Texto principal do anúncio"
+                      },
+                      "headline": {
+                        "type": "string",
+                        "description": "Título do anúncio"
+                      },
+                      "description": {
+                        "type": "string",
+                        "description": "Descrição do anúncio"
+                      },
+                      "cta": {
+                        "type": "string",
+                        "description": "Call-to-action do botão"
+                      },
+                      "headlines": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Títulos para Google Ads responsivo"
+                      },
+                      "descriptions": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Descrições para Google Ads responsivo"
+                      },
+                      "char_count": {
+                        "type": "object",
+                        "description": "Contagem de caracteres por campo",
+                        "properties": {
+                          "text": {
+                            "type": "integer"
+                          },
+                          "headline": {
+                            "type": "integer"
+                          },
+                          "description": {
+                            "type": "integer"
+                          }
+                        }
+                      },
+                      "hook_type": {
+                        "type": "string",
+                        "description": "Ângulo emocional/argumentativo do copy (dor, prova_social, oferta_direta, etc). Cruza com 'linked_variation' do produced_creatives."
+                      },
+                      "match_intent": {
+                        "type": "string",
+                        "description": "(Google Ads) Intenção de busca alvo desta RSA — informacional, comparativa, transacional."
+                      },
+                      "char_count_headlines": {
+                        "type": "array",
+                        "items": {
+                          "type": "integer"
+                        },
+                        "description": "(Google Ads) Contagem de chars por headline, na ordem do array."
+                      },
+                      "char_count_descriptions": {
+                        "type": "array",
+                        "items": {
+                          "type": "integer"
+                        },
+                        "description": "(Google Ads) Contagem de chars por description, na ordem do array."
+                      },
+                      "pair_with_creative": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "IDs dos criativos visuais (feed-0N / story-0N) que devem rodar com esta copy. Cruza com produced_creatives.feed_instagram[].id e .stories_instagram[].id em designer-criativos-anuncios. Omitir quando não houver criativo dedicado."
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "copy_rules_applied": {
+      "type": "array",
+      "description": "5 regras de copy aplicadas neste conjunto.",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 5
+    },
+    "total_variations": {
+      "type": "integer",
+      "description": "Total de ANÚNCIOS COMPLETOS prontos pra subir (não conta cada elemento textual). 1 Meta = 1 anúncio. 1 Google RSA = 1 anúncio (mesmo tendo 5 headlines + 3 descriptions dentro). Use 'variations_breakdown' para detalhar a composição.",
+      "minimum": 1
+    },
+    "variations_breakdown": {
+      "type": "object",
+      "description": "Quebra detalhada da contagem de total_variations — desambigua 'anúncio completo' vs 'elemento textual'.",
+      "properties": {
+        "meta_ads": {
+          "type": "integer",
+          "description": "Quantidade de anúncios Meta (cada um é uma variação completa)."
+        },
+        "google_ads_rsa": {
+          "type": "integer",
+          "description": "Quantidade de RSAs Google (cada uma é 1 anúncio que rotaciona internamente)."
+        },
+        "google_ads_textual_elements": {
+          "type": "integer",
+          "description": "Soma dos headlines + descriptions DENTRO das RSAs (informativo — não conta como anúncio separado)."
+        },
+        "note": {
+          "type": "string",
+          "description": "Explicação curta da convenção de contagem."
+        }
+      }
+    },
+    "sheets_url": {
+      "type": "string",
+      "format": "uri",
+      "description": "URL da planilha Google Sheets exportada"
+    },
+    "how_to_read_this_doc": {
+      "type": "object",
+      "description": "Bloco didático que explica ao cliente como ler e usar este documento. Renderizado como primeira seção da skill no portal.",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "intro": {
+          "type": "string",
+          "description": "1 parágrafo — o que o doc entrega e como conecta com criativos."
+        },
+        "structure": {
+          "type": "array",
+          "description": "Explicação seção-a-seção do JSON. Cada item: section (nome do campo), what (o que é), why (por que está aqui).",
+          "items": {
+            "type": "object",
+            "required": [
+              "section",
+              "what",
+              "why"
+            ],
+            "properties": {
+              "section": {
+                "type": "string"
+              },
+              "what": {
+                "type": "string"
+              },
+              "why": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "workflow_recommended": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Passos numerados de uso prático (validar → exportar → subir → parear → testar)."
+        }
+      }
+    },
+    "char_limits_reference": {
+      "type": "object",
+      "description": "Limites oficiais de caracteres por plataforma — referência rápida ao lado das variações.",
+      "properties": {
+        "meta_ads": {
+          "type": "object",
+          "properties": {
+            "primary_text_max": {
+              "type": "integer"
+            },
+            "headline_max": {
+              "type": "integer"
+            },
+            "description_max": {
+              "type": "integer"
+            },
+            "note": {
+              "type": "string"
+            }
+          }
+        },
+        "google_ads": {
+          "type": "object",
+          "properties": {
+            "headline_max": {
+              "type": "integer"
+            },
+            "description_max": {
+              "type": "integer"
+            },
+            "note": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "test_strategy": {
+      "type": "object",
+      "description": "Critérios para rodar A/B com essas copies — duração, budget e KPIs de kill/winner.",
+      "properties": {
+        "duration_min_days": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "min_budget_per_adset_brl": {
+          "type": "number",
+          "minimum": 0
+        },
+        "kpis_kill_criteria": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Quando pausar (ex: CTR <1% após 1k impressões)."
+        },
+        "kpis_winners": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Quando escalar (ex: CTR ≥1,8%)."
+        }
+      }
+    }
+  }
+}

--- a/.claude/skills/copy-scripts-sdr/SKILL.md
+++ b/.claude/skills/copy-scripts-sdr/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: copy-scripts-sdr
+description: "Cria scripts completos do SDR IA para WhatsApp: boas-vindas, qualificacao com scoring, fluxo por score, tratamento de objecoes e follow-up. Use quando o operador disser 'scripts sdr', 'script do agente', 'mensagens do sdr', 'fluxo de qualificacao', ou na cauda da Semana 3 (POP 3.7)."
+area: copy
+author: luizfreitasv4
+version: 1.0.0
+dependencies:
+  - designer-manual-marca
+outputs: ["copy-scripts-sdr.json"]
+week: 4
+estimated_time: "3h"
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta versao foi portada do sistema de Estruturacao Estrategica. As regras abaixo tem precedencia sobre caminhos e persistencia citados no fluxo original:
+
+- Trabalhe somente em `squads/{squad}/clientes/{cliente}/`, nunca em um diretorio `clientes/` solto na raiz.
+- Leia primeiro o `CLAUDE.md` ou `AGENTS.md` da KB, `mission-control/`, `calls/`, `docs/` e `campanhas/`.
+- Se `client.json` existir, use-o como fonte complementar. Se nao existir, derive o contexto da KB e do Mission Control; nao exija nem invente esse arquivo.
+- Salve entregaveis em `squads/{squad}/clientes/{cliente}/outputs/`, em JSON e Markdown quando o fluxo pedir ambos.
+- Registre decisoes e progresso no `mission-control/historico-checkins.md` ou no arquivo de historico equivalente encontrado na KB.
+- Resolva recursos empacotados a partir do proprio diretorio desta skill. Se uma integracao externa nao estiver configurada, declare o gap e continue apenas com os dados reais disponiveis.
+
+
+# Scripts e Fluxos de Qualificacao do SDR IA (POP 3.7)
+
+> **Posição no fluxo:** Semana 4 — Identidade de Comunicação e Plano de Mídia (**comum** a todos os modelos) a todos os modelos. Consome o diagnóstico comercial **do modelo** quando existe (inside-sales → account-diagnostico-comercial; e-commerce → funil/recuperação; pdv → base ativa/experiência) para calibrar a qualificação; o tom vem do Manual de Marca.
+
+Voce e um especialista em scripts de vendas conversacionais para WhatsApp. Vai criar, junto com o operador, todos os scripts e fluxos que o SDR IA vai usar para qualificar leads no WhatsApp. Os scripts devem ser naturais, curtos e alinhados ao tom de voz da marca.
+
+> **REGRAS FUNDAMENTAIS (aplicam a TODOS os scripts):**
+> - Maximo 3 frases por mensagem (WhatsApp nao e email)
+> - Tom deve seguir EXATAMENTE o Manual de Marca do cliente (designer-manual-marca)
+> - Linguagem natural, nunca robotica — o lead nao pode perceber que e IA
+> - Nunca prometer preco, prazo ou condicao sem autorizacao
+> - Nunca usar emojis em excesso (maximo 1 por mensagem, se coerente com tom)
+> - Nunca enviar bloco de texto — quebre em mensagens curtas
+> - Use o nome do lead sempre que disponivel
+
+## Dados necessários
+
+1. `client.json` (seção `briefing`) — NOME_CLIENTE, PRODUTO_SERVICO, TICKET_MEDIO
+2. `outputs/geral-persona-icp.json` — RESUMO_ICP, dores, comportamento, canais
+3. `outputs/account-diagnostico-comercial.json` — criterios 1-5 estrelas, objecoes mapeadas, SLA
+4. `outputs/designer-manual-marca.json` — TOM_DE_VOZ, personalidade, vocabulario, palavras proibidas
+5. `outputs/account-cliente-oculto.json` — se existir, pontos criticos identificados
+
+Confirme com o operador:
+
+> Vou criar os scripts do SDR IA para {NOME_CLIENTE}.
+> Nome do agente SDR: {se definido, ou pergunte — deve ser nome humano}
+> Tom de voz: {do brandbook}
+> Criterios de qualificacao: {resumo 5/4/3/1-2 estrelas}
+> Objecoes a tratar: {lista}
+
+Consulte `references/exemplos-scripts-sdr-whatsapp.md` para padroes de scripts naturais.
+
+---
+
+## Geração
+
+Gere o output COMPLETO de uma vez: boas-vindas + qualificação + fluxos por score + objeções + follow-up + handoff. Use os dados de `client.json` (briefing) e outputs de skills dependentes em `outputs/`.
+
+### Mensagem de boas-vindas (3 opções)
+
+**Opção A (Direta):** apresentação + objetivo + primeira pergunta
+**Opção B (Empática):** empatia com dor + oferta de ajuda
+**Opção C (Curiosa):** pergunta aberta sobre o desafio
+
+Para cada: a mensagem (máx 3 frases) + melhor contexto de uso. Recomendação com justificativa baseada no brandbook.
+
+### Perguntas de qualificação com lógica de scoring (4-5 perguntas)
+
+Para cada pergunta:
+- Pergunta natural (nunca "interrogatório")
+- O que revela sobre o lead
+- Influência no score: +2 / +1 / 0 / -1 (com descrição de cada resposta)
+- Transição natural para a próxima pergunta
+
+**Tabela de scoring:** total 8-10 → 5★, 5-7 → 4★, 2-4 → 3★, 0-1 → 2★, negativo → 1★
+
+**Regras de conversa:** adaptar tom, não fazer 2 perguntas por vez, responder perguntas do lead antes de continuar.
+
+### Fluxo de resposta por score
+
+**Lead 4-5★ (qualificado):** 3 mensagens (valoriza → informa próximo passo → cria expectativa com SLA) + encaminhar para vendedor
+**Lead 3★ (morno):** 2 mensagens (mantém interesse → oferece valor sem vender) + régua de nutrição
+**Lead 1-2★ (frio):** 1-2 mensagens (agradece sem queimar → oferece algo leve) + nutrição passiva
+
+### Tratamento de objeções
+
+Para CADA objeção do diagnóstico:
+- Objeção exata + tipo
+- Resposta do SDR IA (máx 3 frases, natural)
+- Se insistir: segunda resposta ou escalar para humano
+
+**Objeções não mapeadas:** resposta genérica de reconhecimento + escalamento
+**Regra de escalamento:** 2x mesma objeção → humano. Irritação → imediato. "Pessoa de verdade" → imediato.
+
+### Follow-up
+
+- 1h sem resposta: mensagem leve
+- 24h sem resposta: conteúdo de valor
+- 3 dias sem resposta: encerramento gentil
+
+**Regras:** máx 3 follow-ups, nunca antes de 1h (exceto 5★: 30min), respeitar "não me contacte", horário 9h-19h.
+
+### Handoff para humano
+
+- Quando qualificado (4-5★): transição natural para vendedor
+- Quando lead pede: transição respeitosa
+- Quando SDR não sabe: transição por limitação
+
+**REGRA:** A transição NUNCA revela que é IA. Natural como atendente passando para especialista.
+
+## Auto-validação
+
+Antes de mostrar ao operador, verifique:
+
+- [ ] Mencionou o cliente pelo nome?
+- [ ] Usou dados reais do client.json (não inventou)?
+- [ ] Nenhum item genérico?
+- [ ] Schema validou?
+- [ ] Consistente com brandbook (tom, vocabulário, palavras proibidas)?
+- [ ] Todas as mensagens têm máx 3 frases?
+- [ ] Perguntas soam naturais (não interrogatório)?
+- [ ] Lógica de scoring é consistente com critérios do diagnóstico?
+
+Se falhou → regenere silenciosamente.
+
+## Apresentação e decisões
+
+Apresente o output COMPLETO ao operador.
+
+**DECISÃO 1:** Mensagem de boas-vindas — qual opção?
+- Opção A: "[mensagem direta]"
+- Opção B: "[mensagem empática]"
+- Opção C: "[mensagem curiosa]"
+
+**RECOMENDAÇÃO:** Opção [X]. [Justificativa baseada no brandbook e ICP.]
+
+**PROVOCAÇÃO:** [Ex: "Essa mensagem funciona quando o lead vem de um anúncio de dor? E quando vem de um de resultado?"]
+
+Valide também:
+- "As perguntas soam naturais? O lead nao vai sentir interrogatório?"
+- "A logica de scoring faz sentido com os criterios de qualificacao?"
+- "Os fluxos por score fazem sentido para a realidade do time?"
+- "As respostas de objecoes estao naturais?"
+- "O nome do vendedor para handoff e {NOME} — correto?"
+- "Os follow-ups estão no tom certo? Nenhum soa como spam?"
+
+**IMPORTANTE:** Estes scripts devem ser aprovados pelo CLIENTE antes de configurar no Patagon.
+
+## Finalização
+
+Operador aprova (com ou sem ajustes).
+1. Salve em `squads/{squad}/clientes/{cliente}/outputs/copy-scripts-sdr.json` (com campo `summary` no topo)
+2. Atualize `client.json`: progress.skills → completed, version++, append em history[]
+3. Salve também uma versão Markdown do entregável na mesma pasta de outputs.
+4. Sugira próxima skill do dependency_graph
+   - "Scripts SDR IA salvos. Agente: {nome}. {N} perguntas de qualificação. {N} objeções tratadas."
+   - Sugira: `/account-sdr-ia-config` para configurar no Patagon e integrar com Kommo

--- a/.claude/skills/copy-scripts-sdr/references/exemplos-scripts-sdr-whatsapp.md
+++ b/.claude/skills/copy-scripts-sdr/references/exemplos-scripts-sdr-whatsapp.md
@@ -1,0 +1,313 @@
+# Exemplos de Scripts SDR para WhatsApp
+
+Referencia de scripts naturais para SDR IA em WhatsApp. Todos os exemplos seguem as regras: max 3 frases por mensagem, linguagem natural, sem parecer robo.
+
+---
+
+## Principios de Scripts para WhatsApp
+
+### O que diferencia WhatsApp de outros canais
+
+1. **Informalidade esperada:** WhatsApp e pessoal. O lead espera conversa, nao pitch.
+2. **Mensagens curtas:** Blocos de texto longos sao ignorados. Max 3 frases por balao.
+3. **Velocidade:** Lead espera resposta em segundos/minutos, nao horas.
+4. **Contexto:** O lead pode estar no onibus, no almoco, na fila. Facilite a resposta.
+5. **Audio:** Muitos leads preferem audio. O SDR IA deve funcionar em texto.
+6. **Emojis com moderacao:** 1 emoji por mensagem no maximo. Nenhum e preferivel para tom profissional.
+
+### Erros fatais em scripts de WhatsApp
+
+| Erro | Exemplo ruim | Alternativa |
+|------|-------------|-------------|
+| Mensagem longa | "Ola! Obrigado por entrar em contato com a [empresa]. Somos especialistas em [area] e oferecemos [lista de servicos]. Nossos diferenciais sao [lista]. Gostaria de agendar uma reuniao para conversarmos melhor sobre como podemos ajuda-lo?" | "Oi, [nome]! Sou a Ana da [empresa]. Me conta, o que te motivou a procurar a gente?" |
+| Tom robotico | "Prezado(a), recebemos sua solicitacao. Um de nossos consultores entrara em contato em breve." | "E ai, [nome]! Vi sua mensagem agora. Me fala mais sobre o que voce precisa?" |
+| Interrogatorio | "Qual seu nome? Qual sua empresa? Qual seu orcamento? Quando precisa?" | Distribuir as perguntas ao longo da conversa, uma por vez |
+| Forcar venda cedo | "Temos uma promocao incrivel! So ate sexta! Quer aproveitar?" | "Entendi seu caso. Posso te mostrar como outros [perfil similar] resolveram isso?" |
+| Ignorar o que o lead disse | Lead: "Preciso de ajuda com X" / Atendente: "Nossos planos sao A, B e C" | Repetir o que o lead disse: "Entendi, voce precisa de ajuda com X. Me conta mais..." |
+
+---
+
+## Exemplos por Segmento
+
+### Saude e Estetica (Clinica, Dentista, Personal)
+
+**Boas-vindas:**
+```
+Oi, [nome]! Aqui e a Bia da [clinica].
+Vi que voce se interessou pelo [tratamento/servico].
+Posso te ajudar com algumas informacoes — me conta, e pra voce ou pra alguem da familia?
+```
+
+**Qualificacao (necessidade):**
+```
+Entendi! E a primeira vez que voce faz esse tipo de tratamento ou ja fez antes em outro lugar?
+```
+
+**Qualificacao (urgencia):**
+```
+E voce ta querendo comecar logo ou ainda ta pesquisando opcoes?
+```
+
+**Qualificacao (orcamento — indireta):**
+```
+Perfeito! Pra eu te passar as melhores opcoes, voce ja tem uma ideia de quanto pretende investir nesse momento?
+```
+
+**Objecao de preco:**
+```
+Entendo, [nome]. O investimento realmente precisa fazer sentido.
+O que muitos pacientes me dizem e que o resultado compensa — a Maria, por exemplo, fez o mesmo tratamento e ficou super satisfeita.
+Quer que eu te mostre as opcoes de parcelamento?
+```
+
+### Educacao (Curso, Escola, Treinamento)
+
+**Boas-vindas:**
+```
+Oi, [nome]! Sou o Lucas da [escola].
+Que bom que voce se interessou pelo [curso]!
+Me conta uma coisa: voce ja trabalha na area ou ta querendo comecar?
+```
+
+**Qualificacao (necessidade):**
+```
+Legal! E o que te fez procurar o curso agora? Teve algum motivo especifico?
+```
+
+**Qualificacao (urgencia):**
+```
+Entendi! E voce quer comecar na proxima turma ou ta planejando pra mais pra frente?
+```
+
+**Qualificacao (autoridade):**
+```
+Massa! E essa decisao e so sua ou voce precisa combinar com alguem? Pergunto porque as vagas sao limitadas e quero garantir a sua.
+```
+
+**Objecao de preco:**
+```
+Entendo a preocupacao com o valor, [nome].
+Uma forma de pensar: quanto voce deixa de ganhar por mes sem essa qualificacao? O curso se paga em [X] meses com o aumento que nossos alunos conseguem.
+Quer que eu te mostre o parcelamento?
+```
+
+### Servicos B2B (Consultoria, Agencia, SaaS)
+
+**Boas-vindas:**
+```
+Oi, [nome]! Aqui e a Ana da [empresa].
+Vi que voce se interessou pelo nosso [servico].
+Me conta um pouco sobre o seu negocio — o que ta te travando hoje?
+```
+
+**Qualificacao (necessidade):**
+```
+Interessante. E como voce esta lidando com isso hoje? Tem alguem ou alguma ferramenta cuidando disso ou esta tudo manual?
+```
+
+**Qualificacao (urgencia):**
+```
+Faz sentido. E isso e algo que voce precisa resolver esse mes ou ta planejando pro proximo trimestre?
+```
+
+**Qualificacao (autoridade):**
+```
+Perfeito! Pra eu te dar a melhor solucao: alem de voce, tem mais alguem que participa dessa decisao na empresa?
+```
+
+**Qualificacao (orcamento — indireta):**
+```
+Legal! Pra eu entender melhor: voces ja investem em algo parecido hoje? Quanto mais ou menos?
+```
+
+**Objecao de preco:**
+```
+Entendo, [nome]. Investimento precisa ter retorno claro.
+Posso te mostrar o caso do [cliente similar] que comecou parecido com voces e em [tempo] conseguiu [resultado mensuravel]?
+Normalmente isso ajuda a visualizar o ROI.
+```
+
+### Servicos Locais (Reformas, Manutencao, Dedetizacao)
+
+**Boas-vindas:**
+```
+Oi, [nome]! Sou o Carlos da [empresa].
+Vi que voce precisa de [servico].
+Me fala um pouco: e pra casa ou empresa? E em que bairro/regiao?
+```
+
+**Qualificacao (urgencia):**
+```
+Entendi! E voce precisa disso pra quando? Tem alguma urgencia ou pode ser agendado?
+```
+
+**Qualificacao (orcamento — indireta):**
+```
+Beleza! Voce ja fez orcamento com alguem ou estamos no inicio?
+```
+
+**Objecao de preco:**
+```
+Entendo, [nome]. So pra voce ter seguranca: nosso servico inclui [diferencial 1] e [diferencial 2], que normalmente nao vem nos orcamentos mais baratos.
+Quer que eu detalhe o que ta incluido?
+```
+
+---
+
+## Padroes de Perguntas de Qualificacao
+
+### Perguntas que FUNCIONAM (naturais, uma por vez)
+
+| Dimensao | Pergunta natural | Alternativa |
+|----------|-----------------|-------------|
+| Necessidade | "Me conta, o que te motivou a procurar isso agora?" | "O que ta te incomodando mais em relacao a [tema]?" |
+| Urgencia | "Voce quer resolver isso logo ou ta mais no modo pesquisa?" | "Tem algum prazo ou evento que te motivou a buscar agora?" |
+| Autoridade | "Alem de voce, tem mais alguem que participa dessa decisao?" | "Voce decide isso sozinho ou precisa alinhar com alguem?" |
+| Orcamento | "Voce ja investe em algo parecido hoje?" | "Voce ja tem uma faixa de investimento em mente?" |
+| Experiencia | "Voce ja tentou resolver isso antes? Como foi?" | "Ja trabalhou com alguma empresa parecida com a gente?" |
+
+### Perguntas que NAO funcionam (roboticas, invasivas)
+
+| Evitar | Por que nao funciona |
+|--------|---------------------|
+| "Qual seu orcamento?" | Muito direto, parece que so quer vender |
+| "Voce e o decisor?" | Jargao corporativo, assusta lead pequeno |
+| "Qual seu faturamento?" | Invasivo demais no primeiro contato |
+| "Pode me passar seu email?" | Parece que vai mandar spam |
+| "Tem CNPJ?" | Burocracia antes de criar conexao |
+
+---
+
+## Padroes de Tratamento de Objecoes
+
+### Framework LPRA (Listen, Pause, Respond, Advance)
+
+1. **Listen (Ouca):** Repita o que o lead disse para mostrar que entendeu
+2. **Pause:** Nao responda imediatamente com argumento (1-2 frases antes)
+3. **Respond:** Ofereça perspectiva ou prova social (nao argumente)
+4. **Advance:** Proponha proximo passo concreto
+
+### Exemplos por tipo de objecao
+
+**PRECO:**
+```
+Lead: "Achei caro, o outro orcamento foi metade disso"
+
+SDR: "Entendo, [nome]. Preco e importante mesmo.
+Uma coisa que nossos clientes sempre falam: eles tentaram o mais barato antes e acabaram gastando o dobro pra refazer.
+Quer que eu te mostre o que ta incluido no nosso pra voce comparar de verdade?"
+```
+
+**URGENCIA ("vou pensar"):**
+```
+Lead: "Vou pensar e te dou um retorno semana que vem"
+
+SDR: "Sem problema, [nome]! Pensar com calma e importante.
+So te aviso que [condicao/escassez real, se houver].
+Posso te mandar um resumo por aqui pra facilitar quando voce for decidir?"
+```
+
+**AUTORIDADE ("preciso falar com meu socio"):**
+```
+Lead: "Preciso conversar com meu socio primeiro"
+
+SDR: "Faz total sentido, [nome]! Decisao em conjunto e mais segura.
+Quer que eu prepare um resumo que voce possa mostrar pra ele?
+Ou, se preferir, posso incluir ele numa conversa rapida de 10 minutos."
+```
+
+**CONFIANCA ("nao conheco voces"):**
+```
+Lead: "Nunca ouvi falar de voces, como sei que funciona?"
+
+SDR: "Boa pergunta, [nome]! Normal querer seguranca.
+A [empresa] ja atendeu [numero] clientes em [regiao/segmento] — posso te mandar alguns depoimentos de quem e parecido com voce?
+E se quiser, pode ligar pra [referencia] que e nosso cliente."
+```
+
+**NECESSIDADE ("ja tenho algo parecido"):**
+```
+Lead: "Ja uso o [concorrente/alternativa]"
+
+SDR: "Legal que voce ja tem uma solucao, [nome]!
+Me conta: o que te fez procurar outra opcao? Geralmente e porque [dor comum].
+Se for isso, posso te mostrar como resolvemos isso de um jeito diferente."
+```
+
+---
+
+## Mensagens de Follow-up que Funcionam
+
+### Depois de 1 hora
+
+**Bom:**
+```
+Oi, [nome]! Sei que o dia ta corrido.
+Quando puder, me responde aqui que eu te ajudo rapidinho!
+```
+
+**Ruim:**
+```
+Ola, verificamos que voce nao respondeu. Ainda tem interesse?
+```
+
+### Depois de 24 horas
+
+**Bom:**
+```
+E ai, [nome]! Lembrei da nossa conversa de ontem.
+Separei [conteudo/caso/informacao] que pode te ajudar com [dor].
+Quer que eu te mande?
+```
+
+**Ruim:**
+```
+Bom dia! Estou entrando em contato novamente para dar continuidade.
+```
+
+### Depois de 3 dias (ultimo)
+
+**Bom:**
+```
+[nome], so passando pra dizer que fico por aqui se precisar!
+Quando quiser retomar, e so me chamar.
+Bom restinho de semana!
+```
+
+**Ruim:**
+```
+ULTIMA TENTATIVA DE CONTATO. Temos uma proposta especial para voce.
+```
+
+---
+
+## Mensagem de Handoff (SDR IA para Humano)
+
+### Transicao natural — lead nao percebe a troca
+
+**Bom:**
+```
+Perfeito, [nome]! Pelo que voce me contou, o [nome_vendedor] e a pessoa certa pra te ajudar com isso.
+Ele ja vai ter todo o contexto da nossa conversa.
+Te chama nos proximos minutos!
+```
+
+**Ruim:**
+```
+Vou te transferir para o setor comercial. Aguarde.
+```
+
+### Quando o lead pede para falar com humano
+
+**Bom:**
+```
+Claro, [nome]! Vou chamar o [nome_vendedor] — ele cuida pessoalmente dos novos clientes.
+Voce nao vai precisar repetir nada, ele ja tem todas as infos.
+```
+
+**Ruim:**
+```
+Entendo. Infelizmente sou um chatbot e nao consigo ajudar com isso. Vou transferir.
+```
+
+REGRA DE OURO: A transicao NUNCA deve revelar que era IA. Deve parecer que um atendente esta passando para o especialista.

--- a/.claude/skills/copy-scripts-sdr/schema.json
+++ b/.claude/skills/copy-scripts-sdr/schema.json
@@ -1,0 +1,410 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ScriptsSDR",
+  "description": "Output estruturado da skill scripts-sdr: scripts completos do SDR IA para WhatsApp incluindo boas-vindas, qualificacao, fluxos por score, objecoes e follow-up.",
+  "type": "object",
+  "required": [
+    "summary",
+    "welcome_message",
+    "qualification_questions",
+    "score_flows",
+    "objection_responses",
+    "followup_messages",
+    "human_handoff_message",
+    "client_name",
+    "summary_headline",
+    "summary_highlights",
+    "summary_key_findings"
+  ],
+  "properties": {
+    "client_name": {
+      "type": "string",
+      "description": "Nome do cliente — sempre presente em todo output."
+    },
+    "summary": {
+      "type": "string",
+      "description": "Resumo executivo de 2-3 frases: nome do agente, numero de perguntas, numero de objecoes tratadas, tom de voz."
+    },
+    "summary_headline": {
+      "type": "string",
+      "description": "Manchete em 1 linha (~120 caracteres) com o veredito da skill."
+    },
+    "summary_highlights": {
+      "type": "array",
+      "description": "KPIs em destaque (4-6 itens). Categorias: posicao | competicao | janela | maturidade | oportunidade | risco.",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "label",
+          "value",
+          "tone"
+        ],
+        "properties": {
+          "category": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "subtext": {
+            "type": "string"
+          },
+          "tone": {
+            "type": "string",
+            "enum": [
+              "green",
+              "yellow",
+              "red",
+              "blue",
+              "gray"
+            ]
+          }
+        }
+      }
+    },
+    "summary_key_findings": {
+      "type": "array",
+      "description": "3-5 achados categorizados (vantagem | contexto | ameaca | acao).",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "text"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "vantagem",
+              "contexto",
+              "ameaca",
+              "acao"
+            ]
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "agent_name": {
+      "type": "string",
+      "description": "Nome humano do agente SDR IA (ex: 'Ana da Empresa X')."
+    },
+    "tone_of_voice": {
+      "type": "string",
+      "description": "Tom de voz definido pelo brandbook que guia todos os scripts."
+    },
+    "welcome_message": {
+      "type": "string",
+      "description": "Mensagem de boas-vindas aprovada (max 3 frases). Primeira mensagem enviada ao lead."
+    },
+    "welcome_alternatives": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "approach": {
+            "type": "string",
+            "description": "Tipo de abordagem (direta, empatica, curiosa)."
+          },
+          "message": {
+            "type": "string",
+            "description": "Texto da mensagem alternativa."
+          }
+        }
+      },
+      "description": "Opcoes alternativas de mensagem de boas-vindas (incluindo a escolhida)."
+    },
+    "qualification_questions": {
+      "type": "array",
+      "minItems": 4,
+      "maxItems": 5,
+      "items": {
+        "type": "object",
+        "required": [
+          "question",
+          "reveals",
+          "score_influence"
+        ],
+        "properties": {
+          "order": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 5,
+            "description": "Ordem da pergunta na sequencia de qualificacao."
+          },
+          "question": {
+            "type": "string",
+            "description": "A pergunta em linguagem natural para WhatsApp."
+          },
+          "reveals": {
+            "type": "string",
+            "description": "O que a resposta do lead revela sobre a qualificacao."
+          },
+          "dimension": {
+            "type": "string",
+            "enum": [
+              "need",
+              "urgency",
+              "authority",
+              "budget",
+              "final_qualification"
+            ],
+            "description": "Dimensao de qualificacao que a pergunta avalia."
+          },
+          "score_influence": {
+            "type": "object",
+            "properties": {
+              "plus_2": {
+                "type": "string",
+                "description": "Resposta que adiciona +2 ao score."
+              },
+              "plus_1": {
+                "type": "string",
+                "description": "Resposta que adiciona +1 ao score."
+              },
+              "zero": {
+                "type": "string",
+                "description": "Resposta neutra (0 pontos)."
+              },
+              "minus_1": {
+                "type": "string",
+                "description": "Resposta que subtrai -1 do score."
+              }
+            },
+            "description": "Como a resposta influencia o score total."
+          },
+          "transition_phrase": {
+            "type": "string",
+            "description": "Frase natural de transicao para a proxima pergunta."
+          }
+        }
+      },
+      "description": "Perguntas de qualificacao com logica de scoring."
+    },
+    "scoring_table": {
+      "type": "object",
+      "properties": {
+        "five_star_range": {
+          "type": "string",
+          "description": "Faixa de pontos para 5 estrelas (ex: '8-10')."
+        },
+        "four_star_range": {
+          "type": "string",
+          "description": "Faixa de pontos para 4 estrelas (ex: '5-7')."
+        },
+        "three_star_range": {
+          "type": "string",
+          "description": "Faixa de pontos para 3 estrelas (ex: '2-4')."
+        },
+        "two_star_range": {
+          "type": "string",
+          "description": "Faixa de pontos para 2 estrelas (ex: '0-1')."
+        },
+        "one_star_range": {
+          "type": "string",
+          "description": "Faixa de pontos para 1 estrela (ex: 'negativo')."
+        }
+      }
+    },
+    "score_flows": {
+      "type": "object",
+      "required": [
+        "qualified",
+        "warm",
+        "cold"
+      ],
+      "properties": {
+        "qualified": {
+          "type": "object",
+          "required": [
+            "script",
+            "next_step"
+          ],
+          "properties": {
+            "score_range": {
+              "type": "string",
+              "description": "Faixa de score para este fluxo (ex: '4-5 estrelas')."
+            },
+            "script": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Sequencia de mensagens do SDR para lead qualificado (cada item = 1 mensagem)."
+            },
+            "next_step": {
+              "type": "string",
+              "description": "Acao seguinte (ex: 'Encaminhar para vendedor + alerta WhatsApp')."
+            }
+          }
+        },
+        "warm": {
+          "type": "object",
+          "required": [
+            "script",
+            "nurture_action"
+          ],
+          "properties": {
+            "score_range": {
+              "type": "string",
+              "description": "Faixa de score para este fluxo (ex: '3 estrelas')."
+            },
+            "script": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Sequencia de mensagens do SDR para lead morno."
+            },
+            "nurture_action": {
+              "type": "string",
+              "description": "Acao de nutricao (ex: 'Regua automatica: 1 conteudo/semana por 4 semanas')."
+            }
+          }
+        },
+        "cold": {
+          "type": "object",
+          "required": [
+            "script",
+            "nurture_action"
+          ],
+          "properties": {
+            "score_range": {
+              "type": "string",
+              "description": "Faixa de score para este fluxo (ex: '1-2 estrelas')."
+            },
+            "script": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Sequencia de mensagens do SDR para lead frio."
+            },
+            "nurture_action": {
+              "type": "string",
+              "description": "Acao de nutricao passiva (ex: 'Email mensal + sem follow-up ativo')."
+            }
+          }
+        }
+      }
+    },
+    "objection_responses": {
+      "type": "array",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "objection",
+          "response"
+        ],
+        "properties": {
+          "objection": {
+            "type": "string",
+            "description": "A objecao como o lead a expressa."
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "price",
+              "urgency",
+              "authority",
+              "trust",
+              "need",
+              "competitor"
+            ],
+            "description": "Tipo da objecao."
+          },
+          "response": {
+            "type": "string",
+            "description": "Resposta do SDR IA (max 3 frases, tom natural)."
+          },
+          "escalation_response": {
+            "type": "string",
+            "description": "Segunda resposta se o lead insistir (ou escalar para humano)."
+          }
+        }
+      },
+      "description": "Respostas do SDR IA para cada objecao mapeada."
+    },
+    "unmapped_objection_response": {
+      "type": "string",
+      "description": "Resposta generica para objecoes nao mapeadas (reconhecimento + escalamento)."
+    },
+    "escalation_rules": {
+      "type": "object",
+      "properties": {
+        "after_2_insistences": {
+          "type": "string",
+          "description": "Acao quando lead insiste 2x na mesma objecao."
+        },
+        "on_frustration": {
+          "type": "string",
+          "description": "Acao quando lead demonstra irritacao."
+        },
+        "on_human_request": {
+          "type": "string",
+          "description": "Acao quando lead pede para falar com humano."
+        }
+      }
+    },
+    "followup_messages": {
+      "type": "object",
+      "required": [
+        "after_1h",
+        "after_24h",
+        "after_3d"
+      ],
+      "properties": {
+        "after_1h": {
+          "type": "string",
+          "description": "Mensagem de follow-up apos 1 hora sem resposta."
+        },
+        "after_24h": {
+          "type": "string",
+          "description": "Mensagem de follow-up apos 24 horas sem resposta."
+        },
+        "after_3d": {
+          "type": "string",
+          "description": "Mensagem de follow-up final apos 3 dias sem resposta."
+        },
+        "rules": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Regras de follow-up (max tentativas, horarios, opt-out)."
+        }
+      }
+    },
+    "human_handoff_message": {
+      "type": "object",
+      "required": [
+        "qualified_handoff",
+        "requested_handoff",
+        "limitation_handoff"
+      ],
+      "properties": {
+        "qualified_handoff": {
+          "type": "string",
+          "description": "Mensagem de transicao quando lead qualificado e encaminhado para vendedor."
+        },
+        "requested_handoff": {
+          "type": "string",
+          "description": "Mensagem quando o lead pede para falar com humano."
+        },
+        "limitation_handoff": {
+          "type": "string",
+          "description": "Mensagem quando o SDR IA nao sabe responder algo."
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## O que é

**`copy-anuncios`** — gera 30+ variações de copy de anúncio separadas por etapa de funil e plataforma (Meta e Google). Sai direto pro Google Sheets.

**`copy-scripts-sdr`** — escreve os scripts do SDR IA no WhatsApp de ponta a ponta: boas-vindas, qualificação com scoring, fluxo por score, tratamento de objeções e follow-up. É o insumo de `account-sdr-ia-config`.

## Checagens

- Duplo-write verificado
- `REGISTRY.md` fora do PR — a Action regenera no merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)