### PR TITLE
feat(skills): ekyte-status-cliente e google-sync-drive

### DIFF
--- a/.agents/skills/ekyte-status-cliente/SKILL.md
+++ b/.agents/skills/ekyte-status-cliente/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: ekyte-status-cliente
+description: Puxa o status operacional de um cliente no Ekyte e devolve o que foi concluido no periodo, o que esta em andamento, o que esta atrasado e onde as horas estouraram o estimado. Use sempre que o usuario perguntar como esta a operacao de um cliente, o que o time entregou, o que esta parado, o que atrasou, quantas horas foram gastas, ou quando estiver preparando pauta de check-in e precisar dos fatos de entrega. Tambem cobre o caminho inverso: transformar combinados de call em tarefas no Ekyte, sempre com confirmacao antes de criar.
+area: ekyte
+author: luizricardo
+version: 1.0.0
+---
+
+# /ekyte-status-cliente
+
+Radar de operacao por cliente. Le o Ekyte, separa fato de impressao e entrega o material que alimenta check-in e Mission Control.
+
+## Pre-requisito
+
+O MCP do Ekyte precisa estar configurado (ferramentas `mcp__ekyte__*` disponiveis). Se nao estiverem:
+
+```bash
+claude mcp add --transport http ekyte "https://api.ekyte.com/mcp?token=SEU_TOKEN" --scope user
+```
+
+Token em: avatar → Perfil de Acesso → Integracoes MCP. Gerar token novo invalida o anterior. Depois de adicionar, reinicie o Claude Code. Nunca cole o token no chat, porque o comando roda no terminal do usuario.
+
+## Passo 1: Identificar o cliente
+
+Descubra o `workspaceId`. Nao chute: cada cliente e um workspace.
+
+```
+mcp__ekyte__list_short_workspaces  { "textSearch": "<primeiro nome do cliente>", "active": 1 }
+```
+
+O nome do workspace no Ekyte quase nunca bate com o nome da pasta na KB. Busque pelo
+primeiro nome do cliente e confirme pelo `id` que a busca devolveu, nunca pelo nome.
+Guarde os ids que voce usa com frequencia no `links.md` do cliente.
+
+## Passo 2: Definir a janela
+
+Padrao: ultimos 30 dias. Se o cliente tem `checkins/` na KB, use a data do ultimo check-in como inicio. O recorte util e "o que andou desde a ultima vez que falamos com ele".
+
+Datas em ISO (`2026-07-27`).
+
+## Passo 3: Puxar os quatro recortes
+
+Sempre `list_tasks` com `workspaceId` e `limit: 200`.
+
+| Recorte | Argumentos |
+|---|---|
+| Concluidas no periodo | `situation: "30"`, `concludedDateStart`, `concludedDateEnd` |
+| Em andamento | `situation: "10"` |
+| Pausadas | `situation: "20"` |
+| Atrasadas | `situation: "10,20"`, `currentDueDateEnd: <ontem>` |
+| Canceladas no periodo | `situation: "40"` |
+
+### Armadilhas que ja custaram caro
+
+- **Nao use o filtro `concluded`.** Ele nao significa "nao concluida". Em teste real, `concluded: false` devolveu 19 tarefas das quais 15 estavam concluidas e 3 canceladas. Use `situation`, que e explicito.
+- **`situation` e string, nunca array.** `"10,20"` funciona; `[10,20]` da erro.
+- **Codigos:** Ativa=10, Pausada=20, Concluida=30, Cancelada=40.
+- **Teto de 200 tarefas por consulta.** Se vier exatamente 200, avise que a lista pode estar truncada e estreite a janela.
+- Prioridade: 10=Nao priorizado, 100=Baixa, 200=Media, 300=Alta, 400=Urgente.
+
+## Passo 4: Ler os numeros antes de escrever
+
+Cada tarefa traz `estimatedTime` e `actualTime` (minutos), `phase.name`, `executor.userName`, `responsibles[]`, `ctcTaskType.name`, `currentDueDate` e `tags`.
+
+Calcule:
+
+- **Atraso em dias** por tarefa: hoje menos `currentDueDate`.
+- **Estouro de horas**: `actualTime` contra `estimatedTime`, por tarefa e somado no periodo. Tarefa com estimado 60 e real 180 e um fato de conversa, nao um detalhe.
+- **Onde a fila trava**: agrupe as em andamento e as atrasadas por `phase.name`. Se todas param na mesma fase, o gargalo tem dono.
+- **Distribuicao por executor**, quando fizer sentido para carga de time.
+
+Para horas apontadas de verdade, `mcp__ekyte__list_time_trackings` aceita `workspaceId`, `startDate`, `endDate` e `executorId`, e devolve ate 400 registros.
+
+## Passo 5: Entregar
+
+Pergunte como o usuario quer consumir, ou infira pelo contexto:
+
+- **Resumo no chat** (padrao): entregues no periodo, em andamento com prazo, atrasadas com dias de atraso, gargalo por fase, estouro de horas.
+- **Pauta de check-in**: o bloco de entregas vira o "o que fizemos" do ROPRE. Combine com `/account-checkin-roleplay`.
+- **Atualizar Mission Control**: escreva os fatos em `mission-control/` do cliente. Nao invente status de combinado que o Ekyte nao comprova.
+
+Regras de leitura, herdadas do hub:
+
+- Diferencie **fato do Ekyte** de inferencia. "13 tarefas concluidas" e fato; "o time está performando bem" e opiniao.
+- Tarefa concluida nao prova resultado de negocio. Nao apresente volume de entrega como resultado para o cliente.
+- Se o dado nao existe no Ekyte, diga que nao existe.
+
+## Passo 6: Combinados viram tarefas (escrita, opcional)
+
+So quando o usuario pedir. **Confirmacao obrigatoria**: monte a lista completa (titulo, tipo, executor, prazo, estimativa) e mostre para aprovacao antes de criar qualquer coisa. Toda escrita fica registrada no usuario dono do token.
+
+`create_task` exige: `title`, `description`, `phaseDueDate`, `currentDueDate`, `estimatedTime`, `workspaceId`, `executorId`, `phaseId`, `ctcTaskTypeId`, `situation`, `flow`.
+
+Para montar sem chutar:
+
+1. `list_task_types` ou `list_task_types_create_task` → pega `ctcTaskTypeId`.
+2. `get_task_type_flow` ou `list_task_flow_phases` → pega a primeira fase (`phaseId`) e o `flow`.
+3. `list_admin_editors_users` → pega o `executorId`.
+4. `situation: 10` (Ativa) e `phaseDueDate` calculado a partir de `currentDueDate`.
+
+Depois de criar, confirme devolvendo os IDs criados. Se algo falhar no meio, diga o que foi criado e o que nao foi. Nunca deixe o usuario achando que criou tudo.
+
+Para mover fase use `update_task_phase`; consulte o estado atual antes, porque o fluxo tem regras de progressao.
+
+## Fora de escopo
+
+- Dados de midia (Meta, Google, GA4): use os prefixos `meta-*`, `google-*`, `ga4-*`.
+- CRM e vendas: `hubspot-*`, `kommo-*`.
+- Ekyte nao tem receita nem CAC. Nao tente derivar resultado comercial daqui.

--- a/.agents/skills/google-sync-drive/SKILL.md
+++ b/.agents/skills/google-sync-drive/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: google-sync-drive
+description: Sincroniza uma pasta do Google Drive com a KB de um cliente, trazendo apenas o que é novo ou mudou desde a última execução. Converte Google Docs, Sheets e Slides em markdown, coloca cada arquivo no lugar certo da KB e mantém um estado em JSON para que a próxima rodada seja incremental. Use quando o usuário rodar /google-sync-drive, disser que quer atualizar a KB com o que veio do Drive, que o cliente mandou arquivo novo no Drive, ou perguntar se tem coisa nova lá.
+area: google
+author: luizricardo
+version: 1.0.0
+---
+
+# Google Drive: sync incremental para a KB
+
+Traz do Drive só o que mudou, converte para markdown e organiza na KB. Não é sync de disco: roda quando você chama.
+
+## Pré-requisitos
+
+O conector do Google Drive precisa estar autenticado. Se as ferramentas `mcp__claude_ai_Google_Drive__*` não aparecerem, o usuário precisa conectar em claude.ai, em Settings e Connectors.
+
+O cliente precisa ter `docs/mapa-drive.md` com o ID da pasta raiz. Se não tiver, este é o primeiro sync: rode o Passo 1 e crie o mapa.
+
+## Passo 1: descobrir o escopo
+
+Leia `docs/mapa-drive.md` do cliente e pegue o ID da pasta raiz.
+
+Se o arquivo não existir, peça o link da pasta ao usuário, extraia o ID de `/folders/{ID}`, e confirme com `get_file_metadata` antes de seguir.
+
+Percorra a árvore com `search_files` usando `parentId = '{ID}'`. Repita para cada subpasta encontrada, até não sobrar pasta. Junte tudo numa lista com id, título, mimeType, modifiedTime e o caminho da pasta.
+
+Não use `fullText contains` para descobrir arquivo: a busca por parentId é exata e não traz lixo de outras pastas.
+
+## Passo 2: comparar com o estado anterior
+
+Leia `docs/.drive-sync.json`. O formato é:
+
+```json
+{
+  "raiz": "ID_DA_PASTA",
+  "ultimaSync": "2026-07-30T20:00:00Z",
+  "arquivos": {
+    "FILE_ID": {
+      "titulo": "...",
+      "modifiedTime": "2026-07-24T13:37:29Z",
+      "destino": "campanhas/lps-operacao/copy-lp-....md",
+      "acao": "importado"
+    }
+  }
+}
+```
+
+Classifique cada arquivo do Drive:
+
+- **Novo**: o id não está no estado.
+- **Mudou**: o id está, mas o `modifiedTime` do Drive é maior que o guardado.
+- **Igual**: nada a fazer, não toque no arquivo da KB.
+- **Sumiu**: está no estado e não veio na varredura. Não apague nada da KB. Marque como `"acao": "removido no drive"` e avise o usuário.
+
+Se o estado não existir, trate tudo como novo, mas antes verifique duplicata (Passo 3).
+
+## Passo 3: não importar duplicata
+
+Antes de importar qualquer coisa, confira se o conteúdo já existe na KB com outro nome. Dois testes baratos:
+
+- Tamanho em bytes igual a algum arquivo já existente em `calls/` ou `docs/`.
+- Título muito parecido com arquivo existente.
+
+Já aconteceu de o transcript do kickoff estar no Drive como `.txt` e na KB como `.md`, com exatamente o mesmo tamanho. Importar de novo teria criado uma segunda cópia divergente.
+
+Quando encontrar duplicata, registre no estado com `"acao": "duplicata"` e o caminho do arquivo que já existe.
+
+## Passo 4: importar
+
+Para Google Docs, Sheets e Slides use `read_file_content` com `includeComments: true`. Os comentários costumam conter as decisões de revisão e são a parte mais valiosa. Coloque-os numa seção própria no topo do markdown, com autor e data.
+
+Para PDF, .docx e .xlsx use `read_file_content` também.
+
+Para imagem e outros binários use `download_file_content`. Faça isso apenas quando o usuário pedir explicitamente: arquivo grande em base64 é lento e caro. O padrão é pular binário e listar o que ficou de fora.
+
+Onde colocar cada coisa, seguindo a convenção da KB:
+
+| Tipo de material | Destino |
+|---|---|
+| Copy de landing page, anúncio, roteiro | `campanhas/{campanha}/` |
+| Transcript de reunião | `calls/` |
+| Documento de estratégia, pesquisa, briefing | `docs/` |
+| Identidade visual, key visual, paleta | `docs/identidade-visual/` |
+| Imagem de campanha | `campanhas/{campanha}/assets/` |
+
+Se não houver campanha óbvia, pergunte em vez de inventar pasta.
+
+No cabeçalho de cada arquivo importado, registre origem, id do arquivo no Drive, data de modificação lá e data de importação. Sem isso ninguém sabe se o que está na KB é a versão atual.
+
+## Passo 5: atualizar estado e mapa
+
+Reescreva `docs/.drive-sync.json` com o estado novo. Atualize a tabela de inventário em `docs/mapa-drive.md`.
+
+## Passo 6: relatório
+
+Diga em texto corrido, sem enfeite:
+
+- Quantos arquivos novos entraram e onde.
+- Quais mudaram e o que mudou de fato, não só que mudou.
+- O que foi pulado e por quê: duplicata, binário, formato não suportado.
+- O que sumiu do Drive.
+
+Se nada mudou, diga isso em uma linha e pare.
+
+## Regras
+
+- Nunca sobrescreva arquivo da KB que foi editado à mão depois da última sync. Compare a data de modificação local com a `ultimaSync`. Se for mais nova, pare e pergunte.
+- Nunca apague arquivo da KB porque sumiu do Drive.
+- Não invente conteúdo para arquivo que não conseguiu ler. Registre como falha.
+- Converta travessão em vírgula, dois-pontos ou parênteses no material importado. É padrão da casa e vale inclusive quando o original do cliente usa travessão.
+- Português brasileiro.
+- Pasta compartilhada aparece em "Compartilhados comigo" e funciona normalmente por parentId. Não é preciso mover nada.
+
+## Limite conhecido
+
+Isto não é sync automático. O Drive não notifica este ambiente quando um arquivo muda, então nada acontece até alguém rodar o comando. Se o usuário quiser de fato automático, o caminho é o Google Drive para Desktop, que sincroniza a pasta no disco em tempo real, e aí esta skill passa a servir só para normalizar o que chegou.

--- a/.claude/skills/ekyte-status-cliente/SKILL.md
+++ b/.claude/skills/ekyte-status-cliente/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: ekyte-status-cliente
+description: Puxa o status operacional de um cliente no Ekyte e devolve o que foi concluido no periodo, o que esta em andamento, o que esta atrasado e onde as horas estouraram o estimado. Use sempre que o usuario perguntar como esta a operacao de um cliente, o que o time entregou, o que esta parado, o que atrasou, quantas horas foram gastas, ou quando estiver preparando pauta de check-in e precisar dos fatos de entrega. Tambem cobre o caminho inverso: transformar combinados de call em tarefas no Ekyte, sempre com confirmacao antes de criar.
+area: ekyte
+author: luizricardo
+version: 1.0.0
+---
+
+# /ekyte-status-cliente
+
+Radar de operacao por cliente. Le o Ekyte, separa fato de impressao e entrega o material que alimenta check-in e Mission Control.
+
+## Pre-requisito
+
+O MCP do Ekyte precisa estar configurado (ferramentas `mcp__ekyte__*` disponiveis). Se nao estiverem:
+
+```bash
+claude mcp add --transport http ekyte "https://api.ekyte.com/mcp?token=SEU_TOKEN" --scope user
+```
+
+Token em: avatar → Perfil de Acesso → Integracoes MCP. Gerar token novo invalida o anterior. Depois de adicionar, reinicie o Claude Code. Nunca cole o token no chat, porque o comando roda no terminal do usuario.
+
+## Passo 1: Identificar o cliente
+
+Descubra o `workspaceId`. Nao chute: cada cliente e um workspace.
+
+```
+mcp__ekyte__list_short_workspaces  { "textSearch": "<primeiro nome do cliente>", "active": 1 }
+```
+
+O nome do workspace no Ekyte quase nunca bate com o nome da pasta na KB. Busque pelo
+primeiro nome do cliente e confirme pelo `id` que a busca devolveu, nunca pelo nome.
+Guarde os ids que voce usa com frequencia no `links.md` do cliente.
+
+## Passo 2: Definir a janela
+
+Padrao: ultimos 30 dias. Se o cliente tem `checkins/` na KB, use a data do ultimo check-in como inicio. O recorte util e "o que andou desde a ultima vez que falamos com ele".
+
+Datas em ISO (`2026-07-27`).
+
+## Passo 3: Puxar os quatro recortes
+
+Sempre `list_tasks` com `workspaceId` e `limit: 200`.
+
+| Recorte | Argumentos |
+|---|---|
+| Concluidas no periodo | `situation: "30"`, `concludedDateStart`, `concludedDateEnd` |
+| Em andamento | `situation: "10"` |
+| Pausadas | `situation: "20"` |
+| Atrasadas | `situation: "10,20"`, `currentDueDateEnd: <ontem>` |
+| Canceladas no periodo | `situation: "40"` |
+
+### Armadilhas que ja custaram caro
+
+- **Nao use o filtro `concluded`.** Ele nao significa "nao concluida". Em teste real, `concluded: false` devolveu 19 tarefas das quais 15 estavam concluidas e 3 canceladas. Use `situation`, que e explicito.
+- **`situation` e string, nunca array.** `"10,20"` funciona; `[10,20]` da erro.
+- **Codigos:** Ativa=10, Pausada=20, Concluida=30, Cancelada=40.
+- **Teto de 200 tarefas por consulta.** Se vier exatamente 200, avise que a lista pode estar truncada e estreite a janela.
+- Prioridade: 10=Nao priorizado, 100=Baixa, 200=Media, 300=Alta, 400=Urgente.
+
+## Passo 4: Ler os numeros antes de escrever
+
+Cada tarefa traz `estimatedTime` e `actualTime` (minutos), `phase.name`, `executor.userName`, `responsibles[]`, `ctcTaskType.name`, `currentDueDate` e `tags`.
+
+Calcule:
+
+- **Atraso em dias** por tarefa: hoje menos `currentDueDate`.
+- **Estouro de horas**: `actualTime` contra `estimatedTime`, por tarefa e somado no periodo. Tarefa com estimado 60 e real 180 e um fato de conversa, nao um detalhe.
+- **Onde a fila trava**: agrupe as em andamento e as atrasadas por `phase.name`. Se todas param na mesma fase, o gargalo tem dono.
+- **Distribuicao por executor**, quando fizer sentido para carga de time.
+
+Para horas apontadas de verdade, `mcp__ekyte__list_time_trackings` aceita `workspaceId`, `startDate`, `endDate` e `executorId`, e devolve ate 400 registros.
+
+## Passo 5: Entregar
+
+Pergunte como o usuario quer consumir, ou infira pelo contexto:
+
+- **Resumo no chat** (padrao): entregues no periodo, em andamento com prazo, atrasadas com dias de atraso, gargalo por fase, estouro de horas.
+- **Pauta de check-in**: o bloco de entregas vira o "o que fizemos" do ROPRE. Combine com `/account-checkin-roleplay`.
+- **Atualizar Mission Control**: escreva os fatos em `mission-control/` do cliente. Nao invente status de combinado que o Ekyte nao comprova.
+
+Regras de leitura, herdadas do hub:
+
+- Diferencie **fato do Ekyte** de inferencia. "13 tarefas concluidas" e fato; "o time está performando bem" e opiniao.
+- Tarefa concluida nao prova resultado de negocio. Nao apresente volume de entrega como resultado para o cliente.
+- Se o dado nao existe no Ekyte, diga que nao existe.
+
+## Passo 6: Combinados viram tarefas (escrita, opcional)
+
+So quando o usuario pedir. **Confirmacao obrigatoria**: monte a lista completa (titulo, tipo, executor, prazo, estimativa) e mostre para aprovacao antes de criar qualquer coisa. Toda escrita fica registrada no usuario dono do token.
+
+`create_task` exige: `title`, `description`, `phaseDueDate`, `currentDueDate`, `estimatedTime`, `workspaceId`, `executorId`, `phaseId`, `ctcTaskTypeId`, `situation`, `flow`.
+
+Para montar sem chutar:
+
+1. `list_task_types` ou `list_task_types_create_task` → pega `ctcTaskTypeId`.
+2. `get_task_type_flow` ou `list_task_flow_phases` → pega a primeira fase (`phaseId`) e o `flow`.
+3. `list_admin_editors_users` → pega o `executorId`.
+4. `situation: 10` (Ativa) e `phaseDueDate` calculado a partir de `currentDueDate`.
+
+Depois de criar, confirme devolvendo os IDs criados. Se algo falhar no meio, diga o que foi criado e o que nao foi. Nunca deixe o usuario achando que criou tudo.
+
+Para mover fase use `update_task_phase`; consulte o estado atual antes, porque o fluxo tem regras de progressao.
+
+## Fora de escopo
+
+- Dados de midia (Meta, Google, GA4): use os prefixos `meta-*`, `google-*`, `ga4-*`.
+- CRM e vendas: `hubspot-*`, `kommo-*`.
+- Ekyte nao tem receita nem CAC. Nao tente derivar resultado comercial daqui.

--- a/.claude/skills/google-sync-drive/SKILL.md
+++ b/.claude/skills/google-sync-drive/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: google-sync-drive
+description: Sincroniza uma pasta do Google Drive com a KB de um cliente, trazendo apenas o que é novo ou mudou desde a última execução. Converte Google Docs, Sheets e Slides em markdown, coloca cada arquivo no lugar certo da KB e mantém um estado em JSON para que a próxima rodada seja incremental. Use quando o usuário rodar /google-sync-drive, disser que quer atualizar a KB com o que veio do Drive, que o cliente mandou arquivo novo no Drive, ou perguntar se tem coisa nova lá.
+area: google
+author: luizricardo
+version: 1.0.0
+---
+
+# Google Drive: sync incremental para a KB
+
+Traz do Drive só o que mudou, converte para markdown e organiza na KB. Não é sync de disco: roda quando você chama.
+
+## Pré-requisitos
+
+O conector do Google Drive precisa estar autenticado. Se as ferramentas `mcp__claude_ai_Google_Drive__*` não aparecerem, o usuário precisa conectar em claude.ai, em Settings e Connectors.
+
+O cliente precisa ter `docs/mapa-drive.md` com o ID da pasta raiz. Se não tiver, este é o primeiro sync: rode o Passo 1 e crie o mapa.
+
+## Passo 1: descobrir o escopo
+
+Leia `docs/mapa-drive.md` do cliente e pegue o ID da pasta raiz.
+
+Se o arquivo não existir, peça o link da pasta ao usuário, extraia o ID de `/folders/{ID}`, e confirme com `get_file_metadata` antes de seguir.
+
+Percorra a árvore com `search_files` usando `parentId = '{ID}'`. Repita para cada subpasta encontrada, até não sobrar pasta. Junte tudo numa lista com id, título, mimeType, modifiedTime e o caminho da pasta.
+
+Não use `fullText contains` para descobrir arquivo: a busca por parentId é exata e não traz lixo de outras pastas.
+
+## Passo 2: comparar com o estado anterior
+
+Leia `docs/.drive-sync.json`. O formato é:
+
+```json
+{
+  "raiz": "ID_DA_PASTA",
+  "ultimaSync": "2026-07-30T20:00:00Z",
+  "arquivos": {
+    "FILE_ID": {
+      "titulo": "...",
+      "modifiedTime": "2026-07-24T13:37:29Z",
+      "destino": "campanhas/lps-operacao/copy-lp-....md",
+      "acao": "importado"
+    }
+  }
+}
+```
+
+Classifique cada arquivo do Drive:
+
+- **Novo**: o id não está no estado.
+- **Mudou**: o id está, mas o `modifiedTime` do Drive é maior que o guardado.
+- **Igual**: nada a fazer, não toque no arquivo da KB.
+- **Sumiu**: está no estado e não veio na varredura. Não apague nada da KB. Marque como `"acao": "removido no drive"` e avise o usuário.
+
+Se o estado não existir, trate tudo como novo, mas antes verifique duplicata (Passo 3).
+
+## Passo 3: não importar duplicata
+
+Antes de importar qualquer coisa, confira se o conteúdo já existe na KB com outro nome. Dois testes baratos:
+
+- Tamanho em bytes igual a algum arquivo já existente em `calls/` ou `docs/`.
+- Título muito parecido com arquivo existente.
+
+Já aconteceu de o transcript do kickoff estar no Drive como `.txt` e na KB como `.md`, com exatamente o mesmo tamanho. Importar de novo teria criado uma segunda cópia divergente.
+
+Quando encontrar duplicata, registre no estado com `"acao": "duplicata"` e o caminho do arquivo que já existe.
+
+## Passo 4: importar
+
+Para Google Docs, Sheets e Slides use `read_file_content` com `includeComments: true`. Os comentários costumam conter as decisões de revisão e são a parte mais valiosa. Coloque-os numa seção própria no topo do markdown, com autor e data.
+
+Para PDF, .docx e .xlsx use `read_file_content` também.
+
+Para imagem e outros binários use `download_file_content`. Faça isso apenas quando o usuário pedir explicitamente: arquivo grande em base64 é lento e caro. O padrão é pular binário e listar o que ficou de fora.
+
+Onde colocar cada coisa, seguindo a convenção da KB:
+
+| Tipo de material | Destino |
+|---|---|
+| Copy de landing page, anúncio, roteiro | `campanhas/{campanha}/` |
+| Transcript de reunião | `calls/` |
+| Documento de estratégia, pesquisa, briefing | `docs/` |
+| Identidade visual, key visual, paleta | `docs/identidade-visual/` |
+| Imagem de campanha | `campanhas/{campanha}/assets/` |
+
+Se não houver campanha óbvia, pergunte em vez de inventar pasta.
+
+No cabeçalho de cada arquivo importado, registre origem, id do arquivo no Drive, data de modificação lá e data de importação. Sem isso ninguém sabe se o que está na KB é a versão atual.
+
+## Passo 5: atualizar estado e mapa
+
+Reescreva `docs/.drive-sync.json` com o estado novo. Atualize a tabela de inventário em `docs/mapa-drive.md`.
+
+## Passo 6: relatório
+
+Diga em texto corrido, sem enfeite:
+
+- Quantos arquivos novos entraram e onde.
+- Quais mudaram e o que mudou de fato, não só que mudou.
+- O que foi pulado e por quê: duplicata, binário, formato não suportado.
+- O que sumiu do Drive.
+
+Se nada mudou, diga isso em uma linha e pare.
+
+## Regras
+
+- Nunca sobrescreva arquivo da KB que foi editado à mão depois da última sync. Compare a data de modificação local com a `ultimaSync`. Se for mais nova, pare e pergunte.
+- Nunca apague arquivo da KB porque sumiu do Drive.
+- Não invente conteúdo para arquivo que não conseguiu ler. Registre como falha.
+- Converta travessão em vírgula, dois-pontos ou parênteses no material importado. É padrão da casa e vale inclusive quando o original do cliente usa travessão.
+- Português brasileiro.
+- Pasta compartilhada aparece em "Compartilhados comigo" e funciona normalmente por parentId. Não é preciso mover nada.
+
+## Limite conhecido
+
+Isto não é sync automático. O Drive não notifica este ambiente quando um arquivo muda, então nada acontece até alguém rodar o comando. Se o usuário quiser de fato automático, o caminho é o Google Drive para Desktop, que sincroniza a pasta no disco em tempo real, e aí esta skill passa a servir só para normalizar o que chegou.


### PR DESCRIPTION
## O que é

Duas skills de fonte — puxam dado de integração externa e servem de insumo pras outras.

**`ekyte-status-cliente`** — status operacional do cliente no Ekyte: o que foi concluído no período, o que está em andamento, o que atrasou e onde as horas estouraram o estimado. Cobre também o caminho inverso, transformando combinados de call em tarefas, sempre com confirmação antes de criar.

**`google-sync-drive`** — sincroniza uma pasta do Drive com a KB do cliente trazendo só o que é novo ou mudou. Converte Docs, Sheets e Slides em markdown, coloca cada arquivo no lugar certo da KB e guarda estado em JSON pra próxima rodada ser incremental.

## Checagens

- Duplo-write verificado
- `REGISTRY.md` fora do PR — a Action regenera no merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)