### PR TITLE
feat(skills): 4 skills gerais de estrategia

### DIFF
--- a/.agents/skills/geral-analise-swot/SKILL.md
+++ b/.agents/skills/geral-analise-swot/SKILL.md
@@ -1,0 +1,253 @@
+---
+name: geral-analise-swot
+description: "Análise de Concorrentes + Matriz SWOT estratégica: scorecard digital dos concorrentes (com evidência), SWOT acionável, matriz TOWS, cenários e priorização em Gantt de 90 dias. Use quando o operador disser 'SWOT', 'análise de concorrentes', 'forças e fraquezas', 'análise estratégica', ou na Semana 1."
+area: geral
+author: luizfreitasv4
+version: 1.0.0
+dependencies:
+  - geral-persona-icp
+outputs: ["geral-analise-swot.json"]
+week: 1
+estimated_time: "1h"
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta versao foi portada do sistema de Estruturacao Estrategica. As regras abaixo tem precedencia sobre caminhos e persistencia citados no fluxo original:
+
+- Trabalhe somente em `squads/{squad}/clientes/{cliente}/`, nunca em um diretorio `clientes/` solto na raiz.
+- Leia primeiro o `CLAUDE.md` ou `AGENTS.md` da KB, `mission-control/`, `calls/`, `docs/` e `campanhas/`.
+- Se `client.json` existir, use-o como fonte complementar. Se nao existir, derive o contexto da KB e do Mission Control; nao exija nem invente esse arquivo.
+- Salve entregaveis em `squads/{squad}/clientes/{cliente}/outputs/`, em JSON e Markdown quando o fluxo pedir ambos.
+- Registre decisoes e progresso no `mission-control/historico-checkins.md` ou no arquivo de historico equivalente encontrado na KB.
+- Resolva recursos empacotados a partir do proprio diretorio desta skill. Se uma integracao externa nao estiver configurada, declare o gap e continue apenas com os dados reais disponiveis.
+
+
+# Análise de Concorrentes + Matriz SWOT (POP 1.5)
+
+Você é um estrategista de negócios sênior. Vai mapear o cenário competitivo com evidência observável e gerar uma Matriz SWOT acionável que direciona a estratégia das próximas semanas.
+
+> **Posição no fluxo:** Semana 1 (POP 1.5). Roda com base no briefing, no ICP/Persona e na pesquisa de concorrentes — **não depende** do Diagnóstico de Maturidade (que ocorre na Semana 2). Se um diagnóstico de maturidade já existir de um ciclo anterior, use como reforço; senão, ancore nos dados de briefing e na pesquisa observável.
+
+> **REGRA DE OURO:** Cada item da SWOT deve ser específico para ESTE cliente. Se você trocar o nome da empresa e o item ainda fizer sentido para qualquer negócio do setor, está genérico demais. Refaça.
+
+## Dados necessários
+
+Leia os seguintes arquivos do diretório do cliente:
+
+1. `client.json` (seção `briefing`) — dados base do cliente (OBRIGATÓRIO)
+2. `outputs/geral-persona-icp.json` — ICP/Persona para cruzar concorrentes por fit, faixa de preço e geografia (OBRIGATÓRIO — é dependência)
+3. `client.json` (seção `connectors`) — dados V4MOS se disponíveis
+4. `outputs/gt-diagnostico-maturidade-digital.json` — scores de maturidade, **se já existir** de um ciclo anterior (opcional; normalmente só existe a partir da Semana 2)
+5. `client.json` (seção `history`) — decisões anteriores relevantes
+
+Extraia do briefing:
+- `identification.name` → nome do cliente
+- `identification.segment` → setor
+- `identification.revenue` → faturamento (se disponível)
+- `identification.years_in_market` → tempo de mercado
+- `product.main_product` → produtos/serviços
+- `product.differentials` → diferenciais declarados pelo cliente
+- `competition.competitors` → lista de concorrentes
+- `competition.differentials` → diferencial real vs concorrentes
+
+Do diagnóstico de maturidade (SE já existir — opcional na Semana 1):
+- `overall_score`, `pillar_scores`, `priorities`, `sector_benchmark` → reforçam forças/fraquezas digitais
+- Se não existir ainda, derive forças/fraquezas digitais do `briefing.digital_situation` e da pesquisa observável dos canais do cliente.
+
+Se não encontrar informações sobre concorrência no client.json, pergunte ao operador de uma vez:
+- "Dos concorrentes listados, qual é o mais perigoso e por quê?"
+- "Tem algum concorrente que faz algo melhor que o cliente? O quê?"
+- "O cliente tem alguma vantagem que os concorrentes não conseguem copiar facilmente?"
+- "Existe alguma tendência do mercado que pode impactar esse negócio nos próximos 6-12 meses?"
+- "O cliente depende muito de algum canal ou fornecedor?"
+
+---
+
+## Geração
+
+Gere o output COMPLETO de uma vez usando os dados de `client.json` (briefing, connectors) e outputs de skills dependentes em `outputs/`.
+
+Consulte `references/exemplos-swot-bom-vs-ruim.md` para calibrar a especificidade.
+
+### Análise de Concorrentes (scorecard digital) — PRIMEIRO PASSO
+
+Antes da SWOT, mapeie o cenário competitivo com **evidência observável** (não percepção). É a base factual que alimenta forças/fraquezas/ameaças.
+
+1. **Selecione 3-5 concorrentes diretos + 1-2 indiretos/aspiracionais.** Cruze com o ICP (fit, faixa de preço, geografia) para não listar concorrente percebido que não compete de fato. Valide a lista com o operador.
+2. **Scorecard digital** — pontue cada concorrente de **0-10** por dimensão, **cada nota com 1 linha de evidência observável** (link/print/fato):
+   - `site`, `seo`, `midia_paga`, `social`, `gmn`, `reputacao`, `comunicacao`
+   - Inclua o próprio cliente na tabela para contraste.
+3. **Leitura competitiva** — onde o cliente está acima/abaixo, e qual o gap mais explorável.
+
+Cada concorrente vira um objeto em `competitor_scorecard[]`: `{name, type: "direto|indireto", scores: {site, seo, midia_paga, social, gmn, reputacao, comunicacao}, evidence: {<dimensao>: "evidência"}, overall}`.
+
+> Regra: nota sem evidência observável não entra. Se não conseguir evidência, marque a dimensão como `null` + motivo.
+
+### Forças (Strengths) — 4-6 itens
+Fatores INTERNOS positivos. Busque em:
+- Diagnóstico digital: pilares com score acima da média do setor
+- Briefing: diferenciais declarados que são REAIS (valide com dados)
+- Tempo de mercado / base de clientes existente
+- Equipe / expertise interna
+- Localização / infraestrutura
+
+Para cada força, inclua:
+- **Título:** frase curta e específica
+- **Descrição:** evidência concreta que sustenta essa força (use dados do diagnóstico quando possível)
+- **Implicação estratégica:** como essa força pode ser ALAVANCADA na estratégia
+
+### Fraquezas (Weaknesses) — 4-6 itens
+Fatores INTERNOS negativos. Busque em:
+- Diagnóstico digital: pilares com score abaixo da média do setor
+- Gaps identificados no diagnóstico
+- Limitações de equipe / budget / conhecimento
+- Dependências perigosas
+
+Para cada fraqueza:
+- **Título:** frase curta e específica
+- **Descrição:** evidência concreta
+- **Implicação estratégica:** qual o risco se não for tratada E como mitigar
+
+### Oportunidades (Opportunities) — 4-6 itens
+Fatores EXTERNOS positivos. Busque em:
+- Tendências do setor favoráveis
+- Gaps dos concorrentes
+- Canais não explorados
+- Mudanças de comportamento do consumidor
+- Tecnologia acessível (IA, automação)
+
+Para cada oportunidade:
+- **Título:** frase curta e específica
+- **Descrição:** por que essa oportunidade existe AGORA
+- **Implicação estratégica:** como capturar essa oportunidade
+
+### Ameaças (Threats) — 4-6 itens
+Fatores EXTERNOS negativos. Busque em:
+- Concorrentes em ascensão
+- Mudanças regulatórias
+- Dependência de plataformas (Meta, Google, iFood, etc.)
+- Mudanças de algoritmo / custos de mídia
+- Saturação de mercado
+
+Para cada ameaça:
+- **Título:** frase curta e específica
+- **Descrição:** evidência de que essa ameaça é real
+- **Implicação estratégica:** como se proteger ou mitigar
+
+### Síntese Estratégica (2-3 parágrafos)
+
+Cruze os quadrantes para responder: "Qual é a jogada mais inteligente que este negócio pode fazer AGORA?"
+
+Parágrafo 1: **Forças + Oportunidades (Alavancagem)** — Como usar as forças para capturar as oportunidades? Esta é a aposta principal.
+
+Parágrafo 2: **Fraquezas + Ameaças (Proteção)** — Quais fraquezas, se não tratadas, vão amplificar as ameaças? Este é o risco principal.
+
+Parágrafo 3: **Estratégia recomendada** — Em 1 parágrafo, o que esse negócio deve priorizar nos próximos 90 dias.
+
+### Matriz TOWS (OBRIGATÓRIA — cruzamento estratégico)
+
+Derive estratégias específicas cruzando os quadrantes. Não é redundância da SWOT — é onde a análise vira ação. Gere 2-3 estratégias por célula:
+
+- **SO (Forças × Oportunidades) — Estratégias Ofensivas:** use a força X para capturar a oportunidade Y. Onde o cliente ATACA.
+- **WO (Fraquezas × Oportunidades) — Estratégias de Reforço:** como eliminar a fraqueza X para não perder a oportunidade Y. Onde o cliente INVESTE.
+- **ST (Forças × Ameaças) — Estratégias Defensivas:** use a força X para neutralizar a ameaça Y. Onde o cliente PROTEGE.
+- **WT (Fraquezas × Ameaças) — Estratégias de Sobrevivência:** o pior cenário. O que fazer para reduzir a fraqueza X que se amplifica com a ameaça Y. Onde o cliente MINIMIZA DANO.
+
+Para cada estratégia: `id` (ex: SO1, WT2), `strategy` (ação), `rationale` (por que funciona), `expected_outcome` (o que muda se executar).
+
+### Ações Prioritárias (5-7 ações) — com risk-adjusted scoring
+
+Derive ações concretas da SWOT/TOWS. Para cada:
+1. **Ação** — o que fazer (específico)
+2. **Base SWOT** — quais quadrantes/estratégias TOWS essa ação endereça (ex: "Alavanca F2, captura O3, executa SO1")
+3. **Impacto** — alto/médio/baixo
+4. **Prazo sugerido** — semana 1/2/3 da estruturação
+5. **Financial impact** — objeto com `investment` (R$) + `expected_return_90d` (R$) + `payback_days` + `roi_multiple`. Campos alternativos aceitos: `investment_brl`, `monthly_return_brl` (×3 dá o 90d), `note`.
+6. **Risk-adjusted score** — pode ser NÚMERO 0-100 **ou** OBJETO com dimensões 1-10:
+   ```json
+   {"impact": 9, "probability_of_success": 8, "reversibility": 7, "score": 8.2}
+   ```
+   Use o objeto quando o score for derivado de múltiplas dimensões (mais transparente). O campo `score` é obrigatório.
+7. **Dependência** — se depende de alguma outra ação ou skill
+
+Ordene as ações por risk_adjusted_score (maior primeiro).
+
+> **NÃO GERE:** os campos `scenarios` e `financial_summary_90d` foram removidos do schema — o renderer do portal não os exibe mais. Projeções de cenários vivem em `gt-diagnostico-midia-paga` (budget_reallocation_scenarios). A consolidação financeira é redundante com `priority_actions[].financial_impact`, que o portal já agrega.
+
+### Estrutura visual (obrigatória)
+
+Siga o padrão canônico de `references/padrao-output.md`. Além dos campos acima, SEMPRE inclua:
+
+- **`summary_headline`** (max 200 char) — manchete com o veredito da SWOT. Ex: "[Cliente] tem know-how técnico raro (certificação X), mas mídia zerada — janela SO de 12 meses antes de novo entrante."
+- **`summary_highlights`** (4-6 itens, `{category, label, value, subtext, tone}`) — para SWOT sugestões:
+  - `posicao`: score SWOT líquido, nº de forças vs fraquezas
+  - `oportunidade`: top priority action com ROI projetado, payback
+  - `risco`: ameaça de maior impacto
+  - `janela`: tempo até janela fechar / urgência
+- **`summary_key_findings`** (3-5 itens, `{category, text}`) — `vantagem|contexto|ameaca|acao` — cubra pelo menos 3 dos 4.
+
+### Ponto de alavancagem
+
+Em SWOT, o ponto de alavancagem é a **combinação Força × Oportunidade mais assimétrica** (quadrante SO com maior risk_adjusted_score). Estruture em `key_insight`:
+```json
+"key_insight": {
+  "headline": "Cruzamento F×O em 1 frase (pode virar quote)",
+  "context": "2-3 linhas sobre por que esta combinação é única",
+  "numbered_reasons": ["(1) força específica...", "(2) oportunidade específica...", "(3) timing/janela..."],
+  "discussion_anchor": "Por que o stakeholder precisa decidir sobre apetite e ritmo"
+}
+```
+
+Se SWOT revelou fragilidade estrutural (mais ameaças que forças, ausência de diferencial real), inclua `honesty_alert`.
+
+## Auto-validação
+
+Antes de mostrar ao operador, verifique:
+
+- [ ] Mencionou o cliente pelo nome?
+- [ ] Usou dados reais do client.json (não inventou)?
+- [ ] Nenhum item genérico (ex: "quer crescer", "qualidade e compromisso")?
+- [ ] Schema da skill validou?
+- [ ] Todos os campos do schema preenchidos (ou com `null` + `unavailable_reason` no pai)?
+- [ ] Nenhuma string vazia (`""`) — substituí por `null` + reason quando o dado não existe?
+- [ ] Estimativas marcadas com `estimated: true` ou `[E]`?
+- [ ] `competitor_scorecard` tem 3-5 diretos (+ indiretos), notas 0-10 e **evidência observável** por nota (não percepção)?
+- [ ] Concorrentes validados por fit/ICP (não listou percebido que não compete)?
+- [ ] Cada item da SWOT é específico — se trocar o nome da empresa, NÃO serve para outro negócio do setor?
+- [ ] Síntese cruza quadrantes (não é apenas resumo)?
+- [ ] Ações derivam dos quadrantes (referência F/W/O/T explícita)?
+- [ ] Matriz TOWS tem pelo menos 2 estratégias por célula (SO, WO, ST, WT)?
+- [ ] Cada priority_action tem `financial_impact` (investment, return, payback, ROI) e `risk_adjusted_score`?
+- [ ] Priority_actions estão ORDENADAS por risk_adjusted_score (maior primeiro)?
+- [ ] NÃO gerou `scenarios` nem `financial_summary_90d` (removidos do schema)?
+- [ ] Tem `summary_headline` específico?
+- [ ] `summary_highlights` tem 4-6 itens com categorias e tons válidos?
+- [ ] `summary_key_findings` cobre pelo menos 3 dos 4 tipos?
+- [ ] Identificou `key_insight` (cruzamento SO mais assimétrico) para stakeholder?
+- [ ] Se há fragilidade estrutural, incluiu `honesty_alert`?
+
+Se falhou → regenere silenciosamente. Não avise o operador.
+
+## Apresentação e decisões
+
+Apresente o output COMPLETO ao operador em formato visual claro (tabela ou lista organizada por quadrante).
+
+Revise o output. O que está errado, exagerado ou faltando?
+
+- "Algum item está genérico demais? (lembre: se serve pra qualquer empresa do setor, está genérico)"
+- "Falta alguma força ou fraqueza que você enxerga no dia a dia?"
+- "Alguma oportunidade ou ameaça que eu não considerei?"
+- "A síntese captura a essência do que o cliente precisa fazer?"
+- "As ações fazem sentido no contexto do que será trabalhado nas próximas semanas?"
+- "Quer ajustar a priorização?"
+
+## Finalização
+
+Operador aprova (com ou sem ajustes).
+1. Salve em `squads/{squad}/clientes/{cliente}/outputs/geral-analise-swot.json` (com campo `summary` no topo)
+2. Atualize `client.json`: progress.skills → completed, version++, append em history[]
+3. Salve também uma versão Markdown do entregável na mesma pasta de outputs.
+4. Sugira próxima skill do dependency_graph
+   - "SWOT salva. Este output será usado pela skill geral-posicionamento-estrategico (semana 2) e como referência para todas as skills de produção."
+   - Sugira a próxima skill da semana 1 (account-auditoria-comunicacao ou geral-persona-icp se ainda não feita)

--- a/.agents/skills/geral-analise-swot/references/exemplos-swot-bom-vs-ruim.md
+++ b/.agents/skills/geral-analise-swot/references/exemplos-swot-bom-vs-ruim.md
@@ -1,0 +1,160 @@
+# SWOT: Exemplos de Itens Específicos vs Genéricos
+
+O maior erro em análise SWOT é ser genérico. Uma SWOT genérica não serve para tomar decisão nenhuma. Este documento calibra o que é aceito e o que deve ser refeito.
+
+---
+
+## O Teste de Especificidade
+
+Para cada item da SWOT, aplique este teste:
+
+> **Se eu trocar o nome da empresa por qualquer concorrente do mesmo setor, o item ainda faz sentido?**
+> - Se SIM → está GENÉRICO. Refaça.
+> - Se NÃO → está específico. Aprovado.
+
+---
+
+## Exemplo 1: Clínica de Estética (Curitiba)
+
+### FORÇAS
+
+| RUIM (genérico) | BOM (específico) |
+|------------------|-------------------|
+| "Equipe qualificada" | "Dra. Marina é referência em harmonização facial natural no PR, com 12K seguidores orgânicos e lista de espera de 3 semanas" |
+| "Localização privilegiada" | "Localizada no Batel (bairro nobre), a 200m do Shopping Pátio Batel — 80% dos clientes citam proximidade como fator de escolha" |
+| "Bom atendimento" | "NPS de 92 medido mensalmente. 67% dos clientes vieram por indicação. Taxa de retorno para segundo procedimento: 45% em 6 meses" |
+| "Variedade de serviços" | "Única clínica da região que combina dermatologia + estética + nutrologia no mesmo espaço, permitindo protocolo integrado" |
+
+### FRAQUEZAS
+
+| RUIM (genérico) | BOM (específico) |
+|------------------|-------------------|
+| "Marketing fraco" | "Score de mídia paga 22/100 — roda R$3k/mês no Meta sem pixel configurado, CPA de R$180 (3x a média do setor)" |
+| "Falta de tecnologia" | "Agendamento é por WhatsApp manual. 30% dos contatos não são respondidos em 24h. Sem CRM — leads se perdem entre as 3 recepcionistas" |
+| "Pouca presença digital" | "Instagram com 2.4K seguidores, frequência irregular (2-3 posts/mês). Nenhum conteúdo de bastidores ou resultado. Concorrente principal tem 18K seguidores" |
+| "Precisa melhorar processos" | "Protocolo de follow-up pós-procedimento é informal — pacientes só voltam se ligarem por conta própria. Sem automação de reativação" |
+
+### OPORTUNIDADES
+
+| RUIM (genérico) | BOM (específico) |
+|------------------|-------------------|
+| "Mercado em crescimento" | "Mercado de estética em Curitiba cresceu 23% em 2025. Busca por 'harmonização facial Curitiba' aumentou 47% no Google Trends vs. ano anterior" |
+| "Usar redes sociais" | "Reels de antes/depois geram 5-10x mais engajamento que posts regulares no nicho. Concorrentes locais não exploram UGC de pacientes (oportunidade de diferenciação)" |
+| "Expandir serviços" | "Pacientes frequentes perguntam por bioestimuladores de colágeno (Sculptra) — procedimento de ticket R$3-5k que a clínica ainda não oferece mas a Dra. Marina é habilitada" |
+| "Atrair novos clientes" | "40% da base mora no Batel/Água Verde. Campanha geo-localizada no Meta para raio de 5km nunca foi feita — concorrente X captura esse tráfego local" |
+
+### AMEAÇAS
+
+| RUIM (genérico) | BOM (específico) |
+|------------------|-------------------|
+| "Concorrência forte" | "Clínica Belissima (concorrente direto) abriu 2a unidade a 800m, investindo R$20k/mês em Meta Ads com vídeos profissionais. Capturando público do Batel" |
+| "Crise econômica" | "Ticket médio de R$1.500/procedimento posiciona no segmento premium. Em cenário de contração, público A/B corta estética antes de necessidades — risco de queda de 15-25% em demanda" |
+| "Mudanças regulatórias" | "CFM está revisando normas de publicidade médica para 2026. Se aprovar restrição de antes/depois no Instagram (como já ocorre em alguns CRMs), principal canal de aquisição fica comprometido" |
+| "Problemas com fornecedores" | "80% dos insumos vêm de 1 distribuidor (Galderma). Atraso de 15 dias na entrega em fevereiro forçou cancelamento de 8 procedimentos e perda estimada de R$12k" |
+
+---
+
+## Exemplo 2: E-commerce de Suplementos
+
+### FORÇAS
+
+| RUIM | BOM |
+|------|-----|
+| "Produtos de qualidade" | "Fórmula aberta (sem blend proprietário) em todos os 47 SKUs. 23% dos compradores citam 'transparência no rótulo' como motivo da compra (dados da pesquisa pós-venda)" |
+| "Preço competitivo" | "Whey isolado a R$89/900g posiciona 35% abaixo de Growth Supplements e Integralmedica para composição equivalente. Melhor custo-por-grama de proteína do mercado" |
+| "Boa marca" | "DA 38 no site (acima da média do setor = 25). Ranqueia top 5 para 'melhor whey custo beneficio' e 'creatina boa e barata'. 2.1K reviews com nota 4.6/5" |
+| "Logística eficiente" | "Fulfillment próprio em Barueri. Tempo médio de entrega SP capital: 1.2 dias. Frete grátis acima de R$149 (ticket médio = R$167)" |
+
+### FRAQUEZAS
+
+| RUIM | BOM |
+|------|-----|
+| "Pouca variedade" | "Catálogo concentrado em whey e creatina (78% do faturamento). Sem categoria de saúde/wellness que cresce 40% ao ano no setor (colágeno, vitaminas, adaptógenos)" |
+| "Marketing precisa melhorar" | "ROAS caiu de 6.2x para 3.8x nos últimos 6 meses sem mudança de budget (R$45k/mês). Frequência de criativos novos: 1 por mês. Benchmark do setor: 4-6 por semana" |
+| "Dependência de plataforma" | "64% das vendas vêm de tráfego pago no Meta. Orgânico e email representam apenas 12%. Qualquer aumento de CPM impacta diretamente a margem" |
+| "Sem programa de fidelidade" | "Taxa de recompra em 90 dias: 18%. Benchmark do setor para suplementos: 35-45%. Sem régua de reativação, sem desconto progressivo, sem clube de assinatura" |
+
+### OPORTUNIDADES
+
+| RUIM | BOM |
+|------|-----|
+| "Crescer nas redes" | "TikTok Shop lança no Brasil em 2026. Concorrentes diretos ainda não têm presença. Conteúdo de 'review honesto de suplemento' tem média de 500K views na plataforma" |
+| "Lançar novos produtos" | "Creatina monohidratada creapure (matéria-prima premium alemã) — único SKU que esgota todo mês. Lançar versão 500g (hoje só tem 300g) pode capturar R$80k/mês adicionais com base na demanda reprimida" |
+| "Parcerias" | "3 criadores com 100K-500K seguidores no nicho fitness mencionaram a marca organicamente no último trimestre. Nenhum é patrocinado — programa de embaixadores custaria ~R$15k/mês para formalizar" |
+| "Vender mais" | "Clube de assinatura com 10% de desconto + frete grátis. Benchmark: marcas com subscription no setor convertem 25-30% da base ativa. Estimativa: R$120k/mês recorrente em 6 meses" |
+
+### AMEAÇAS
+
+| RUIM | BOM |
+|------|-----|
+| "Muita concorrência" | "Growth Supplements captou R$15M em investimento e está subsidiando frete grátis + cupom de primeira compra agressivamente. Market share deles cresceu 8pp no último ano" |
+| "Mudanças no mercado" | "CPM médio no Meta para e-commerce fitness subiu 42% em 2025. Com ROAS já em queda, margem líquida pode ficar abaixo de 8% em 6 meses se tendência continuar" |
+| "Regulação" | "ANVISA publicou consulta pública sobre rotulagem de suplementos esportivos. Se aprovada, obrigaria reformulação de 12 dos 47 SKUs (custo estimado R$200k + 4 meses)" |
+| "Economia" | "Câmbio acima de R$6.00 impacta matéria-prima importada (whey WPC/WPI vem dos EUA). Cada R$0.50 de alta no dólar comprime R$2.30/kg no custo — margem bruta cai 3pp" |
+
+---
+
+## Exemplo 3: Restaurante Contemporâneo (Campinas)
+
+### FORÇAS
+
+| RUIM | BOM |
+|------|-----|
+| "Comida boa" | "Chef Renato foi finalista do prêmio Prazeres da Mesa 2024 na categoria 'Melhor Novo Restaurante Interior SP'. Nota 4.7/5 no Google (312 reviews)" |
+| "Boa localização" | "Cambuí (bairro gastronômico de Campinas). A 50m da rua mais movimentada de bares/restaurantes. 3 estacionamentos conveniados num raio de 200m" |
+| "Ambiente agradável" | "Projeto arquitetônico premiado (escritório SuperLimão). O espaço é fotografado e postado organicamente — 40% dos posts marcados no Instagram são do ambiente, não da comida" |
+| "Equipe dedicada" | "Sommelier residente (único restaurante contemporâneo de Campinas com sommelier fixo). Carta de vinhos curada com 85 rótulos, ticket médio de bebida R$78" |
+
+### FRAQUEZAS
+
+| RUIM | BOM |
+|------|-----|
+| "Custos altos" | "Food cost em 38% (meta do setor: 28-32%). Menu degustação de 7 etapas usa ingredientes sazonais importados — margem bruta do degustação é 12pp menor que pratos à la carte" |
+| "Pouco marketing" | "Instagram com 4.8K seguidores mas sem padrão visual. Últimas 20 fotos foram tiradas com celular em iluminação ruim. Concorrente Chez Claude tem 22K com fotógrafo semanal" |
+| "Capacidade limitada" | "52 lugares. Sexta e sábado lotam (taxa de ocupação 95%). Terça e quarta ficam em 40%. Sem estratégia de preenchimento para dias fracos (desconto, evento, menu especial)" |
+| "Dependência do iFood" | "iFood responde por 35% do faturamento mas cobra 27% de comissão. Margem líquida do delivery: 4% (vs. 18% do salão). Sem app próprio ou pedido direto" |
+
+### OPORTUNIDADES
+
+| RUIM | BOM |
+|------|-----|
+| "Atrair novos clientes" | "Campinas tem 15 empresas com 500+ funcionários num raio de 10km. Nenhuma tem contrato de catering/eventos corporativos com restaurante contemporâneo. Ticket corporativo médio: R$8-15k/evento" |
+| "Usar delivery" | "Criar menu delivery exclusivo com 5 pratos de margem alta (acima de 65%) e embalagem instagramável. Benchmark: restaurantes que lançam 'menu delivery premium' reduzem dependência do iFood em 40% em 6 meses" |
+| "Fazer eventos" | "Terça e quarta vagas → 'Noite de Harmonização' (R$189/pessoa, vinícola parceira custeia vinho). 30 lugares x 2 noites x 4 semanas = R$45k/mês com margem de 55%" |
+| "Redes sociais" | "Food content no TikTok/Reels de Campinas é dominado por fast food. Restaurante contemporâneo com plating bonito + storytelling do chef tem espaço vazio. 3 concorrentes de SP (Maní, A Casa do Porco) já faturam R$50k+/mês em visibilidade gratuita via Reels" |
+
+### AMEAÇAS
+
+| RUIM | BOM |
+|------|-----|
+| "Concorrência" | "3 novos restaurantes contemporâneos abriram no Cambuí nos últimos 12 meses, incluindo o 'Raíz' (chef ex-D.O.M.) com investimento estimado de R$2M e campanha de lançamento agressiva" |
+| "Custos subindo" | "Azeite extra-virgem subiu 80% em 12 meses. Proteínas nobres (wagyu, polvo) subiram 25%. Sem repasse no menu desde fev/2025 — margem comprimindo mês a mês" |
+| "Economia" | "Campinas tem concentração de funcionários do setor de TI (40% dos clientes do jantar). Layoffs no setor em 2025 reduziram frequência de jantar fora — ticket médio caiu 8% QoQ" |
+| "Mudanças" | "iFood anunciou aumento de comissão de 27% para 30% a partir de jul/2026. Impacto estimado: R$4.5k/mês a menos de margem. Se subir para 33% (rumor), delivery fica no breakeven" |
+
+---
+
+## Checklist de Qualidade para SWOT
+
+Antes de apresentar a SWOT ao operador, verifique:
+
+| # | Critério | Teste |
+|---|----------|-------|
+| 1 | Especificidade | Cada item tem dados, números, nomes, ou evidências concretas? |
+| 2 | Diferenciação | O item é exclusivo deste cliente? Ou serve para qualquer empresa do setor? |
+| 3 | Implicação clara | Cada item diz o que fazer com aquela informação (alavancar, mitigar, capturar, proteger)? |
+| 4 | Base factual | O item é baseado em dado real (diagnóstico, briefing, operador) ou é suposição? Se suposição, marcar e validar |
+| 5 | Equilíbrio | Tem 4-6 itens por quadrante? Nenhum quadrante está inflado ou vazio? |
+| 6 | Forças reais | As forças são REAIS ou são o que o cliente GOSTARIA de ser? (Validar com dados) |
+| 7 | Fraquezas honestas | As fraquezas são honestas? Não amenizou nada por "educação"? |
+| 8 | Oportunidades atingíveis | As oportunidades são capturáveis com os recursos do cliente? Ou são fantasia? |
+| 9 | Ameaças concretas | As ameaças são reais e prováveis? Não colocou "recessão global" como ameaça para uma padaria? |
+| 10 | Síntese coerente | A síntese cruza os quadrantes e gera direcionamento claro? |
+
+## Erros mais comuns em SWOT
+
+1. **Confundir interno com externo.** "Mercado grande" é oportunidade, não força. "Equipe pequena" é fraqueza, não ameaça.
+2. **Listar sintomas, não causas.** "Vendas caindo" é sintoma. A fraqueza é "CRM inexistente com 0% de reativação de clientes inativos".
+3. **SWOT otimista.** 6 forças, 2 fraquezas, 5 oportunidades, 1 ameaça. Se a SWOT parece um pitch de vendas, está enviesada.
+4. **Itens repetidos entre quadrantes.** "Equipe pequena" como fraqueza E "contratar" como oportunidade é redundância.
+5. **SWOT sem dados.** "Acreditamos que..." não é análise. Use dados do diagnóstico, briefing, e pesquisa.

--- a/.agents/skills/geral-analise-swot/references/padrao-output.md
+++ b/.agents/skills/geral-analise-swot/references/padrao-output.md
@@ -1,0 +1,202 @@
+# Padrão de Output das Skills — V4 Estruturação IA
+
+Este documento define a **estrutura canônica** que todos os outputs de skill devem seguir para renderizar no portal com hierarquia visual consistente. O objetivo é que o operador e o stakeholder final abram qualquer entregável e encontrem o mesmo ritmo: manchete → KPIs → achados categorizados → ponto de alavancagem destacado → detalhes expansíveis.
+
+---
+
+## Princípios
+
+1. **Manchete antes de texto.** Toda skill abre com uma frase única e específica que resume a conclusão. Não é parágrafo, é headline.
+2. **Números em destaque, não escondidos no corpo do texto.** KPIs que importam viram cards. Texto corrido é para contexto, não para fato quantitativo.
+3. **Achados categorizados por intenção.** Cada insight é classificado como `vantagem | contexto | ameaca | acao` — o leitor identifica o tom antes de ler.
+4. **Ponto de alavancagem visualmente isolado.** Toda skill tem UM ponto onde a conversa com o stakeholder precisa acontecer. Esse ponto ganha hero visual (border, gradient, quote destacada).
+5. **Detalhe denso → colapsável.** Listas longas (concorrentes, itens de checklist, fontes) ficam em `<details>` para não afogar a leitura.
+
+---
+
+## Campos obrigatórios no JSON
+
+Todo output de skill DEVE ter estes campos no topo (antes dos campos específicos da skill):
+
+```json
+{
+  "client_name": "Nome do Cliente",
+  "summary": "Resumo em 1-2 frases. Específico, com dados reais. Alimenta o resumo executivo do portal.",
+
+  "summary_headline": "Manchete em 1 linha (max 120 caracteres). A frase que o stakeholder lê primeiro.",
+
+  "summary_highlights": [
+    {
+      "category": "posicao | competicao | janela | maturidade | oportunidade | risco",
+      "label": "Rótulo curto (max 30 char)",
+      "value": "Valor em destaque (número, %, status)",
+      "subtext": "Contexto em 1 linha (max 60 char)",
+      "tone": "green | yellow | red | blue | gray"
+    }
+  ],
+
+  "summary_key_findings": [
+    {
+      "category": "vantagem | contexto | ameaca | acao",
+      "text": "Achado em 1-2 linhas. Específico, acionável."
+    }
+  ]
+}
+```
+
+### Regras dos campos de summary
+
+**`summary_headline`**: É a ÚNICA frase que o stakeholder precisa ler se só tiver 5 segundos. Deve conter o veredito da skill. Exemplos bons:
+- ✓ "[Cliente] é o ÚNICO player premium da microrregião com [diferencial declarado] — janela competitiva de 12-18 meses."
+- ✗ "Análise de mercado concluída com sucesso."
+
+**`summary_highlights`** (4-6 itens): KPIs visuais. Categorias sugeridas:
+- `posicao` — onde o cliente está hoje vs potencial
+- `competicao` — quem disputa o mesmo espaço
+- `janela` — tempo/urgência
+- `maturidade` — estágio atual em algum eixo
+- `oportunidade` — tamanho do ganho possível
+- `risco` — tamanho da ameaça
+
+Agrupar de 2 em 2 por categoria no renderer (dá layout balanceado 3x2 ou 2x2).
+
+**`summary_key_findings`** (3-5 itens): Achados que embasam a manchete. Categorias:
+- `vantagem` (✓ verde) — o que o cliente tem a favor
+- `contexto` (i azul) — o que é fato do mercado, neutro
+- `ameaca` (! vermelho) — o que pode dar errado
+- `acao` (▸ laranja) — o que precisa ser feito
+
+---
+
+## Ponto de Alavancagem (hero block)
+
+Toda skill deve identificar **UM bloco que merece destaque visual especial** — o ponto onde a conversa estratégica precisa acontecer. O nome do campo varia por skill, mas a estrutura é consistente:
+
+```json
+{
+  "key_leverage_point": {
+    "headline": "Frase-manchete do ponto (pode ir como quote)",
+    "context": "Contexto em 2-3 linhas explicando o cenário",
+    "numbered_reasons": [
+      "Razão 1 (parse-friendly, pode começar com texto direto)",
+      "Razão 2",
+      "Razão 3"
+    ],
+    "discussion_anchor": "Frase curta sobre POR QUE este é o ponto de conversa com o stakeholder"
+  }
+}
+```
+
+Exemplos por skill:
+- `pesquisa-mercado` → `unexploited_opportunity` (whitespace estratégico)
+- `persona-icp` → persona principal + dor mais ignorada
+- `swot` → combinação força × oportunidade mais assimétrica
+- `posicionamento` → PUV vs alternativas descartadas
+- `diagnostico-midia` → canal mais subotimizado + upside estimado
+- `diagnostico-maturidade` → pilar mais fraco com maior impacto
+
+O renderer aplica:
+- Border verde 2px + gradient sutil
+- Selo "Whitespace Estratégico · Discussão com Stakeholder" no topo
+- Pill de viabilidade/urgência à direita
+- Quote/headline em card branco isolado
+- Razões numeradas em 3 círculos
+- Footer "💬 Momento de validar com a stakeholder"
+
+---
+
+## Alerta de honestidade
+
+Se a pesquisa/análise revelou fragilidade do cliente (não há diferencial real, ICP mal definido, mercado saturado, etc.), inclua:
+
+```json
+{
+  "honesty_alert": "Texto explicando a fragilidade encontrada e o que precisa ser feito antes de seguir."
+}
+```
+
+Esse campo renderiza em box amarelo/vermelho após os achados. **Nunca omita** se a realidade justifica. O valor do sistema depende de não vender aspiracional como real.
+
+---
+
+## Instrução para a IA da skill
+
+Em cada `SKILL.md`, incluir esta seção na geração:
+
+> ### Estrutura visual (obrigatória)
+>
+> Além dos campos específicos desta skill, gere SEMPRE:
+>
+> - `summary_headline` — manchete em 1 linha com o veredito
+> - `summary_highlights` — 4-6 KPIs categorizados (`posicao|competicao|janela|maturidade|oportunidade|risco`) com `{label, value, subtext, tone}`
+> - `summary_key_findings` — 3-5 achados categorizados (`vantagem|contexto|ameaca|acao`)
+> - `honesty_alert` se houver fragilidade
+>
+> Identifique o **ponto de alavancagem** desta skill (o bloco que merece hero visual) e estruture-o com headline + contexto + razões numeradas + discussion anchor.
+>
+> Consulte `references/padrao-output.md` para especificação completa.
+
+E na auto-validação:
+
+> - [ ] Tem `summary_headline` específico (não "análise concluída")?
+> - [ ] `summary_highlights` tem 4-6 itens com categorias válidas?
+> - [ ] `summary_key_findings` cobre pelo menos 3 dos 4 tipos (vantagem/contexto/ameaça/ação)?
+> - [ ] Identificou o ponto de alavancagem para discussão com stakeholder?
+> - [ ] Se há fragilidade, incluiu `honesty_alert`?
+
+---
+
+## Completude (regra crítica)
+
+**Todo campo definido no schema da skill é obrigatório no output.** Não omitir campos — o renderer assume que os campos do schema existem e quebra/fica vazio silenciosamente quando faltam.
+
+Se um dado **não pode ser obtido** (GA4 não instalado, conector não conectado, cliente não sabe, etc.), preencher com `null` E adicionar `unavailable_reason` no objeto pai:
+
+```json
+{
+  "current_conversion_rate": null,
+  "current_bounce_rate": null,
+  "avg_time_on_page": null,
+  "unavailable_reason": "GA4 não instalado no site — métricas de analytics não coletadas nesta auditoria"
+}
+```
+
+Para arrays vazios legitimamente (ex: nenhum competidor identificado), preencher com `[]` e adicionar uma nota no campo irmão `{campo}_note`:
+
+```json
+{
+  "competitors": [],
+  "competitors_note": "Nenhum concorrente direto identificado na microrregião após busca em Google Maps + Instagram."
+}
+```
+
+Para valores **estimados** (sem fonte pública), adicionar flag `[E]` no texto OU campo `estimated: true` no objeto:
+
+```json
+{ "tam_brl": 450000000, "estimated": true, "estimation_basis": "IBGE população × SEBRAE ticket médio" }
+```
+
+**Nunca** deixar string vazia (`""`), zero falso (`0` quando não é zero real), ou omitir o campo. Essas três formas são invisíveis para o renderer e geram o bug "coluna vazia".
+
+Valide o JSON contra o `schema.json` empacotado na skill e corrija campos ausentes ou `null` sem `unavailable_reason`.
+
+### Checklist adicional de auto-validação
+
+> - [ ] Todos os campos do schema estão presentes (preenchidos ou com `null` + `unavailable_reason`)?
+> - [ ] Nenhuma string vazia (`""`) — substituí por `null` + reason quando o dado não existe?
+> - [ ] Arrays vazios legítimos têm `{campo}_note` explicando por quê?
+> - [ ] Estimativas marcadas com `estimated: true` ou `[E]`?
+
+---
+
+## Tons de voz
+
+- `green` — oportunidade/vantagem/confirmado
+- `yellow` — atenção/potencial/médio
+- `red` — risco/ameaça/fraco
+- `blue` — contexto/informativo/neutro
+- `gray` — desativado/aspiracional/ausente
+
+Usar tons consistentemente: nunca pintar ameaça de verde ou vantagem de vermelho para "chamar atenção". O tom é semântico.
+
+---

--- a/.agents/skills/geral-analise-swot/schema.json
+++ b/.agents/skills/geral-analise-swot/schema.json
@@ -1,0 +1,566 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "SWOT",
+  "description": "Output estruturado da skill swot: análise SWOT completa com síntese estratégica e ações prioritárias.",
+  "type": "object",
+  "required": [
+    "summary",
+    "strengths",
+    "weaknesses",
+    "opportunities",
+    "threats",
+    "strategic_synthesis",
+    "priority_actions",
+    "client_name",
+    "summary_headline",
+    "summary_highlights",
+    "summary_key_findings"
+  ],
+  "properties": {
+    "client_name": {
+      "type": "string",
+      "description": "Nome do cliente — sempre presente em todo output."
+    },
+    "competitor_scorecard": {
+      "type": "array",
+      "description": "POP 1.5 — scorecard digital dos concorrentes (3-5 diretos + 1-2 indiretos), com nota 0-10 por dimensão e evidência observável. Inclua o próprio cliente para contraste.",
+      "items": {
+        "type": "object",
+        "required": ["name", "type", "scores"],
+        "properties": {
+          "name": { "type": "string" },
+          "type": { "type": "string", "enum": ["cliente", "direto", "indireto", "aspiracional"] },
+          "scores": {
+            "type": "object",
+            "description": "Notas 0-10 por dimensão.",
+            "properties": {
+              "site": { "type": ["number", "null"] },
+              "seo": { "type": ["number", "null"] },
+              "midia_paga": { "type": ["number", "null"] },
+              "social": { "type": ["number", "null"] },
+              "gmn": { "type": ["number", "null"] },
+              "reputacao": { "type": ["number", "null"] },
+              "comunicacao": { "type": ["number", "null"] }
+            }
+          },
+          "evidence": { "type": "object", "description": "1 linha de evidência observável por dimensão pontuada." },
+          "overall": { "type": ["number", "null"], "description": "Média/leitura geral 0-10." }
+        }
+      }
+    },
+    "summary": {
+      "type": "string",
+      "description": "Resumo de 1-2 frases da análise SWOT. Usado como referência rápida por outras skills."
+    },
+    "summary_headline": {
+      "type": "string",
+      "maxLength": 200,
+      "description": "Manchete em 1 linha com o veredito desta skill (hero do resumo executivo no portal). Ver references/padrao-output.md"
+    },
+    "summary_highlights": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 8,
+      "description": "KPIs visuais categorizados para o resumo executivo. Cada item: {category, label, value, subtext, tone}.",
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "label",
+          "value"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "posicao",
+              "competicao",
+              "janela",
+              "maturidade",
+              "oportunidade",
+              "risco"
+            ]
+          },
+          "label": {
+            "type": "string",
+            "maxLength": 40
+          },
+          "value": {
+            "type": "string"
+          },
+          "subtext": {
+            "type": "string",
+            "maxLength": 80
+          },
+          "tone": {
+            "type": "string",
+            "enum": [
+              "green",
+              "yellow",
+              "red",
+              "blue",
+              "gray"
+            ]
+          }
+        }
+      }
+    },
+    "summary_key_findings": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 6,
+      "description": "Achados categorizados por intenção (vantagem/contexto/ameaça/ação). Pelo menos 3 dos 4 tipos cobertos.",
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "text"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "vantagem",
+              "contexto",
+              "ameaca",
+              "acao"
+            ]
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "strengths": {
+      "type": "array",
+      "minItems": 4,
+      "maxItems": 6,
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "description",
+          "implication"
+        ],
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "Frase curta e específica descrevendo a força."
+          },
+          "description": {
+            "type": "string",
+            "description": "Evidência concreta que sustenta essa força (com dados quando possível)."
+          },
+          "implication": {
+            "type": "string",
+            "description": "Como essa força pode ser alavancada na estratégia."
+          },
+          "source": {
+            "type": "string",
+            "enum": [
+              "diagnostico",
+              "briefing",
+              "operador",
+              "v4mos"
+            ],
+            "description": "De onde veio a evidência."
+          }
+        }
+      },
+      "description": "Fatores internos positivos do negócio."
+    },
+    "weaknesses": {
+      "type": "array",
+      "minItems": 4,
+      "maxItems": 6,
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "description",
+          "implication"
+        ],
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "Frase curta e específica descrevendo a fraqueza."
+          },
+          "description": {
+            "type": "string",
+            "description": "Evidência concreta da fraqueza."
+          },
+          "implication": {
+            "type": "string",
+            "description": "Risco se não tratada + sugestão de mitigação."
+          },
+          "severity": {
+            "type": "string",
+            "enum": [
+              "critical",
+              "high",
+              "medium"
+            ],
+            "description": "Severidade da fraqueza."
+          },
+          "source": {
+            "type": "string",
+            "enum": [
+              "diagnostico",
+              "briefing",
+              "operador",
+              "v4mos"
+            ],
+            "description": "De onde veio a evidência."
+          }
+        }
+      },
+      "description": "Fatores internos negativos do negócio."
+    },
+    "opportunities": {
+      "type": "array",
+      "minItems": 4,
+      "maxItems": 6,
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "description",
+          "implication"
+        ],
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "Frase curta e específica descrevendo a oportunidade."
+          },
+          "description": {
+            "type": "string",
+            "description": "Por que essa oportunidade existe AGORA."
+          },
+          "implication": {
+            "type": "string",
+            "description": "Como capturar essa oportunidade."
+          },
+          "time_sensitivity": {
+            "type": "string",
+            "enum": [
+              "urgent",
+              "medium_term",
+              "long_term"
+            ],
+            "description": "Janela de oportunidade."
+          },
+          "source": {
+            "type": "string",
+            "enum": [
+              "diagnostico",
+              "briefing",
+              "operador",
+              "v4mos",
+              "market_trend"
+            ],
+            "description": "De onde veio a evidência."
+          }
+        }
+      },
+      "description": "Fatores externos positivos (oportunidades de mercado)."
+    },
+    "threats": {
+      "type": "array",
+      "minItems": 4,
+      "maxItems": 6,
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "description",
+          "implication"
+        ],
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "Frase curta e específica descrevendo a ameaça."
+          },
+          "description": {
+            "type": "string",
+            "description": "Evidência de que essa ameaça é real."
+          },
+          "implication": {
+            "type": "string",
+            "description": "Como se proteger ou mitigar."
+          },
+          "probability": {
+            "type": "string",
+            "enum": [
+              "high",
+              "medium",
+              "low"
+            ],
+            "description": "Probabilidade de materialização."
+          },
+          "impact": {
+            "type": "string",
+            "enum": [
+              "high",
+              "medium",
+              "low"
+            ],
+            "description": "Impacto se materializar."
+          },
+          "source": {
+            "type": "string",
+            "enum": [
+              "diagnostico",
+              "briefing",
+              "operador",
+              "v4mos",
+              "market_trend"
+            ],
+            "description": "De onde veio a evidência."
+          }
+        }
+      },
+      "description": "Fatores externos negativos (ameaças de mercado)."
+    },
+    "strategic_synthesis": {
+      "type": "object",
+      "required": [
+        "leverage",
+        "protection",
+        "recommended_strategy"
+      ],
+      "properties": {
+        "leverage": {
+          "type": "string",
+          "description": "Parágrafo: como usar forças para capturar oportunidades (Forças x Oportunidades)."
+        },
+        "protection": {
+          "type": "string",
+          "description": "Parágrafo: quais fraquezas amplificam ameaças e como proteger (Fraquezas x Ameaças)."
+        },
+        "recommended_strategy": {
+          "type": "string",
+          "description": "Parágrafo: estratégia recomendada para os próximos 90 dias."
+        }
+      }
+    },
+    "priority_actions": {
+      "type": "array",
+      "minItems": 5,
+      "maxItems": 7,
+      "items": {
+        "type": "object",
+        "required": [
+          "action",
+          "swot_basis",
+          "impact",
+          "suggested_timeline"
+        ],
+        "properties": {
+          "action": {
+            "type": "string",
+            "description": "O que fazer (específico e acionável)."
+          },
+          "swot_basis": {
+            "type": "string",
+            "description": "Quais quadrantes/itens essa ação endereça (ex: 'Alavanca F2, captura O3, executa SO1')."
+          },
+          "impact": {
+            "type": "string",
+            "enum": [
+              "high",
+              "medium",
+              "low"
+            ],
+            "description": "Impacto esperado da ação."
+          },
+          "suggested_timeline": {
+            "type": "string",
+            "description": "Quando executar (semana 1/2/3 ou prazo específico)."
+          },
+          "dependencies": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Dependências desta ação."
+          },
+          "financial_impact": {
+            "type": "object",
+            "description": "Impacto financeiro projetado da ação. Aceita nomenclatura com ou sem sufixo '_brl'.",
+            "properties": {
+              "investment": {
+                "type": "number",
+                "description": "Investimento em R$ (mensal ou único). Alternativa: 'investment_brl'."
+              },
+              "investment_brl": {
+                "type": "number",
+                "description": "Alternativa a 'investment'."
+              },
+              "expected_return_90d": {
+                "type": "number",
+                "description": "Retorno esperado em 90 dias em R$. Alternativa: 'monthly_return_brl' (será multiplicado por 3)."
+              },
+              "monthly_return_brl": {
+                "type": "number",
+                "description": "Retorno mensal em R$. Se presente, retorno 90d = monthly × 3."
+              },
+              "payback_days": {
+                "type": "number",
+                "description": "Dias até o payback."
+              },
+              "roi_multiple": {
+                "type": "number",
+                "description": "Múltiplo de ROI (ex: 5.2 = 5.2x). Se ausente, calculado como retorno/investment."
+              },
+              "note": {
+                "type": "string",
+                "description": "Observação textual opcional."
+              }
+            }
+          },
+          "risk_adjusted_score": {
+            "description": "Score de priorização. Aceita dois formatos: número 0-100 OU objeto com dimensões avaliadas em escala 1-10. O renderer do portal ordena e exibe ambos.",
+            "oneOf": [
+              {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 100,
+                "description": "Score agregado 0-100."
+              },
+              {
+                "type": "object",
+                "required": [
+                  "score"
+                ],
+                "properties": {
+                  "impact": {
+                    "type": "number",
+                    "minimum": 1,
+                    "maximum": 10,
+                    "description": "Impacto esperado (1-10)."
+                  },
+                  "probability_of_success": {
+                    "type": "number",
+                    "minimum": 1,
+                    "maximum": 10,
+                    "description": "Probabilidade de sucesso (1-10)."
+                  },
+                  "reversibility": {
+                    "type": "number",
+                    "minimum": 1,
+                    "maximum": 10,
+                    "description": "Reversibilidade se der errado (1-10, maior = mais reversível)."
+                  },
+                  "score": {
+                    "type": "number",
+                    "description": "Score final agregado (1-10 ou 0-100)."
+                  }
+                }
+              }
+            ]
+          }
+        }
+      },
+      "description": "Ações prioritárias derivadas do cruzamento SWOT/TOWS, ordenadas por risk_adjusted_score."
+    },
+    "tows_matrix": {
+      "type": "object",
+      "description": "Matriz TOWS: cruzamento estratégico dos quadrantes SWOT para derivar estratégias acionáveis.",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Breve explicação do que é a matriz."
+        },
+        "so_strategies": {
+          "type": "array",
+          "description": "Estratégias Ofensivas (Forças × Oportunidades). Onde o cliente ataca.",
+          "items": {
+            "$ref": "#/definitions/towsStrategy"
+          }
+        },
+        "wo_strategies": {
+          "type": "array",
+          "description": "Estratégias de Reforço (Fraquezas × Oportunidades). Onde o cliente investe.",
+          "items": {
+            "$ref": "#/definitions/towsStrategy"
+          }
+        },
+        "st_strategies": {
+          "type": "array",
+          "description": "Estratégias Defensivas (Forças × Ameaças). Onde o cliente protege.",
+          "items": {
+            "$ref": "#/definitions/towsStrategy"
+          }
+        },
+        "wt_strategies": {
+          "type": "array",
+          "description": "Estratégias de Sobrevivência (Fraquezas × Ameaças). Onde o cliente minimiza dano.",
+          "items": {
+            "$ref": "#/definitions/towsStrategy"
+          }
+        }
+      }
+    },
+    "_deprecated_notes": {
+      "type": "string",
+      "description": "NÃO usar. Campos descontinuados que o renderer do portal ignora: 'scenarios', 'financial_summary_90d', 'risk_adjusted_ranking'. A projeção de cenários é feita em gt-diagnostico-midia-paga (budget_reallocation_scenarios); a consolidação financeira é redundante com priority_actions[].financial_impact."
+    },
+    "key_insight": {
+      "type": "object",
+      "description": "Ponto de alavancagem desta skill — o bloco que merece destaque visual para conversa com o stakeholder. Ver PADRAO-OUTPUT.md.",
+      "properties": {
+        "headline": {
+          "type": "string",
+          "description": "Frase-manchete do ponto (pode virar quote destacada no renderer)"
+        },
+        "context": {
+          "type": "string",
+          "description": "Contexto em 2-3 linhas explicando o cenário"
+        },
+        "numbered_reasons": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Razões numeradas (o renderer vira 3 cards numerados)"
+        },
+        "discussion_anchor": {
+          "type": "string",
+          "description": "Por que este é o ponto para stakeholder decidir/validar"
+        }
+      }
+    },
+    "honesty_alert": {
+      "type": "string",
+      "description": "Alerta se a análise revelou fragilidade real do cliente (não há diferencial claro, premissa contraditória, etc.). Nunca omitir se justificado."
+    }
+  },
+  "definitions": {
+    "towsStrategy": {
+      "type": "object",
+      "required": [
+        "id",
+        "strategy"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Identificador (ex: SO1, WT2)."
+        },
+        "strategy": {
+          "type": "string",
+          "description": "Ação específica de cruzamento."
+        },
+        "rationale": {
+          "type": "string",
+          "description": "Por que essa estratégia funciona (cita a força/fraqueza e a oportunidade/ameaça)."
+        },
+        "expected_outcome": {
+          "type": "string",
+          "description": "O que muda se executar (resultado tangível)."
+        }
+      }
+    }
+  }
+}

--- a/.agents/skills/geral-persona-icp/SKILL.md
+++ b/.agents/skills/geral-persona-icp/SKILL.md
@@ -1,0 +1,279 @@
+---
+name: geral-persona-icp
+description: "Cria o ICP (Ideal Customer Profile) e Persona do cliente usando framework JTBD. Skill raiz que alimenta toda a estratégia. Use quando o operador disser 'persona', 'ICP', 'cliente ideal', 'Jobs-to-be-Done', ou quando iniciar a semana 1."
+area: geral
+author: luizfreitasv4
+version: 1.0.0
+dependencies: []
+outputs: ["geral-persona-icp.json"]
+week: 1
+estimated_time: "45-60 min"
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta versao foi portada do sistema de Estruturacao Estrategica. As regras abaixo tem precedencia sobre caminhos e persistencia citados no fluxo original:
+
+- Trabalhe somente em `squads/{squad}/clientes/{cliente}/`, nunca em um diretorio `clientes/` solto na raiz.
+- Leia primeiro o `CLAUDE.md` ou `AGENTS.md` da KB, `mission-control/`, `calls/`, `docs/` e `campanhas/`.
+- Se `client.json` existir, use-o como fonte complementar. Se nao existir, derive o contexto da KB e do Mission Control; nao exija nem invente esse arquivo.
+- Salve entregaveis em `squads/{squad}/clientes/{cliente}/outputs/`, em JSON e Markdown quando o fluxo pedir ambos.
+- Registre decisoes e progresso no `mission-control/historico-checkins.md` ou no arquivo de historico equivalente encontrado na KB.
+- Resolva recursos empacotados a partir do proprio diretorio desta skill. Se uma integracao externa nao estiver configurada, declare o gap e continue apenas com os dados reais disponiveis.
+
+
+# Persona e ICP — Perfil do Cliente Ideal (POP 1.7)
+
+Você é um especialista em Jobs-to-be-Done e pesquisa de cliente. Vai construir, junto com o operador, o perfil do cliente ideal (ICP) e a persona que vai orientar TODA a comunicação, criativos e estratégia de mídia do cliente.
+
+> **Posição no fluxo:** Semana 1 — skill raiz, comum a todos os modelos de venda (e-commerce / inside-sales / pdv). É dependência de quase tudo que vem depois.
+> **IMPORTANCIA:** Este é o documento mais referenciado em todos os squads seguintes. Se o ICP estiver errado, tudo que vem depois estará errado. Invista tempo aqui.
+
+## Dados necessários
+
+Leia os seguintes arquivos do diretório do cliente:
+
+1. `client.json` (seção `briefing`) — dados base do cliente (OBRIGATORIO)
+2. `client.json` (seção `connectors`) — se existir, extraia `MarketingProfile` para pré-popular dados
+
+Extraia do briefing:
+- `identification.name` → nome do cliente
+- `identification.segment` → segmento/setor
+- `identification.region` → região de atuação
+- `product.main_product` → produto/serviço principal
+- `product.ticket` → ticket médio
+- `icp.best_customers` → descrição dos melhores clientes
+- `icp.not_customers` → quem NÃO é cliente (anti-persona)
+- `brand.voice_tone` → tom de voz desejado
+- `competition.competitors` → concorrentes (para diferenciação)
+
+Se `client.json` (seção `connectors`) existir e tiver `workspace.marketingProfile`, use esses dados como ponto de partida mas sempre valide com o operador.
+
+---
+
+## Geração
+
+Carregue todos os dados do `client.json` (seção `briefing`) e conectores.
+
+Se algum campo crítico estiver faltando (`identification.segment`, `product.main_product`, `icp.best_customers` com < 20 caracteres), apresente TUDO que já tem e pergunte APENAS o que falta, numa única interação. Não faça uma pergunta por vez. Se todos os campos críticos estão preenchidos, prossiga sem parar.
+
+Gere o output COMPLETO de uma vez — ICP, Persona, Canais, e Mensagens-chave. Consulte `references/jtbd-framework.md` para aplicar o framework corretamente. Consulte `references/exemplos-bom-vs-ruim.md` para calibrar especificidade.
+
+O output completo inclui:
+
+**A) ICP com Jobs-to-be-Done**
+
+#### Dados Demográficos
+- Se B2B: faturamento anual, setor, número de funcionários, cargo do decisor, localização
+- Se B2C: faixa etária, renda, localização, estado civil, escolaridade, profissão
+- Se misto: ambos os perfis separados
+
+#### Dados Comportamentais
+- Como toma decisão de compra (racional vs emocional, individual vs comitê)
+- Onde pesquisa antes de comprar (Google, Instagram, indicação, YouTube, etc.)
+- Principais objeções na hora da compra
+- O que o faz trocar de fornecedor
+- Frequência de compra e ciclo de decisão
+
+#### Jobs-to-be-Done (SEÇÃO MAIS IMPORTANTE)
+Aplique o framework JTBD rigorosamente:
+
+- **Job funcional:** O que a pessoa precisa FAZER. Não é "comprar [produto]" — é a tarefa que precisa ser cumprida. Use o formato: "Quando [situação], eu quero [motivação], para que [resultado esperado]."
+- **Job emocional:** Como a pessoa quer se SENTIR durante e após a compra. Segurança? Alívio? Orgulho? Confiança?
+- **Job social:** Como a pessoa quer ser VISTA pelos outros. Status? Competência? Cuidado? Modernidade?
+
+#### Dores (3-5 dores ESPECÍFICAS)
+- Ordene por intensidade (da mais dolorosa para a menos)
+- Cada dor deve ser algo que o cliente reconheceria imediatamente
+- Use linguagem do cliente, não jargão de marketing
+
+#### Ganhos Desejados (3-5 ganhos)
+- O que o cliente quer alcançar (não o que o produto oferece)
+- Tangíveis e intangíveis
+- Priorize os ganhos que mais se conectam com os Jobs
+
+**B) Persona**
+
+- **Nome fictício:** Escolha um nome comum para o perfil demográfico identificado
+- **Descrição da foto:** Descreva como seria a foto de perfil dessa pessoa. Seja específico: idade aparente, expressão, contexto (escritório, loja, casa), vestuário
+- **História:** 1 parágrafo (4-6 linhas) contando a situação atual desta pessoa, seus desafios, e por que ela precisa da solução. Use storytelling, não bullet points
+- **Frase-citação:** Uma frase que essa persona diria sobre o problema que o cliente resolve. Deve soar autêntica — como se fosse transcrita de uma entrevista real. Use linguagem coloquial
+
+**C) Onde Encontrar Este ICP**
+
+- **Canais digitais:** Canais ESPECÍFICOS (não genéricos como "redes sociais" — especifique: "grupos de Facebook de [tema]", "hashtags [x] no Instagram")
+- **Palavras-chave:** Termos que essa persona digitaria no Google/YouTube
+- **Influenciadores/referências:** Perfis, podcasts, canais que acompanha
+- **Comunidades:** Grupos, fóruns, associações de classe, eventos
+
+**D-pre1) Anti-Persona (OBRIGATÓRIO — 2-3 perfis)**
+
+A persona define quem você QUER atender. A anti-persona define quem você NÃO QUER atender — clientes que consomem recurso, geram atrito e não convertem. Sem anti-persona definida, a equipe não sabe quando dizer "não".
+
+Para cada anti-persona (2-3):
+- **profile_name** (ou **label**): apelido descritivo (ex: "Caçador de preço", "Emergência única")
+- **description** (ou **who**): 2-3 linhas sobre o comportamento típico
+- **signals** (ou **red_flags**): lista de 3-6 sinais concretos que o time observa na triagem (ex: "pede desconto antes do diagnóstico", "pergunta só preço por WhatsApp sem contexto")
+- **why_not**: por que não é cliente ideal (custo de atendimento, ticket baixo, alta rotatividade, objeção que não resolve)
+- **operational_rule**: regra prática — como o time identifica e o que faz (ex: "Se pedir desconto antes do diagnóstico, encaminhar para tabela padrão")
+
+> Use **profile_name/description/signals** como padrão. O renderer aceita os alternativos (label/who/red_flags) para compatibilidade, mas prefira o conjunto principal.
+
+Feche com um `operational_rule` geral — a regra-mãe que alinha o time.
+
+**D-pre2) Buyer Journey (OBRIGATÓRIO — 5-6 estágios)**
+
+Mapeie a jornada de decisão da persona do gatilho ao pós-compra. Cada estágio com:
+- **Stage:** nome (ex: Gatilho, Pesquisa, Consideração, Decisão, Pós-compra, Recompra)
+- **Trigger:** o que inicia esse estágio (evento externo, interno, emocional)
+- **Mental state:** estado mental dominante (dúvida, ansiedade, urgência, cobrança social)
+- **Primary channel:** onde a persona busca informação neste estágio
+- **Dominant question:** a pergunta que ela está tentando responder
+- **[Cliente] intervention:** como o cliente intervém nesse estágio (conteúdo, anúncio, contato)
+- **Friction today:** qual o atrito/problema atual nesse estágio
+- **Duration estimate:** quanto tempo típico (horas, dias, semanas)
+
+Feche com `critical_leakage_point`: onde o cliente mais perde leads HOJE. Pode ser:
+- **String livre** (preferido quando o vazamento é qualitativo): ex. `"O maior vazamento é na Consideração: a persona pesquisa 3-7 dias e a clínica não aparece no Google Maps local"`.
+- **Objeto estruturado** (use quando tiver número de perda): `{stage, evidence, estimated_loss_pct}`.
+
+**D-pre3) Willingness-to-Pay (OBRIGATÓRIO — por serviço principal)**
+
+Para cada serviço/produto principal (3-5), use o SHAPE PREFERIDO (mais rico que o legado):
+- **service**: nome do serviço
+- **current_ticket_range**: faixa de ticket atual praticada (ex: `"R$180-250"`)
+- **perceived_fair_range**: faixa que a persona percebe como justa (ex: `"R$180-300"`)
+- **premium_ceiling**: teto premium aceito COM justificativa (ex: `"R$400 com exame complementar incluso"`)
+- **elasticity**: palavra-chave + nuance separada por `—` (ex: `"baixa — aceita pagar mais se entender o porquê"`). O portal usa a palavra-chave como tag colorida e o texto após o travessão como nota.
+- **pricing_lever**: o que justifica cobrar mais (especialização, tempo de consulta, garantia, bundle)
+
+> Os campos legados (`current_price`, `fair_range`, `premium_range`) ainda funcionam, mas **prefira** o shape novo — ele comunica range (não ponto) e o teto com justificativa, que é o que a análise realmente pede.
+
+Isso não é exercício de pricing — é alinhar posicionamento e copy ao WTP real da persona.
+
+**D-pre4) Objection Library (OBRIGATÓRIO — 5-7 objeções)**
+
+Catálogo de objeções reais da persona. Para cada:
+- **Objection:** como ela diz (linguagem do cliente)
+- **Subtext:** o que ela REALMENTE está dizendo (medo, dúvida, experiência anterior)
+- **Bad response:** resposta automática que NÃO funciona e por quê
+- **Good response:** resposta que funciona — pequena história, dado, reframe
+- **When to use:** em que canal/momento essa resposta é usada
+
+Essa library alimenta copy, SDR, scripts de atendimento e FAQs.
+
+**E) 3 Opções de Mensagem-Chave**
+
+1. **Opção funcional:** Foco no resultado prático/tangível
+2. **Opção emocional:** Foco no sentimento/transformação
+3. **Opção social:** Foco em como o cliente será visto/percebido
+
+Para cada opção:
+- A mensagem em si (1 frase, máximo 15 palavras)
+- Por que essa abordagem funciona para este ICP
+- Em que contexto usar (anúncios, bio Instagram, headline do site, etc.)
+
+### Estrutura visual (obrigatória)
+
+Siga o padrão canônico de `references/padrao-output.md`. Além dos campos acima, SEMPRE inclua:
+
+- **`summary_headline`** (string, max 200 char) — manchete com o veredito do ICP/Persona. Específica, com dados reais.
+  - Ex: "Mariana (35-50, tutora de gatos premium) é o ICP. Ignorada pelos concorrentes que tratam cão e gato igual."
+
+- **`summary_highlights`** (4-6 itens) — KPIs visuais. Sugestões para persona-ICP:
+  - `posicao`: faixa etária/renda da persona, ticket médio atual vs premium ceiling
+  - `competicao`: nº de concorrentes que atendem o mesmo ICP declaradamente
+  - `janela`: tempo de decisão médio (buyer journey duration)
+  - `oportunidade`: dor mais aguda não endereçada, WTP gap (premium ceiling - current ticket)
+  - `risco`: objeção mais comum / leakage point mais crítico
+  - Cada item: `{category, label, value, subtext, tone}` (tons: `green|yellow|red|blue|gray`)
+
+- **`summary_key_findings`** (3-5 itens) — achados categorizados:
+  - `vantagem | contexto | ameaca | acao`
+  - Cubra pelo menos 3 dos 4 tipos.
+
+### Ponto de alavancagem
+
+Em persona-ICP, o ponto de alavancagem é a **combinação {persona principal + dor mais ignorada pelos concorrentes + frase-citação}** — o que o time precisa internalizar para mudar comunicação/atendimento. Estruture como:
+
+```json
+"key_insight": {
+  "headline": "Frase-manchete (ex: 'Mariana paga R$400 se entender o porquê — e ninguém explica')",
+  "context": "2-3 linhas explicando o insight",
+  "numbered_reasons": ["(1) razão A", "(2) razão B", "(3) razão C"],
+  "discussion_anchor": "Por que este é o ponto para o stakeholder decidir"
+}
+```
+
+Alternativamente, se o renderer da skill tiver um campo específico de destaque (ex: `critical_leakage_point` com objeto estruturado), use a mesma lógica de quote + razões.
+
+Se a pesquisa do ICP revelou fragilidade (persona mal definida, ICP contraditório com o produto, WTP incompatível), inclua `honesty_alert`.
+
+## Auto-validação
+
+Antes de mostrar ao operador, verifique:
+
+- [ ] Mencionou o cliente pelo nome?
+- [ ] Usou dados reais do client.json (não inventou)?
+- [ ] Nenhum item genérico (ex: "quer crescer", "qualidade e compromisso")?
+- [ ] Schema da skill validou?
+- [ ] Todos os campos do schema preenchidos (ou com `null` + `unavailable_reason` no pai)?
+- [ ] Nenhuma string vazia (`""`) — substituí por `null` + reason quando o dado não existe?
+- [ ] Estimativas marcadas com `estimated: true` ou `[E]`?
+- [ ] Consistente com outputs anteriores (se houver)?
+- [ ] Cada dor tem > 20 caracteres e usa linguagem do cliente (não jargão)?
+- [ ] Jobs-to-be-Done seguem formato "Quando [situação], eu quero [motivação], para que [resultado]"?
+- [ ] Nenhum item genérico — se trocar o nome do cliente e ainda servir, refaça?
+- [ ] Persona tem frase-citação que soa como fala real (não corporativês)?
+- [ ] Canais são específicos (não "redes sociais" nem "Google")?
+- [ ] Mensagens-chave têm <= 15 palavras cada?
+- [ ] Cada mensagem é diferente das outras (funcional vs emocional vs social)?
+- [ ] Anti-persona com 2-3 perfis e `operational_rule` clara para o time?
+- [ ] Buyer journey tem 5-6 estágios, cada um com trigger, mental_state, canal, pergunta dominante, intervenção e fricção atual?
+- [ ] `critical_leakage_point` identifica onde o cliente mais perde leads hoje COM evidência?
+- [ ] Willingness-to-pay cobre os serviços principais com preço atual, faixa justa, faixa premium, elasticidade e pricing_lever?
+- [ ] Objection library tem 5-7 objeções com subtext, bad_response e good_response (linguagem real, não corporativês)?
+- [ ] Tem `summary_headline` específico (não "persona definida")?
+- [ ] `summary_highlights` tem 4-6 itens com categorias e tons válidos?
+- [ ] `summary_key_findings` cobre pelo menos 3 dos 4 tipos (vantagem/contexto/ameaça/ação)?
+- [ ] Identificou `key_insight` para ancorar conversa com stakeholder?
+- [ ] Se há fragilidade, incluiu `honesty_alert`?
+
+Se falhou → regenere silenciosamente. Não avise o operador.
+
+## Apresentação e decisões
+
+Apresente o output COMPLETO ao operador de uma vez.
+
+**DECISÃO 1:** Mensagem-chave — qual direção?
+- Opção A: "[mensagem funcional]" — foco no resultado prático
+- Opção B: "[mensagem emocional]" — foco no sentimento
+- Opção C: "[mensagem social]" — foco na percepção
+
+**RECOMENDAÇÃO:** Opção [X]. [Justificativa baseada nos dados — ex: concorrentes já ocupam o território emocional, a funcional diferencia mais. Explique por que as outras são mais fracas.]
+
+**PROVOCAÇÃO:** [Pergunta contraintuitiva que força o operador a pensar — ex: "Se a persona ouvisse essas 3 frases num feed, qual faria ela parar o scroll? E o cliente tem coragem de bancar essa promessa?"]
+
+**DECISÃO 2:** Ajustes no ICP/Persona
+- O ICP faz sentido com o que você conhece deste cliente?
+- As dores são dolorosas de verdade? O cliente se reconheceria?
+- A persona parece real? Você consegue imaginar conversando com ela?
+- Os canais onde encontrá-la fazem sentido?
+- Algum canal ou comunidade que você sabe que esse público frequenta?
+
+Aguarde o operador responder. Ele pode:
+- Escolher uma mensagem e aprovar tudo
+- Pedir ajustes em seções específicas
+- Combinar elementos de mais de uma mensagem
+
+Incorpore todos os ajustes e gere a versão final.
+
+## Finalização
+
+Operador aprova (com ou sem ajustes).
+1. Salve em `squads/{squad}/clientes/{cliente}/outputs/geral-persona-icp.json` (com campo `summary` no topo)
+2. Atualize `client.json`: progress.skills → completed, version++, append em history[]
+3. Salve também uma versão Markdown do entregável na mesma pasta de outputs.
+4. Sugira próxima skill do dependency_graph
+   - "ICP e Persona salvos. Este output será usado por: account-auditoria-comunicacao, geral-pesquisa-mercado, geral-posicionamento-estrategico, e todas as skills de produção."
+   - Sugira a próxima skill da semana 1 (ex: gt-diagnostico-maturidade-digital ou account-auditoria-comunicacao)

--- a/.agents/skills/geral-persona-icp/references/exemplos-bom-vs-ruim.md
+++ b/.agents/skills/geral-persona-icp/references/exemplos-bom-vs-ruim.md
@@ -1,0 +1,213 @@
+# ICP e Persona: Exemplos Bom vs Ruim
+
+Este documento serve de calibracao para garantir que o ICP gerado seja especifico, concreto e util — nao generico e descartavel.
+
+---
+
+## Exemplo 1: Clinica de Estetica em Curitiba
+
+### RUIM (generico, descartavel)
+
+**ICP:**
+- Mulheres, 25-55 anos
+- Classe B/C
+- Se preocupam com aparencia
+- Querem ficar bonitas
+
+**Persona:** Maria, 35 anos, mulher vaidosa que gosta de se cuidar.
+
+**Jobs-to-be-Done:** "Quer ficar mais bonita e se sentir bem consigo mesma."
+
+**Problemas:**
+- Tudo e obvio — qualquer clinica poderia usar
+- "Mulheres 25-55" e metade da populacao feminina
+- O job e tao generico que serve para academia, salao, dermatologista
+- A persona nao e uma pessoa, e um estereotipo
+
+### BOM (especifico, acionavel)
+
+**ICP:**
+- Mulheres 32-48 anos, renda familiar acima de R$12k/mes
+- Moram em Curitiba ou regiao metropolitana (ate 30min de carro)
+- Profissionais ativas (advogadas, medicas, empresarias, gerentes)
+- Ja fizeram pelo menos 1 procedimento estetico na vida (nao sao novatas)
+- Gastam R$500-2000/mes com autocuidado (salao, academia, dermato)
+- Pesquisam no Instagram e Google antes, mas a decisao final vem de indicacao de amiga
+
+**Persona:** Fernanda, 41 anos, advogada tributarista. Trabalha 50h/semana. Percebeu sulcos nasogenianos e flacidez no pescoco depois dos 40. Ja fez botox e preenchimento, mas procura algo mais "natural" — tem medo de ficar com cara de "fez procedimento". Segue @dracarolinebittencourt e @renatavasconcellos no Instagram. Pesquisa "harmonizacao facial natural Curitiba" no Google. A ultima clinica que foi, o medico nem olhou direito pra ela — atendeu em 15 minutos e cobrou R$2.500.
+
+**Frase:** "Eu so quero parecer descansada. Nao quero que ninguem note que fiz algo — quero que perguntem se eu voltei de ferias."
+
+**Jobs-to-be-Done:**
+- Funcional: "Quando olho no espelho e vejo sinais de cansaco que nao saem com creme, quero um tratamento que me rejuvenesca de forma gradual e natural, para que eu continue parecendo eu mesma, so que melhor."
+- Emocional: "Quero me sentir confiante no tribunal e em reunioes sem pensar no que estao olhando no meu rosto."
+- Social: "Quero que as pessoas digam 'voce esta otima!' e nao 'voce fez algo?'."
+
+**Por que e bom:**
+- Faixa etaria restrita e justificada (pos-40 e o gatilho)
+- Renda especifica que valida o ticket
+- Comportamento de pesquisa mapeado com canais reais
+- A persona tem profissao, rotina, experiencia previa, e medo especifico
+- A frase-citacao soa como algo que alguem realmente diria
+- Os jobs sao impossveis de confundir com outro negocio
+
+---
+
+## Exemplo 2: SaaS de Gestao para Restaurantes
+
+### RUIM
+
+**ICP:**
+- Donos de restaurante
+- Querem organizar o negocio
+- Ticket: R$299/mes
+
+**Persona:** Joao, 45 anos, dono de restaurante que nao tem tempo.
+
+**Jobs:** "Quer ter mais controle do negocio."
+
+### BOM
+
+**ICP:**
+- Donos de restaurantes independentes (nao redes/franquias) com faturamento entre R$80k-R$400k/mes
+- 1-3 unidades, equipe de 8-30 funcionarios
+- Cidades com mais de 200k habitantes
+- Ja tentaram planilha mas nao conseguem manter atualizada
+- Pagam contador mas nao tem visao de DRE em tempo real
+- Principal canal de venda: iFood + balcao (hibrido)
+- Decisor: dono que tambem opera (cozinha ou salao)
+- Nao tem gerente financeiro — faz tudo ele mesmo ou com 1 auxiliar
+
+**Persona:** Toninho, 38 anos, dono do "Sabor & Arte" (restaurante contemporaneo em Campinas). Fatura R$180k/mes mas nao sabe quanto sobra. O iFood come 27% do faturamento mas responde por 45% dos pedidos. Tem 14 funcionarios e a folha de pagamento e seu maior custo. Usa uma planilha que o sobrinho fez no Google Sheets, mas so atualiza quando "da tempo" (nunca). O contador manda o DRE com 40 dias de atraso. Na semana passada, vendeu 30 pratos do dia que davam prejuizo por prato porque nao tinha ficha tecnica atualizada.
+
+**Frase:** "Eu trabalho 14 horas por dia e no final do mes nao sei se dei lucro ou prejuizo. So descubro quando o contador manda o balancete — ai ja era."
+
+**Jobs:**
+- Funcional: "Quando chego no restaurante as 7h e preciso decidir o que comprar e quanto produzir, quero ver os numeros de ontem e a projecao da semana em 2 minutos, para que eu nao compre demais nem falte insumo no sabado."
+- Emocional: "Quero a tranquilidade de saber que o restaurante esta saudavel financeiramente mesmo quando nao estou la."
+- Social: "Quero poder dizer pro meu socio e pra minha esposa exatamente quanto o negocio esta dando, com numeros, nao com achismo."
+
+**Por que e bom:**
+- Faturamento especifico que valida o ticket do SaaS
+- Perfil operacional detalhado (iFood, folha, sem gerente financeiro)
+- A persona tem um problema CONCRETO (vendeu prato com prejuizo)
+- O job funcional descreve o momento exato do dia em que o software e usado
+- A frase revela a dor real: trabalha muito e nao tem controle
+
+---
+
+## Exemplo 3: Escritorio de Advocacia Trabalhista
+
+### RUIM
+
+**ICP:**
+- Empresas que precisam de advogado trabalhista
+- PMEs
+- Preocupadas com processos
+
+**Persona:** Carlos, empresario que tem medo de processos trabalhistas.
+
+### BOM
+
+**ICP:**
+- Empresas com 20-150 funcionarios em regime CLT
+- Segmentos com alta rotatividade: varejo, alimentacao, logistica, call center
+- Faturamento entre R$2M-R$20M/ano
+- Ja sofreram pelo menos 1 processo trabalhista nos ultimos 2 anos
+- Nao tem departamento juridico interno — usam advogado sob demanda
+- Decisor: dono ou diretor administrativo/financeiro
+- Localizacao: Grande Sao Paulo (ate 40km do escritorio para reunioes presenciais)
+
+**Persona:** Dona Marcia, 52 anos, dona de uma rede de 3 lojas de roupas femininas no ABC Paulista. 47 funcionarios CLT, rotatividade media de 8 por ano. Ja perdeu R$180k em 2 processos trabalhistas nos ultimos 18 meses (horas extras nao registradas e assedio moral de gerente). Usa um advogado "do primo" que cobra barato mas nao faz preventivo. Vive com medo de ser surpreendida por uma nova notificacao. Tem uma gerente que ela sabe que "fala grosso" com funcionarios mas nao sabe como resolver sem demiti-la (e perder a melhor vendedora da rede).
+
+**Frase:** "Eu nao quero mais apagar incendio. Quero alguem que me diga o que eu tenho que mudar ANTES de virar processo."
+
+**Jobs:**
+- Funcional: "Quando recebo uma notificacao do Tribunal do Trabalho, quero ter um advogado que ja conheca minha empresa e responda em 48h, para que eu nao perca prazo nem pague multa."
+- Emocional: "Quero dormir tranquila sabendo que minha empresa esta protegida e que nao vou ser pega de surpresa."
+- Social: "Quero que meus funcionarios me vejam como uma empresa seria e organizada, nao como aquela que 'enrola' nos direitos."
+
+---
+
+## Exemplo 4: E-commerce de Suplementos
+
+### RUIM
+
+**ICP:**
+- Homens que treinam
+- 18-40 anos
+- Querem resultado rapido
+
+**Persona:** Pedro, 25 anos, treina todo dia e quer ficar grande.
+
+### BOM
+
+**ICP:**
+- Homens 26-38 anos, renda individual R$4k-R$10k/mes
+- Treinam musculacao 4-6x/semana ha mais de 2 anos (nao sao iniciantes)
+- Ja usam whey e creatina — buscam suplementacao mais avancada
+- Gastam R$200-R$600/mes em suplementos
+- Compram online (70% das compras) — preco e informacao sao decisivos
+- Leem rotulo e comparam composicao — nao compram so pela marca
+- Seguem canais de "evidencia cientifica" no YouTube (Leandro Twin, Paulo Muzy)
+- Decisao de compra: comparam 3-4 marcas no Google/Amazon, leem reviews, confiam em creators que mostram evidencia
+- Regiao: sudeste e sul (70% do faturamento)
+
+**Persona:** Gustavo, 31 anos, analista de dados em SP. Treina as 6h da manha antes do trabalho, 5x/semana, ha 4 anos. Ja passou pela fase de comprar o whey mais barato e percebeu que qualidade faz diferenca. Gasta R$400/mes em suplementos. Tem planilha de periodizacao e acompanha macros no MyFitnessPal. Na ultima Black Friday, comprou 3 potes de whey isolado por R$89/cada e ficou satisfeito. Pesquisa composicao no site antes de comprar. Desconfia de marcas que usam "blend proprietario" sem abrir a formula.
+
+**Frase:** "Eu nao compro suplemento por marketing — eu compro por rotulo. Me mostra a dosagem e a evidencia que eu decido."
+
+**Jobs:**
+- Funcional: "Quando estou montando meu proximo ciclo de suplementacao, quero comparar composicao e custo-beneficio entre marcas rapidamente, para que eu nao pague mais por menos produto efetivo."
+- Emocional: "Quero ter certeza de que estou colocando no corpo algo que funciona e e seguro, nao so marketing."
+- Social: "Quero ser o cara do grupo de treino que indica os melhores suplementos porque realmente entende."
+
+---
+
+## Exemplo 5: Curso Online de Confeitaria
+
+### RUIM
+
+**ICP:**
+- Mulheres que gostam de confeitaria
+- Querem aprender a fazer bolos
+- Iniciantes
+
+**Persona:** Ana, 30 anos, gosta de cozinhar e quer fazer bolos bonitos.
+
+### BOM
+
+**ICP:**
+- Mulheres 28-45 anos, maes que estao em casa (licenca, desemprego, ou escolheram sair do CLT)
+- Renda familiar R$4k-R$8k/mes — precisam complementar renda, nao e hobby
+- Ja fazem bolos para familia/amigos mas nunca venderam profissionalmente
+- Moram em cidades medias (50k-500k habitantes) onde encomenda de bolo e forte
+- Dispostas a investir R$200-R$500 num curso se tiver garantia de retorno
+- Pesquisam no Instagram (buscam perfis de confeiteiras) e YouTube (tutoriais gratis)
+- Gatilho de compra: alguem elogiou um bolo que fizeram e disse "voce devia vender"
+
+**Persona:** Renata, 34 anos, mae de 2 filhos (3 e 6 anos), mora em Londrina-PR. Saiu do emprego de auxiliar administrativa ha 1 ano quando nasceu o segundo filho. Faz bolos de aniversario para a familia desde sempre. Mes passado, fez o bolo do aniversario da filha da vizinha e recebeu R$150. Ficou animada mas nao sabe precificar, nao tem Instagram profissional, e tem medo de pegar encomenda e "dar errado". Gasta 2h por dia vendo Reels de confeitaria e pensa "eu consigo fazer isso". O marido apoia mas quer ver resultado — "se for pra gastar com curso, tem que se pagar".
+
+**Frase:** "Todo mundo fala que meu bolo e o melhor, mas eu nao sei cobrar. Tenho medo de montar o Instagram e ninguem encomendar."
+
+**Jobs:**
+- Funcional: "Quando recebo um pedido de bolo e nao sei quanto cobrar nem como organizar a producao, quero um metodo passo-a-passo que me ensine a precificar, produzir e entregar profissionalmente, para que eu consiga atender 8-10 encomendas por mes sem surtar."
+- Emocional: "Quero me sentir profissional e capaz de ter meu proprio negocio, nao so 'a mae que faz bolinho'."
+- Social: "Quero que meu marido e minha familia me vejam como alguem que tem um negocio de verdade, nao um hobby que gasta dinheiro."
+
+---
+
+## Checklist de qualidade
+
+Use este checklist para validar se o ICP e a persona estao no nivel BOM:
+
+| Criterio | Teste |
+|----------|-------|
+| Especificidade | Consigo distinguir este ICP de outro segmento? Se trocar o nome do negocio, o ICP ainda faz sentido? Se sim, esta generico |
+| Reconhecimento | Se eu mostrasse este ICP para o cliente, ele diria "e exatamente isso"? |
+| Acionabilidade | Consigo criar um anuncio no Meta Ads mirando este ICP? Se nao consigo segmentar, faltam dados |
+| Dores reais | As dores descritas causam desconforto de verdade? O cliente perderia sono por causa delas? |
+| Jobs especificos | Os jobs descrevem um MOMENTO (quando) + ACAO (quero) + RESULTADO (para que)? |
+| Persona viva | A persona tem nome, profissao, rotina, problema concreto, e frase autentica? Ou e um boneco generico? |
+| Canais concretos | Os canais listados sao especificos (nome de influencer, hashtag, grupo) ou genericos ("redes sociais")? |
+| Mensagem diferenciada | A mensagem-chave e diferente do que o concorrente diria? Se qualquer empresa do setor poderia usar, esta fraca |

--- a/.agents/skills/geral-persona-icp/references/jtbd-framework.md
+++ b/.agents/skills/geral-persona-icp/references/jtbd-framework.md
@@ -1,0 +1,118 @@
+# Framework Jobs-to-be-Done (JTBD)
+
+## O que e JTBD
+
+Jobs-to-be-Done e um framework de inovacao criado por Clayton Christensen (Harvard) que muda o foco de "quem e o cliente" para "qual tarefa o cliente esta tentando cumprir". A premissa: pessoas nao compram produtos -- elas contratam produtos para fazer um job.
+
+> "As pessoas nao querem uma furadeira de 1/4 de polegada. Elas querem um buraco de 1/4 de polegada." — Theodore Levitt
+
+Mas JTBD vai alem: elas nao querem o buraco. Querem pendurar a foto da familia na parede. E por que querem pendurar? Porque querem se sentir em casa. E querem que visitas vejam que sao uma familia unida.
+
+## Os 3 tipos de Jobs
+
+### 1. Job Funcional
+O que a pessoa precisa FAZER. E a tarefa pratica, objetiva.
+
+**Formato:** "Quando [situacao/gatilho], eu quero [motivacao/acao], para que [resultado esperado]."
+
+**Exemplos BONS:**
+- Clinica odontologica: "Quando sinto dor de dente que nao passa com remedio, quero encontrar um dentista confiavel rapido, para que resolva meu problema sem que eu precise faltar varios dias de trabalho."
+- Software de gestao: "Quando perco o controle do fluxo de caixa no final do mes, quero um sistema que me mostre entradas e saidas em tempo real, para que eu tome decisoes sem depender do contador."
+- Escola particular: "Quando meu filho esta na transicao para o ensino medio, quero uma escola que o prepare para o vestibular sem matar a criatividade, para que ele tenha opcoes de carreira."
+
+**Exemplos RUINS (genericos demais):**
+- "Quero crescer o negocio" — isso nao e um job, e uma aspiracao
+- "Quero um produto de qualidade" — obvio demais, todo mundo quer
+- "Quero economizar tempo" — em que? quando? fazendo o que?
+
+### 2. Job Emocional
+Como a pessoa quer se SENTIR durante e apos a experiencia.
+
+**Exemplos BONS:**
+- Clinica odontologica: "Quero me sentir seguro de que o profissional sabe o que esta fazendo e nao vai me causar mais dor do que o necessario."
+- Software de gestao: "Quero sentir que tenho controle do meu negocio, nao que o negocio me controla."
+- Escola particular: "Quero ter tranquilidade de que fiz a melhor escolha para o futuro do meu filho."
+
+**Exemplos RUINS:**
+- "Quero me sentir bem" — vago
+- "Quero ser feliz" — isso e tudo, nao e nada
+- "Quero ficar satisfeito com a compra" — obvio
+
+### 3. Job Social
+Como a pessoa quer ser VISTA pelos outros ao usar/consumir a solucao.
+
+**Exemplos BONS:**
+- Clinica odontologica: "Quero poder sorrir em fotos sem vergonha e parecer alguem que se cuida."
+- Software de gestao: "Quero parecer um gestor organizado e profissional quando investidores pedirem numeros."
+- Escola particular: "Quero que outros pais reconhecam que fiz uma boa escolha educacional."
+
+**Exemplos RUINS:**
+- "Quero parecer bem-sucedido" — generico
+- "Quero impressionar os amigos" — infantil e pouco util
+
+## Como identificar Jobs reais
+
+### Perguntas para descobrir o Job Funcional
+1. O que aconteceu ANTES de voce decidir procurar essa solucao?
+2. Qual foi o momento exato em que voce pensou "preciso resolver isso"?
+3. Quais alternativas voce tentou antes? Por que nao funcionaram?
+4. Se voce nao tivesse essa solucao, o que faria? (O substituto revela o job real)
+
+### Perguntas para descobrir o Job Emocional
+1. O que mais te incomoda nessa situacao?
+2. Como voce se sente quando o problema aparece?
+3. Quando o problema e resolvido, o que muda no seu dia?
+4. O que te faria dormir tranquilo em relacao a isso?
+
+### Perguntas para descobrir o Job Social
+1. Se alguem perguntasse por que voce escolheu essa solucao, o que diria?
+2. O que seus colegas/amigos/familia pensariam se soubessem?
+3. Existe algum "status" associado a usar/nao usar esse tipo de solucao?
+
+## Aplicacao no ICP V4
+
+Ao construir o ICP para um cliente V4, siga esta ordem:
+
+1. **Comece pelo Job Funcional** — identifique a tarefa que o cliente precisa cumprir
+2. **Mapeie as Dores** — o que impede de cumprir o job hoje?
+3. **Mapeie os Ganhos** — qual o resultado ideal quando o job e cumprido?
+4. **Identifique o Job Emocional** — como o cliente quer se sentir?
+5. **Identifique o Job Social** — como o cliente quer ser percebido?
+6. **Valide com dados** — os "melhores clientes" descritos no briefing se encaixam?
+
+### Armadilhas comuns
+
+| Armadilha | Exemplo | Correcao |
+|-----------|---------|----------|
+| Confundir job com feature | "Quer um app rapido" | "Quer resolver X sem perder tempo" |
+| Job generico demais | "Quer crescer" | "Quer dobrar o faturamento em 12 meses para abrir a segunda unidade" |
+| Projetar desejos do negocio no cliente | "Quer uma marca forte" | "Quer que clientes cheguem ja confiando, sem precisar convencer" |
+| Ignorar o contexto/gatilho | "Quer contratar marketing" | "Quando perdeu 30% das vendas para o concorrente que aparece no Google, decidiu investir em marketing" |
+| Job emocional superficial | "Quer se sentir bem" | "Quer a seguranca de que nao esta desperdicando dinheiro com marketing que nao funciona" |
+
+## Jobs-to-be-Done por segmento (exemplos V4)
+
+### E-commerce de Moda
+- **Funcional:** "Quando preciso renovar o guarda-roupa para a nova estacao, quero encontrar pecas que combinem com meu estilo sem gastar horas em shopping, para que eu esteja sempre bem-vestida sem estresse."
+- **Emocional:** "Quero me sentir estilosa e atual sem gastar uma fortuna."
+- **Social:** "Quero que as pessoas perguntem 'onde voce comprou isso?' quando me virem."
+
+### Clinica de Estetica
+- **Funcional:** "Quando percebo sinais de envelhecimento no espelho que me incomodam, quero um tratamento que de resultado visivel sem parecer artificial, para que eu me sinta como a versao mais jovem de mim mesma."
+- **Emocional:** "Quero recuperar a autoestima sem medo de ficar com aparencia de 'fez procedimento'."
+- **Social:** "Quero que as pessoas digam que estou bem, nao que 'fez algo no rosto'."
+
+### Escritorio de Contabilidade
+- **Funcional:** "Quando o fiscal da empresa fica desatualizado e tenho medo de multas, quero um contador que me avise ANTES dos problemas, nao depois, para que eu foque no negocio sem surpresas tributarias."
+- **Emocional:** "Quero ter certeza de que estou pagando o minimo possivel de imposto dentro da lei, sem risco."
+- **Social:** "Quero parecer um empresario organizado que tem as contas em dia quando um investidor pedir os numeros."
+
+### Escola de Idiomas
+- **Funcional:** "Quando percebo que estou perdendo oportunidades de carreira por nao falar ingles, quero aprender rapido o suficiente para participar de reunioes em 6 meses, sem atrapalhar minha rotina de trabalho."
+- **Emocional:** "Quero parar de sentir vergonha quando alguem fala ingles e eu nao consigo responder."
+- **Social:** "Quero ser visto como alguem qualificado internacionalmente no meu ambiente de trabalho."
+
+### Construtora / Imobiliaria
+- **Funcional:** "Quando decido que e hora de sair do aluguel, quero encontrar um imovel que caiba no meu orcamento sem burocracia que emperre o processo, para que eu mude em menos de 6 meses."
+- **Emocional:** "Quero a seguranca de que estou fazendo o maior investimento da minha vida com uma empresa seria."
+- **Social:** "Quero convidar familia e amigos para a casa nova e sentir orgulho de onde moro."

--- a/.agents/skills/geral-persona-icp/references/padrao-output.md
+++ b/.agents/skills/geral-persona-icp/references/padrao-output.md
@@ -1,0 +1,202 @@
+# Padrão de Output das Skills — V4 Estruturação IA
+
+Este documento define a **estrutura canônica** que todos os outputs de skill devem seguir para renderizar no portal com hierarquia visual consistente. O objetivo é que o operador e o stakeholder final abram qualquer entregável e encontrem o mesmo ritmo: manchete → KPIs → achados categorizados → ponto de alavancagem destacado → detalhes expansíveis.
+
+---
+
+## Princípios
+
+1. **Manchete antes de texto.** Toda skill abre com uma frase única e específica que resume a conclusão. Não é parágrafo, é headline.
+2. **Números em destaque, não escondidos no corpo do texto.** KPIs que importam viram cards. Texto corrido é para contexto, não para fato quantitativo.
+3. **Achados categorizados por intenção.** Cada insight é classificado como `vantagem | contexto | ameaca | acao` — o leitor identifica o tom antes de ler.
+4. **Ponto de alavancagem visualmente isolado.** Toda skill tem UM ponto onde a conversa com o stakeholder precisa acontecer. Esse ponto ganha hero visual (border, gradient, quote destacada).
+5. **Detalhe denso → colapsável.** Listas longas (concorrentes, itens de checklist, fontes) ficam em `<details>` para não afogar a leitura.
+
+---
+
+## Campos obrigatórios no JSON
+
+Todo output de skill DEVE ter estes campos no topo (antes dos campos específicos da skill):
+
+```json
+{
+  "client_name": "Nome do Cliente",
+  "summary": "Resumo em 1-2 frases. Específico, com dados reais. Alimenta o resumo executivo do portal.",
+
+  "summary_headline": "Manchete em 1 linha (max 120 caracteres). A frase que o stakeholder lê primeiro.",
+
+  "summary_highlights": [
+    {
+      "category": "posicao | competicao | janela | maturidade | oportunidade | risco",
+      "label": "Rótulo curto (max 30 char)",
+      "value": "Valor em destaque (número, %, status)",
+      "subtext": "Contexto em 1 linha (max 60 char)",
+      "tone": "green | yellow | red | blue | gray"
+    }
+  ],
+
+  "summary_key_findings": [
+    {
+      "category": "vantagem | contexto | ameaca | acao",
+      "text": "Achado em 1-2 linhas. Específico, acionável."
+    }
+  ]
+}
+```
+
+### Regras dos campos de summary
+
+**`summary_headline`**: É a ÚNICA frase que o stakeholder precisa ler se só tiver 5 segundos. Deve conter o veredito da skill. Exemplos bons:
+- ✓ "[Cliente] é o ÚNICO player premium da microrregião com [diferencial declarado] — janela competitiva de 12-18 meses."
+- ✗ "Análise de mercado concluída com sucesso."
+
+**`summary_highlights`** (4-6 itens): KPIs visuais. Categorias sugeridas:
+- `posicao` — onde o cliente está hoje vs potencial
+- `competicao` — quem disputa o mesmo espaço
+- `janela` — tempo/urgência
+- `maturidade` — estágio atual em algum eixo
+- `oportunidade` — tamanho do ganho possível
+- `risco` — tamanho da ameaça
+
+Agrupar de 2 em 2 por categoria no renderer (dá layout balanceado 3x2 ou 2x2).
+
+**`summary_key_findings`** (3-5 itens): Achados que embasam a manchete. Categorias:
+- `vantagem` (✓ verde) — o que o cliente tem a favor
+- `contexto` (i azul) — o que é fato do mercado, neutro
+- `ameaca` (! vermelho) — o que pode dar errado
+- `acao` (▸ laranja) — o que precisa ser feito
+
+---
+
+## Ponto de Alavancagem (hero block)
+
+Toda skill deve identificar **UM bloco que merece destaque visual especial** — o ponto onde a conversa estratégica precisa acontecer. O nome do campo varia por skill, mas a estrutura é consistente:
+
+```json
+{
+  "key_leverage_point": {
+    "headline": "Frase-manchete do ponto (pode ir como quote)",
+    "context": "Contexto em 2-3 linhas explicando o cenário",
+    "numbered_reasons": [
+      "Razão 1 (parse-friendly, pode começar com texto direto)",
+      "Razão 2",
+      "Razão 3"
+    ],
+    "discussion_anchor": "Frase curta sobre POR QUE este é o ponto de conversa com o stakeholder"
+  }
+}
+```
+
+Exemplos por skill:
+- `pesquisa-mercado` → `unexploited_opportunity` (whitespace estratégico)
+- `persona-icp` → persona principal + dor mais ignorada
+- `swot` → combinação força × oportunidade mais assimétrica
+- `posicionamento` → PUV vs alternativas descartadas
+- `diagnostico-midia` → canal mais subotimizado + upside estimado
+- `diagnostico-maturidade` → pilar mais fraco com maior impacto
+
+O renderer aplica:
+- Border verde 2px + gradient sutil
+- Selo "Whitespace Estratégico · Discussão com Stakeholder" no topo
+- Pill de viabilidade/urgência à direita
+- Quote/headline em card branco isolado
+- Razões numeradas em 3 círculos
+- Footer "💬 Momento de validar com a stakeholder"
+
+---
+
+## Alerta de honestidade
+
+Se a pesquisa/análise revelou fragilidade do cliente (não há diferencial real, ICP mal definido, mercado saturado, etc.), inclua:
+
+```json
+{
+  "honesty_alert": "Texto explicando a fragilidade encontrada e o que precisa ser feito antes de seguir."
+}
+```
+
+Esse campo renderiza em box amarelo/vermelho após os achados. **Nunca omita** se a realidade justifica. O valor do sistema depende de não vender aspiracional como real.
+
+---
+
+## Instrução para a IA da skill
+
+Em cada `SKILL.md`, incluir esta seção na geração:
+
+> ### Estrutura visual (obrigatória)
+>
+> Além dos campos específicos desta skill, gere SEMPRE:
+>
+> - `summary_headline` — manchete em 1 linha com o veredito
+> - `summary_highlights` — 4-6 KPIs categorizados (`posicao|competicao|janela|maturidade|oportunidade|risco`) com `{label, value, subtext, tone}`
+> - `summary_key_findings` — 3-5 achados categorizados (`vantagem|contexto|ameaca|acao`)
+> - `honesty_alert` se houver fragilidade
+>
+> Identifique o **ponto de alavancagem** desta skill (o bloco que merece hero visual) e estruture-o com headline + contexto + razões numeradas + discussion anchor.
+>
+> Consulte `references/padrao-output.md` para especificação completa.
+
+E na auto-validação:
+
+> - [ ] Tem `summary_headline` específico (não "análise concluída")?
+> - [ ] `summary_highlights` tem 4-6 itens com categorias válidas?
+> - [ ] `summary_key_findings` cobre pelo menos 3 dos 4 tipos (vantagem/contexto/ameaça/ação)?
+> - [ ] Identificou o ponto de alavancagem para discussão com stakeholder?
+> - [ ] Se há fragilidade, incluiu `honesty_alert`?
+
+---
+
+## Completude (regra crítica)
+
+**Todo campo definido no schema da skill é obrigatório no output.** Não omitir campos — o renderer assume que os campos do schema existem e quebra/fica vazio silenciosamente quando faltam.
+
+Se um dado **não pode ser obtido** (GA4 não instalado, conector não conectado, cliente não sabe, etc.), preencher com `null` E adicionar `unavailable_reason` no objeto pai:
+
+```json
+{
+  "current_conversion_rate": null,
+  "current_bounce_rate": null,
+  "avg_time_on_page": null,
+  "unavailable_reason": "GA4 não instalado no site — métricas de analytics não coletadas nesta auditoria"
+}
+```
+
+Para arrays vazios legitimamente (ex: nenhum competidor identificado), preencher com `[]` e adicionar uma nota no campo irmão `{campo}_note`:
+
+```json
+{
+  "competitors": [],
+  "competitors_note": "Nenhum concorrente direto identificado na microrregião após busca em Google Maps + Instagram."
+}
+```
+
+Para valores **estimados** (sem fonte pública), adicionar flag `[E]` no texto OU campo `estimated: true` no objeto:
+
+```json
+{ "tam_brl": 450000000, "estimated": true, "estimation_basis": "IBGE população × SEBRAE ticket médio" }
+```
+
+**Nunca** deixar string vazia (`""`), zero falso (`0` quando não é zero real), ou omitir o campo. Essas três formas são invisíveis para o renderer e geram o bug "coluna vazia".
+
+Valide o JSON contra o `schema.json` empacotado na skill e corrija campos ausentes ou `null` sem `unavailable_reason`.
+
+### Checklist adicional de auto-validação
+
+> - [ ] Todos os campos do schema estão presentes (preenchidos ou com `null` + `unavailable_reason`)?
+> - [ ] Nenhuma string vazia (`""`) — substituí por `null` + reason quando o dado não existe?
+> - [ ] Arrays vazios legítimos têm `{campo}_note` explicando por quê?
+> - [ ] Estimativas marcadas com `estimated: true` ou `[E]`?
+
+---
+
+## Tons de voz
+
+- `green` — oportunidade/vantagem/confirmado
+- `yellow` — atenção/potencial/médio
+- `red` — risco/ameaça/fraco
+- `blue` — contexto/informativo/neutro
+- `gray` — desativado/aspiracional/ausente
+
+Usar tons consistentemente: nunca pintar ameaça de verde ou vantagem de vermelho para "chamar atenção". O tom é semântico.
+
+---

--- a/.agents/skills/geral-persona-icp/schema.json
+++ b/.agents/skills/geral-persona-icp/schema.json
@@ -1,0 +1,664 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PersonaICP",
+  "description": "Output estruturado da skill persona-icp: ICP completo com JTBD, persona detalhada, canais de aquisição e mensagem-chave.",
+  "type": "object",
+  "required": [
+    "summary",
+    "icp",
+    "persona",
+    "where_to_find",
+    "key_message",
+    "client_name",
+    "summary_headline",
+    "summary_highlights",
+    "summary_key_findings"
+  ],
+  "properties": {
+    "client_name": {
+      "type": "string",
+      "description": "Nome do cliente — sempre presente em todo output."
+    },
+    "summary": {
+      "type": "string",
+      "description": "Resumo executivo de 2-3 frases do ICP e persona. Usado como referência rápida por outras skills."
+    },
+    "summary_headline": {
+      "type": "string",
+      "maxLength": 200,
+      "description": "Manchete em 1 linha com o veredito desta skill (hero do resumo executivo no portal). Ver references/padrao-output.md"
+    },
+    "summary_highlights": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 8,
+      "description": "KPIs visuais categorizados para o resumo executivo. Cada item: {category, label, value, subtext, tone}.",
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "label",
+          "value"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "posicao",
+              "competicao",
+              "janela",
+              "maturidade",
+              "oportunidade",
+              "risco"
+            ]
+          },
+          "label": {
+            "type": "string",
+            "maxLength": 40
+          },
+          "value": {
+            "type": "string"
+          },
+          "subtext": {
+            "type": "string",
+            "maxLength": 80
+          },
+          "tone": {
+            "type": "string",
+            "enum": [
+              "green",
+              "yellow",
+              "red",
+              "blue",
+              "gray"
+            ]
+          }
+        }
+      }
+    },
+    "summary_key_findings": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 6,
+      "description": "Achados categorizados por intenção (vantagem/contexto/ameaça/ação). Pelo menos 3 dos 4 tipos cobertos.",
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "text"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "vantagem",
+              "contexto",
+              "ameaca",
+              "acao"
+            ]
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "icp": {
+      "type": "object",
+      "required": [
+        "demographics",
+        "behavior",
+        "jobs",
+        "pains",
+        "gains"
+      ],
+      "properties": {
+        "demographics": {
+          "type": "object",
+          "description": "Perfil demográfico do cliente ideal.",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "B2B",
+                "B2C",
+                "mixed"
+              ],
+              "description": "Tipo de cliente: B2B, B2C, ou misto."
+            },
+            "age_range": {
+              "type": "string",
+              "description": "Faixa etária (B2C) ou faixa de faturamento (B2B)."
+            },
+            "income_or_revenue": {
+              "type": "string",
+              "description": "Renda mensal (B2C) ou faturamento anual (B2B)."
+            },
+            "location": {
+              "type": "string",
+              "description": "Região geográfica principal."
+            },
+            "company_size": {
+              "type": "string",
+              "description": "B2B: número de funcionários. B2C: omitir ou null."
+            },
+            "decision_maker_role": {
+              "type": "string",
+              "description": "B2B: cargo do decisor. B2C: perfil pessoal."
+            },
+            "education": {
+              "type": "string",
+              "description": "Nível de escolaridade típico."
+            },
+            "other": {
+              "type": "object",
+              "description": "Campos adicionais específicos do segmento.",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "behavior": {
+          "type": "object",
+          "description": "Como o ICP se comporta no processo de compra.",
+          "properties": {
+            "decision_process": {
+              "type": "string",
+              "description": "Como toma decisão de compra (racional/emocional, individual/comitê)."
+            },
+            "research_channels": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Onde pesquisa antes de comprar."
+            },
+            "main_objections": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Principais objeções na hora da compra."
+            },
+            "switching_triggers": {
+              "type": "string",
+              "description": "O que faz trocar de fornecedor."
+            },
+            "purchase_frequency": {
+              "type": "string",
+              "description": "Frequência de compra e ciclo de decisão."
+            }
+          }
+        },
+        "jobs": {
+          "type": "object",
+          "required": [
+            "functional",
+            "emotional",
+            "social"
+          ],
+          "description": "Jobs-to-be-Done: tarefas que o cliente está tentando cumprir.",
+          "properties": {
+            "functional": {
+              "type": "string",
+              "description": "Job funcional no formato: 'Quando [situação], eu quero [motivação], para que [resultado]'."
+            },
+            "emotional": {
+              "type": "string",
+              "description": "Job emocional: como o cliente quer se sentir durante e após a compra."
+            },
+            "social": {
+              "type": "string",
+              "description": "Job social: como o cliente quer ser visto pelos outros."
+            }
+          }
+        },
+        "pains": {
+          "type": "array",
+          "minItems": 3,
+          "maxItems": 5,
+          "items": {
+            "type": "object",
+            "required": [
+              "pain",
+              "intensity"
+            ],
+            "properties": {
+              "pain": {
+                "type": "string",
+                "description": "Descrição da dor na linguagem do cliente."
+              },
+              "intensity": {
+                "type": "string",
+                "enum": [
+                  "critical",
+                  "high",
+                  "medium"
+                ],
+                "description": "Intensidade da dor."
+              },
+              "current_workaround": {
+                "type": "string",
+                "description": "Como o cliente lida com essa dor hoje (se aplicável)."
+              }
+            }
+          },
+          "description": "Dores do ICP, ordenadas da mais intensa para a menos."
+        },
+        "gains": {
+          "type": "array",
+          "minItems": 3,
+          "maxItems": 5,
+          "items": {
+            "type": "object",
+            "required": [
+              "gain",
+              "type"
+            ],
+            "properties": {
+              "gain": {
+                "type": "string",
+                "description": "Ganho desejado pelo cliente."
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "tangible",
+                  "intangible"
+                ],
+                "description": "Se o ganho é tangível (mensurável) ou intangível (sentimento/percepção)."
+              }
+            }
+          },
+          "description": "Ganhos que o ICP deseja alcançar."
+        }
+      }
+    },
+    "persona": {
+      "type": "object",
+      "required": [
+        "name",
+        "photo_description",
+        "story",
+        "quote"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Nome fictício da persona."
+        },
+        "photo_description": {
+          "type": "string",
+          "description": "Descrição detalhada para gerar foto da persona (idade, expressão, contexto, vestuário)."
+        },
+        "story": {
+          "type": "string",
+          "description": "História de 1 parágrafo: situação atual, desafios, e por que precisa da solução."
+        },
+        "quote": {
+          "type": "string",
+          "description": "Frase que a persona diria sobre o problema. Deve soar como transcrição real."
+        }
+      }
+    },
+    "where_to_find": {
+      "type": "object",
+      "required": [
+        "digital_channels",
+        "keywords",
+        "influencers",
+        "communities"
+      ],
+      "properties": {
+        "digital_channels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Canais digitais específicos onde o ICP está (não genéricos)."
+        },
+        "keywords": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Palavras-chave que o ICP busca no Google/YouTube."
+        },
+        "influencers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Perfis, podcasts, canais que o ICP acompanha."
+        },
+        "communities": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Grupos, fóruns, associações, eventos que o ICP frequenta."
+        }
+      }
+    },
+    "anti_persona": {
+      "type": "object",
+      "description": "Perfis que NÃO são cliente ideal. Define quando o time diz 'não'.",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "profiles": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 4,
+          "items": {
+            "type": "object",
+            "description": "Cada perfil tem um identificador (profile_name OU label), uma descrição (description OU who) e uma lista de sinais (signals OU red_flags). O renderer do portal aceita ambos os conjuntos.",
+            "properties": {
+              "profile_name": {
+                "type": "string",
+                "description": "Apelido descritivo (ex: 'Caçador de preço'). Alternativa: 'label'."
+              },
+              "label": {
+                "type": "string",
+                "description": "Alternativa a 'profile_name'."
+              },
+              "description": {
+                "type": "string",
+                "description": "Comportamento típico em 2-3 linhas. Alternativa: 'who'."
+              },
+              "who": {
+                "type": "string",
+                "description": "Alternativa a 'description'."
+              },
+              "why_not": {
+                "type": "string",
+                "description": "Por que não é cliente ideal."
+              },
+              "signals": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Sinais concretos que o time usa para identificar esse perfil (3-6 itens). Alternativa: 'red_flags'."
+              },
+              "red_flags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Alternativa a 'signals'."
+              },
+              "operational_rule": {
+                "type": "string",
+                "description": "Como o time identifica e o que faz."
+              }
+            }
+          }
+        },
+        "operational_rule": {
+          "type": "string",
+          "description": "Regra-mãe que alinha o time."
+        }
+      }
+    },
+    "buyer_journey": {
+      "type": "object",
+      "description": "Jornada de decisão da persona do gatilho ao pós-compra.",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "stages": {
+          "type": "array",
+          "minItems": 4,
+          "maxItems": 7,
+          "items": {
+            "type": "object",
+            "required": [
+              "stage",
+              "mental_state",
+              "dominant_question"
+            ],
+            "properties": {
+              "stage": {
+                "type": "string"
+              },
+              "trigger": {
+                "type": "string",
+                "description": "O que inicia esse estágio."
+              },
+              "mental_state": {
+                "type": "string",
+                "description": "Estado mental dominante."
+              },
+              "primary_channel": {
+                "type": "string",
+                "description": "Onde a persona busca informação."
+              },
+              "dominant_question": {
+                "type": "string",
+                "description": "A pergunta que ela tenta responder."
+              },
+              "client_intervention": {
+                "type": "string",
+                "description": "Como o cliente intervém nesse estágio."
+              },
+              "friction_today": {
+                "type": "string",
+                "description": "Atrito/problema atual nesse estágio."
+              },
+              "duration_estimate": {
+                "type": "string",
+                "description": "Tempo típico (horas/dias/semanas)."
+              }
+            }
+          }
+        },
+        "critical_leakage_point": {
+          "description": "Estágio onde o cliente mais perde leads hoje. Aceita duas formas: (a) string livre com diagnóstico textual, ou (b) objeto estruturado com stage/evidence/estimated_loss_pct. A string é mais natural quando o vazamento é qualitativo; o objeto quando há número de perda.",
+          "oneOf": [
+            {
+              "type": "string",
+              "description": "Diagnóstico livre do ponto de vazamento (1-3 frases)."
+            },
+            {
+              "type": "object",
+              "properties": {
+                "stage": {
+                  "type": "string"
+                },
+                "evidence": {
+                  "type": "string"
+                },
+                "estimated_loss_pct": {
+                  "type": "number"
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "willingness_to_pay": {
+      "type": "object",
+      "description": "Faixas de preço que a persona aceita por serviço/produto principal.",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "services": {
+          "type": "array",
+          "description": "Cada serviço tem faixa atual, faixa justa percebida e teto premium. Shape preferido: 'current_ticket_range' + 'perceived_fair_range' + 'premium_ceiling' (strings como 'R$180-250' ou 'R$400'). O shape legado (current_price/fair_range/premium_range) ainda é aceito pelo renderer.",
+          "items": {
+            "type": "object",
+            "required": [
+              "service"
+            ],
+            "properties": {
+              "service": {
+                "type": "string",
+                "description": "Nome do serviço precificado."
+              },
+              "current_ticket_range": {
+                "type": "string",
+                "description": "PREFERIDO. Faixa de ticket atual praticada (ex: 'R$180-250')."
+              },
+              "perceived_fair_range": {
+                "type": "string",
+                "description": "PREFERIDO. Faixa que a persona percebe como justa (ex: 'R$180-300')."
+              },
+              "premium_ceiling": {
+                "type": "string",
+                "description": "PREFERIDO. Teto premium que a persona aceita pagar com justificativa (ex: 'R$400 com exame incluso')."
+              },
+              "current_price": {
+                "type": [
+                  "number",
+                  "string"
+                ],
+                "description": "LEGADO. Alternativa a current_ticket_range."
+              },
+              "fair_range": {
+                "type": "string",
+                "description": "LEGADO. Alternativa a perceived_fair_range."
+              },
+              "premium_range": {
+                "type": "string",
+                "description": "LEGADO. Alternativa a premium_ceiling."
+              },
+              "elasticity": {
+                "type": "string",
+                "description": "Elasticidade de preço. Pode ser palavra única (alta/média/baixa) ou frase com nuance separada por '—' ou ':' (ex: 'baixa — aceita pagar mais se entender o porquê'). O portal usa a primeira palavra como tag e o restante como nota explicativa."
+              },
+              "pricing_lever": {
+                "type": "string",
+                "description": "O que justifica cobrar mais (especialização, garantia, bundle, experiência)."
+              }
+            }
+          }
+        }
+      }
+    },
+    "objection_library": {
+      "type": "object",
+      "description": "Catálogo de objeções reais da persona com respostas testadas.",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "objections": {
+          "type": "array",
+          "minItems": 4,
+          "maxItems": 8,
+          "items": {
+            "type": "object",
+            "required": [
+              "objection",
+              "subtext",
+              "good_response"
+            ],
+            "properties": {
+              "objection": {
+                "type": "string",
+                "description": "Como ela diz, na linguagem do cliente."
+              },
+              "subtext": {
+                "type": "string",
+                "description": "O que ela realmente está dizendo."
+              },
+              "bad_response": {
+                "type": "string",
+                "description": "Resposta automática que NÃO funciona."
+              },
+              "good_response": {
+                "type": "string",
+                "description": "Resposta que funciona."
+              },
+              "when_to_use": {
+                "type": "string",
+                "description": "Canal/momento de uso."
+              }
+            }
+          }
+        }
+      }
+    },
+    "key_message": {
+      "type": "object",
+      "required": [
+        "chosen_message",
+        "approach",
+        "alternatives"
+      ],
+      "properties": {
+        "chosen_message": {
+          "type": "string",
+          "description": "Mensagem-chave final aprovada pelo operador (máx 15 palavras)."
+        },
+        "approach": {
+          "type": "string",
+          "enum": [
+            "functional",
+            "emotional",
+            "social",
+            "combined"
+          ],
+          "description": "Abordagem da mensagem escolhida."
+        },
+        "usage_context": {
+          "type": "string",
+          "description": "Onde usar esta mensagem (anúncios, bio, headline, etc.)."
+        },
+        "alternatives": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "message": {
+                "type": "string"
+              },
+              "approach": {
+                "type": "string"
+              },
+              "rationale": {
+                "type": "string"
+              }
+            }
+          },
+          "description": "As 3 opções apresentadas ao operador (incluindo a escolhida)."
+        }
+      }
+    },
+    "key_insight": {
+      "type": "object",
+      "description": "Ponto de alavancagem desta skill — o bloco que merece destaque visual para conversa com o stakeholder. Ver PADRAO-OUTPUT.md.",
+      "properties": {
+        "headline": {
+          "type": "string",
+          "description": "Frase-manchete do ponto (pode virar quote destacada no renderer)"
+        },
+        "context": {
+          "type": "string",
+          "description": "Contexto em 2-3 linhas explicando o cenário"
+        },
+        "numbered_reasons": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Razões numeradas (o renderer vira 3 cards numerados)"
+        },
+        "discussion_anchor": {
+          "type": "string",
+          "description": "Por que este é o ponto para stakeholder decidir/validar"
+        }
+      }
+    },
+    "honesty_alert": {
+      "type": "string",
+      "description": "Alerta se a análise revelou fragilidade real do cliente (não há diferencial claro, premissa contraditória, etc.). Nunca omitir se justificado."
+    }
+  }
+}

--- a/.agents/skills/geral-pesquisa-mercado/SKILL.md
+++ b/.agents/skills/geral-pesquisa-mercado/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: geral-pesquisa-mercado
+description: "Pesquisa de mercado completa: TAM/SAM/SOM, analise de concorrentes, tendencias, JTBD e diferenciais reais. Use quando o operador disser /geral-pesquisa-mercado ou 'pesquisa de mercado' ou 'analise de concorrentes' ou 'sizing de mercado'."
+area: geral
+author: luizfreitasv4
+version: 1.0.0
+dependencies:
+  - geral-persona-icp
+tools:
+  - WebSearch
+week: 1
+estimated_time: "3h"
+output_file: "geral-pesquisa-mercado.json"
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta versao foi portada do sistema de Estruturacao Estrategica. As regras abaixo tem precedencia sobre caminhos e persistencia citados no fluxo original:
+
+- Trabalhe somente em `squads/{squad}/clientes/{cliente}/`, nunca em um diretorio `clientes/` solto na raiz.
+- Leia primeiro o `CLAUDE.md` ou `AGENTS.md` da KB, `mission-control/`, `calls/`, `docs/` e `campanhas/`.
+- Se `client.json` existir, use-o como fonte complementar. Se nao existir, derive o contexto da KB e do Mission Control; nao exija nem invente esse arquivo.
+- Salve entregaveis em `squads/{squad}/clientes/{cliente}/outputs/`, em JSON e Markdown quando o fluxo pedir ambos.
+- Registre decisoes e progresso no `mission-control/historico-checkins.md` ou no arquivo de historico equivalente encontrado na KB.
+- Resolva recursos empacotados a partir do proprio diretorio desta skill. Se uma integracao externa nao estiver configurada, declare o gap e continue apenas com os dados reais disponiveis.
+
+
+# Pesquisa de Mercado (POP 1.9)
+
+Voce e um analista de mercado especializado em PMEs brasileiras. Vai conduzir uma pesquisa de mercado completa para embasar o posicionamento estrategico do cliente. Esta pesquisa e a base factual que valida (ou invalida) todo o posicionamento que sera definido na skill seguinte.
+
+> **Posição no fluxo:** Semana 1 (POP 1.9) — comum a todos os modelos. Divisão de trabalho com a `geral-analise-swot`: o **scorecard digital 0-10** dos concorrentes é gerado lá (POP 1.5); aqui o foco é **TAM/SAM/SOM + market share + posicionamento competitivo profundo + tendências**. Não duplique o scorecard; aprofunde o sizing e a leitura estratégica.
+
+## Dados necessários
+
+1. Leia `client.json` (seção `briefing`) do cliente — extraia: NOME_CLIENTE, SEGMENTO, REGIAO, PRODUTO_SERVICO, CONCORRENTES
+2. Leia `outputs/geral-persona-icp.json` — extraia: RESUMO_ICP, dores principais, Jobs-to-be-Done
+3. Se houver `client.json` (seção `connectors`), verifique se ha dados de mercado ja coletados
+
+Se faltar a lista de concorrentes no briefing, pergunte ao operador:
+
+> Preciso de 3 a 5 concorrentes diretos de {NOME_CLIENTE}. Podem ser empresas da mesma regiao ou concorrentes online. Quem sao?
+
+Se o operador nao souber, use WebSearch para identificar os principais players do segmento na regiao e sugira uma lista para validacao.
+
+---
+
+## Geração
+
+Gere o output COMPLETO de uma vez usando os dados de `client.json` (briefing, connectors) e outputs de skills dependentes em `outputs/`.
+
+Use WebSearch extensivamente para pesquisar dados reais.
+
+### TAM/SAM/SOM com fontes
+
+Consulte o framework em `references/framework-tam-sam-som.md` para a metodologia completa. Busque dados reais de mercado: relatórios SEBRAE, IBGE, ABComm, Statista, etc.
+
+Para cada nível (TAM, SAM, SOM):
+- Valor em R$ (anual)
+- Descrição
+- Fonte com link
+- Premissas (para SOM)
+
+Valores marcados com [E] sao estimativas. Demais tem fonte publica.
+
+**⚠️ Regras criticas para o SOM — leia antes de calcular:**
+
+1. **SOM NAO e a meta do cliente.** Meta comercial (do briefing, V4MOS, kickoff) e aspiracao operacional separada. Registrar como campo proprio (`market_share.client_annual_revenue_goal_brl` + `client_annual_revenue_goal_source`), nao incorporar no SOM. Se o SOM ficar igual a meta, voce provavelmente derivou o errado — refaca.
+
+2. **SOM NAO e capacidade operacional.** Se a empresa so tem X vets / Y atendentes e o SOM calculado pelo mercado e maior que a capacidade atual, isso e restricao INTERNA, nao de mercado. Registre como `tam_sam_som.som.operational_ceiling_note`. O SOM continua sendo o teto de mercado, nao de capacidade.
+
+3. **Triangulacao obrigatoria.** Nao calcule SOM por 1 metodo so. Use 3 metodos independentes (ver framework). Se convergirem, use a media; se divergirem, investigue.
+
+4. **Se o SAM tem perfis heterogeneos (premium/medio/ocasional), adicione camada de Mercado Enderecavel.** Preencha `market_share.enderecavel_value_brl` + `enderecavel_composition` + `enderecavel_note` — explica ao cliente por que o SOM nao e o SAM inteiro (decisao estrategica de perfil) separado da dinamica competitiva.
+
+5. **Meta da cliente pode vir de MAIS de uma fonte.** Se o formulario V4MOS tem "Meta 12M = R$ 1,32M" e o kickoff tem "R$ 90k/mes = R$ 1,08M", registre AMBAS com fonte documentada. Nao escolha uma arbitrariamente.
+
+6. **Remova cenarios/horizontes temporais do SOM.** SOM de mercado e o teto tangivel — sem "3 anos", sem "agressivo". Se precisar de horizonte, use no plano de execucao (forecast), nao no SOM.
+
+### Analise de concorrentes
+
+Para CADA concorrente da lista, faca análise profunda. Use WebSearch para visitar sites, redes sociais, e Meta Ads Library. Consulte `references/template-analise-concorrente.md`.
+
+Para cada concorrente:
+- Posicionamento (PUV, mensagem principal)
+- Canais de aquisicao
+- Pontos fortes e fracos
+- Estimativa de preco/ticket
+- Presenca digital (score 1-10: site, Instagram, Google, anúncios)
+
+Gere o Mapa Competitivo 2x2 (posicionando todos os concorrentes e sugerindo posição para o cliente).
+
+### Tendencias, JTBD e diferenciais reais
+
+Use WebSearch para pesquisar tendencias recentes do setor:
+- Tendencias em crescimento (3, com evidencia)
+- Ameacas para os proximos 12 meses (2, com impacto)
+- Oportunidade nao explorada pelos concorrentes
+
+Jobs-to-be-Done do mercado:
+- Solucao principal (como a maioria resolve)
+- Alternativas diretas e indiretas
+- Custo de inacao
+
+Diferenciais competitivos reais:
+- O que o cliente TEM hoje (com justificativa para o ICP)
+- O que PODERIA ter (com ação necessária)
+- ALERTA DE HONESTIDADE: se nao ha diferencial claro, diga aqui
+
+### Estrutura visual (obrigatória)
+
+Siga o padrão canônico de `references/padrao-output.md`. Além dos campos específicos acima, SEMPRE inclua:
+
+- **`summary_headline`** (string, max 160 char) — manchete em 1 linha com o veredito da pesquisa. Específica, com dados reais.
+  - Ex: "[Cliente] é o ÚNICO player da microrregião com [especialização declarada] — janela de 12-18 meses."
+
+- **`summary_highlights`** (4-6 itens) — KPIs visuais. Cada item:
+  - `category`: `posicao | competicao | janela | oportunidade | risco`
+  - `label` (max 30 char), `value` (destaque curto), `subtext` (contexto max 60 char), `tone` (`green|yellow|red|blue|gray`)
+  - Sugestão para pesquisa de mercado: fatia atual do SAM, meta SOM, nº de concorrentes diretos, janela estratégica, crescimento do segmento, preço médio vs cliente.
+
+- **`summary_key_findings`** (3-5 itens) — achados categorizados:
+  - `category`: `vantagem | contexto | ameaca | acao`
+  - `text`: 1-2 linhas, acionável
+  - Cubra pelo menos 3 dos 4 tipos.
+
+- **`market_share`** (objeto) — se o cliente tem faturamento conhecido, compare com SAM/SOM:
+  - **Obrigatorios:** `current_revenue_brl`, `current_share_of_sam_pct`, `target_share_of_sam_pct` (= SOM/SAM), `gap_to_som_brl`, `gap_to_som_pct`, `commentary`
+  - **Meta do cliente (se houver):** `client_annual_revenue_goal_brl` + `client_annual_revenue_goal_source` (ex: "Formulario V4MOS — campo 'Meta 12M'") + `client_goal_vs_som_note` (narrativa distinguindo meta de SOM). Se houver MAIS de uma meta em fontes diferentes (V4MOS vs kickoff), documente as duas na `client_goal_vs_som_note`.
+  - **Camada enderecavel (se SAM tem perfis heterogeneos):** `enderecavel_value_brl` + `enderecavel_composition` (como chegou no numero) + `enderecavel_note` (explicacao pedagogica da camada — o renderer do portal exibe esse texto abaixo do grafico Market Share).
+
+### Ponto de alavancagem
+
+Em pesquisa de mercado, o ponto de alavancagem é **`unexploited_opportunity`**. Estruture para render hero:
+- `description`: inclua a frase-território entre aspas simples ou duplas (o renderer extrai como quote destacada). Ex: "Ocupar o território 'O único especialista em [nicho] de [região]' — ..."
+- `why_nobody_does_it`: use padrão `(1) razão A. (2) razão B. (3) razão C.` — o renderer parseia os números e vira cards numerados.
+- `feasibility`: `alta | media | baixa`.
+
+## Auto-validação
+
+Antes de mostrar ao operador, verifique:
+
+- [ ] Mencionou o cliente pelo nome?
+- [ ] Usou dados reais do client.json (não inventou)?
+- [ ] Nenhum item genérico (ex: "quer crescer", "qualidade e compromisso")?
+- [ ] Schema da skill validou?
+- [ ] Todos os campos do schema preenchidos (ou com `null` + `unavailable_reason` no pai)?
+- [ ] Nenhuma string vazia (`""`) — substituí por `null` + reason quando o dado não existe?
+- [ ] Estimativas marcadas com `estimated: true` ou `[E]`?
+- [ ] Consistente com outputs anteriores (ICP, posicionamento)?
+- [ ] TAM/SAM/SOM tem fontes citadas (não apenas estimativas)?
+- [ ] **SOM foi triangulado por 3 métodos independentes** (capacidade, market share top-down, segmento premium) e os números convergem?
+- [ ] **SOM NÃO foi derivado da meta comercial da cliente** (V4MOS, briefing ou kickoff)? Se meta da cliente e SOM ficaram iguais, refez?
+- [ ] **SOM NÃO foi limitado pela capacidade operacional?** Se a empresa tem capacidade inferior ao SOM, registrou `operational_ceiling_note` separadamente em vez de reduzir o SOM?
+- [ ] **Meta da cliente registrada com fonte documentada** (`client_annual_revenue_goal_source`)? Se há 2 metas em fontes diferentes (V4MOS + kickoff), registrou as duas na `client_goal_vs_som_note`?
+- [ ] **Se SAM tem perfis heterogeneos, adicionou camada enderecavel** (`enderecavel_value_brl` + `enderecavel_composition` + `enderecavel_note`)?
+- [ ] **Removeu cenários ("agressivo") e horizontes temporais ("3 anos") do SOM**? SOM e teto de mercado, nao forecast.
+- [ ] Análise de concorrentes é baseada em pesquisa real (não suposições)?
+- [ ] Diferenciais são honestos (não aspiracionais vendidos como reais)?
+- [ ] Tem `summary_headline` específico (não "pesquisa concluída")?
+- [ ] `summary_highlights` tem 4-6 itens com categorias válidas e tons consistentes?
+- [ ] `summary_key_findings` cobre pelo menos 3 dos 4 tipos (vantagem/contexto/ameaça/ação)?
+- [ ] `unexploited_opportunity.description` tem frase-território entre aspas?
+- [ ] `unexploited_opportunity.why_nobody_does_it` está no formato `(1) ... (2) ... (3) ...`?
+- [ ] Se há fragilidade, incluiu `honesty_alert`?
+
+Se falhou → regenere silenciosamente. Não avise o operador.
+
+## Apresentação e decisões
+
+Apresente o output COMPLETO ao operador.
+
+Revise o output. O que está errado, exagerado ou faltando?
+
+- "Os numeros de sizing fazem sentido para a realidade do cliente? O SOM parece realista ou otimista demais?"
+- "A analise de concorrentes esta precisa? Alguma informacao que voce sabe e que esta diferente?"
+- "Onde {NOME_CLIENTE} deveria se posicionar no mapa competitivo?"
+- "Os diferenciais listados sao reais ou algum e mais aspiracional do que factual?"
+- "Alguma tendencia que voce ja percebeu no dia a dia e que nao apareceu aqui?"
+
+## Finalização
+
+Operador aprova (com ou sem ajustes).
+1. Salve em `squads/{squad}/clientes/{cliente}/outputs/geral-pesquisa-mercado.json` (com campo `summary` no topo)
+2. Atualize `client.json`: progress.skills → completed, version++, append em history[]
+3. Salve também uma versão Markdown do entregável na mesma pasta de outputs.
+4. Sugira próxima skill do dependency_graph
+   - "Pesquisa concluída. TAM: R$ {valor} | SAM: R$ {valor} | SOM: R$ {valor}. Concorrentes analisados: {numero}. Diferenciais reais identificados: {numero}."
+   - "Proximo passo recomendado: /geral-posicionamento-estrategico (Usa esta pesquisa como base para definir PUV, canvas 4P e territorio de marca)"
+
+
+## Campo obrigatório: summary
+
+Sempre inclua no JSON de saída:
+```json
+"summary": "Resumo de 1-2 frases do pesquisa de mercado: oportunidade principal e diferencial real do cliente. Seja específico — mencione o cliente, números reais e a conclusão principal."
+```
+
+Este campo alimenta o Resumo Executivo do portal de entregas. Deve ser objetivo, com dados reais, sem genéricos.

--- a/.agents/skills/geral-pesquisa-mercado/references/framework-tam-sam-som.md
+++ b/.agents/skills/geral-pesquisa-mercado/references/framework-tam-sam-som.md
@@ -1,0 +1,313 @@
+# Framework TAM/SAM/SOM para PMEs Brasileiras
+
+## O que e cada metrica
+
+### TAM (Total Addressable Market)
+Mercado total disponivel. O tamanho do mercado inteiro se voce pudesse atender 100% dele.
+
+**Para PMEs brasileiras, o TAM geralmente e:**
+- O faturamento total do segmento no Brasil
+- Ou o numero total de empresas no segmento x ticket medio anual
+
+### SAM (Serviceable Addressable Market)
+Mercado enderecavel. A fatia do TAM que voce PODE atingir considerando restricoes reais.
+
+**Filtros comuns para PMEs:**
+- Regiao geografica (cidade, estado, regiao)
+- Porte do cliente (micro, pequena, media)
+- Perfil de cliente (B2B vs B2C, segmento especifico)
+- Canal de distribuicao disponivel
+- Capacidade operacional atual
+
+### SOM (Serviceable Obtainable Market)
+Mercado obtenivel. A fatia do SAM que a empresa realisticamente consegue capturar dada sua oferta, posicionamento e a concorrencia real.
+
+**Duas leituras possiveis — escolha uma e seja explicito:**
+
+**(a) SOM de mercado (recomendado para diagnostico estrategico):** teto tangivel de captura, sem horizonte temporal e sem restricao de capacidade interna. Representa o potencial que o mercado permite a uma empresa plenamente consolidada no seu nicho. Util para discussao estrategica com a cliente — mostra quanto ela PODE atingir se toda a execucao for correta.
+
+**(b) SOM operacional (mais conservador):** fatia capturavel em horizonte definido (12-24 meses) considerando capacidade atual, budget de marketing e ciclo de venda. Util para forecast de curto prazo e metas operacionais.
+
+**Premissas realistas para PMEs:**
+- Para SOM de mercado: share tipico 3-8% do SAM para empresa de nicho bem posicionada; 8-15% para lider do quadrante premium com diferenciacao real; 15-25% para dominante estrutural.
+- Para SOM operacional: 1-5% do SAM para empresas novas, 5-15% para empresas estabelecidas, em horizonte de 12-24m.
+- **NUNCA derive o SOM da meta comercial do cliente.** Meta do cliente e aspiracao operacional, nao metrica de mercado. Ver secao dedicada abaixo.
+
+---
+
+## Camada intermediaria: MERCADO ENDERECAVEL
+
+O TAM/SAM/SOM classico tem 3 camadas, mas muitas vezes uma 4a camada pedagogica — o **Mercado Enderecavel** — ajuda a separar duas barreiras diferentes que senao se misturam.
+
+### O que e
+
+Subset do SAM onde a oferta da empresa e RELEVANTE, dada a decisao estrategica de perfil. Nao e todo o SAM — exclui segmentos que a empresa decide NAO perseguir (commodity, ocasional, fora do ICP).
+
+### Quando usar
+
+- Quando o SAM tem perfis de consumidor muito heterogeneos (premium vs medio vs ocasional/commodity)
+- Quando a empresa explicitamente NAO compete em parte do SAM (decisao de posicionamento)
+- Quando o ratio SOM/SAM fica baixo (5-15%) e isso poderia parecer "empresa captura pouco" — mas na verdade ela nao mira o SAM inteiro por desenho
+
+### Como calcular
+
+```
+Mercado Enderecavel = SAM × % do SAM relevante a oferta da empresa
+Razao SOM/Enderecavel = quanto a empresa captura DO QUE ela persegue
+```
+
+Ratio SOM/Enderecavel e metrica mais honesta para medir performance competitiva:
+- 20-40% = empresa lider do seu nicho
+- 10-20% = empresa competitiva mas nao dominante
+- <10% = empresa com grande espaco para crescer dentro do seu proprio quadrante
+
+### Separa duas barreiras distintas
+
+Sem essa camada, SAM → SOM mistura:
+1. **Barreira de escolha estrategica** (SAM → Enderecavel): empresa decide nao competir em partes do SAM
+2. **Barreira competitiva** (Enderecavel → SOM): dentro do perfil alvo, empresa disputa com concorrentes
+
+Com a camada separada, fica visivel O QUE a empresa escolheu deixar de fora vs O QUE a concorrencia disputa dela.
+
+### Exemplo (hipotético)
+
+```
+SAM: R$ 34M (todo o mercado regional do segmento)
+  ├─ Premium:                  R$ 17,1M (50% do gasto) ← a empresa compete aqui
+  ├─ Medio regular:            R$ 10,2M (30% do gasto) ← parte upgrade para a empresa
+  └─ Ocasional/commodity:      R$  6,7M (20% do gasto) ← a empresa NAO compete
+
+Mercado Enderecavel: R$ 20M (premium completo + 20% do medio que upgrade)
+SOM: R$ 7M (35% do enderecavel — empresa lider do quadrante)
+```
+
+Razao SOM/SAM = 20,6% (parece baixa)
+Razao SOM/Enderecavel = 35% (captura real do que ela persegue — lider de nicho)
+
+### Quando NAO usar
+
+- Quando a empresa mira todo o SAM indiferentemente (ex: commodity puro)
+- Quando o SAM e homogeneo (sem subsegmentos claros de gasto)
+- Quando adicionar a camada complica a comunicacao sem agregar clareza estrategica
+
+---
+
+## SOM vs Capacidade Operacional vs Meta Comercial — tres metricas distintas
+
+Confundir essas tres e erro comum. Separe-as explicitamente:
+
+### SOM (metrica de mercado)
+Teto tangivel de captura dado posicionamento + competicao. INDEPENDENTE de capacidade interna ou prazo da empresa.
+
+### Capacidade operacional (restricao interna)
+Teto de producao dada a estrutura atual (equipe, instalacoes, agenda). Se SOM > capacidade, a diferenca flagga necessidade de expansao futura (contratar, 2a unidade, etc).
+
+**Exemplo:**
+- SOM de mercado: R$ 7M
+- Capacidade atual (3 vets, 1 unidade): R$ 5,4M em regime de agenda cheia
+- Gap: R$ 1,6M exigem expansao (2a unidade ou ampliacao)
+
+Registrar como `operational_ceiling_note` separado do SOM. Nunca reduzir o SOM pela capacidade — SOM e sobre mercado, nao sobre a empresa.
+
+### Meta comercial do cliente (aspiracao operacional)
+Numero que a cliente registrou no V4MOS, no briefing ou no kickoff como meta de faturamento. **Isso NAO e SOM.**
+
+Se a meta aparecer como "R$ 1,32M ano que vem", ela e uma aspiracao operacional da cliente — pode estar abaixo do SOM (cliente conservadora), acima do SOM (cliente otimista), ou alinhada. **Nao confundir.**
+
+**Regra critica:** registrar a meta do cliente como campo separado (`client_annual_revenue_goal_brl`) com fonte documentada (`client_annual_revenue_goal_source`), e comparar com o SOM na narrativa — nao incorporar no calculo do SOM.
+
+**Fontes tipicas de meta da cliente (podem divergir entre si):**
+- Formulario V4MOS (campo "Meta 12M" preenchido pela cliente) → ambicao dela
+- Kickoff da V4 (meta mensal negociada com o executor) → versao operacional, as vezes mais conservadora
+- Plano de ROI / Rollout → meta intermedia
+
+Se houver duas metas em fontes diferentes, documente as DUAS separadamente. Nao escolha uma arbitrariamente.
+
+---
+
+## Triangulacao metodologica para SOM robusto
+
+Nao chegue a um numero de SOM por um metodo so. **Triangule com 3 metodos independentes** — se os tres convergirem em uma faixa, o numero e defensavel. Se divergirem muito, algo esta errado.
+
+### Metodo 1 — Capacidade operacional plenamente madura (bottom-up da estrutura)
+
+Responde: "qual o teto produtivo da empresa em agenda cheia + ticket otimizado?"
+
+Para servicos presenciais (clinicas, consultorios, restaurantes):
+```
+Capacidade = (unidades produtivas) × (consultas/atendimentos por dia) × (dias uteis/mes) × 12
+Receita total = Capacidade × ticket medio × fator de servicos complementares
+  (fator tipico: 1/0.6 = 1.67 se consulta e 60% da receita; ajuste por modelo)
+```
+
+**Exemplo hipotético:**
+- 3 profissionais × 2.400 atendimentos/ano = 7.200 atendimentos
+- × R$ 450 ticket medio = R$ 3,24M em atendimentos
+- ÷ 0,6 (atendimentos = 60% da receita) = R$ 5,4M teto operacional
+
+### Metodo 2 — Market share top-down (benchmark de nicho)
+
+Responde: "qual fatia do SAM regional uma empresa de nicho similar tipicamente captura quando plenamente consolidada?"
+
+Use benchmarks:
+- Generalista mediana: 1-3%
+- Diferenciada com posicionamento claro: 3-5%
+- Lider do quadrante de nicho: **5-12%**
+- Dominante estrutural (ex: hospital 24h em cidade pequena): 15-25%
+
+Aplique o % apropriado ao SAM.
+
+### Metodo 3 — Segmento premium por nicho (bottom-up do mercado)
+
+Responde: "de dentro do SAM, qual fatia corresponde ao nicho-alvo da empresa, e quanto desse nicho ela pode capturar?"
+
+Passos:
+1. Decomponha o SAM por perfil de gasto (premium vs medio vs ocasional)
+2. Identifique qual fatia corresponde ao ICP alvo (ex: premium humanizado)
+3. Dentro do nicho-alvo, estime captura realista (30-60% se lider, 15-30% se competitivo)
+
+### Convergencia
+
+Se Metodo 1 → R$ X, Metodo 2 → R$ Y, Metodo 3 → R$ Z e `X ≈ Y ≈ Z`, a faixa e defensavel. Use o ponto medio como SOM.
+
+Se divergirem muito (ex: X=R$1M, Y=R$5M, Z=R$3M), investigue:
+- Capacidade pode estar bloqueando crescimento → plano de expansao
+- Benchmark de market share pode estar errado → recalibrar
+- Segmento alvo pode estar mal definido → revisar ICP
+
+---
+
+## Segmentacao heterogenea do SAM
+
+SAM calculado como "media simples × populacao" esconde heterogeneidade que muda tudo. Em setores de servico:
+
+| Segmento | % tipico dos consumidores | % do gasto total | Gasto medio anual |
+|---|---|---|---|
+| Premium humanizado | 15-20% | 40-55% | 3-10× a media do SAM |
+| Medio regular | 30-40% | 25-35% | ~= media do SAM |
+| Ocasional/commodity | 40-50% | 10-20% | 1/3 a 1/2 da media |
+| Subsistencia / nao-consumo | 3-8% | <5% | negligivel |
+
+**Implicacoes:**
+1. Se a empresa mira **premium humanizado**, o verdadeiro mercado enderecavel pode ser 40-55% do SAM, nao 15-20% (porque cada consumidor premium gasta muito mais)
+2. Se o SAM foi calculado com media simples (R$ X por domicilio), o numero subestima o mercado para empresas premium. Considere recalibrar ou usar a camada enderecavel.
+3. **No premium humanizado**, o mix entre sub-segmentos (ex: gato vs cao no pet) pode divergir do mix nacional. Ex: Gen Z/Millennial humanizado tende a ter mais gatos que a media brasileira.
+
+## Metodologias de estimativa
+
+### Top-Down (do macro para o micro)
+1. Comece com dados macro do setor (IBGE, SEBRAE, associacoes)
+2. Aplique filtros de regiao e perfil
+3. Estime o share obtenivel
+
+**Quando usar:** Quando ha dados setoriais publicos disponiveis.
+
+**Fontes confiáveis:**
+- IBGE — Pesquisa Anual de Servicos, CEMPRE, PNAD
+- SEBRAE — Estudos setoriais, DataSEBRAE
+- ABComm — E-commerce brasileiro
+- ABRASEL — Alimentacao fora do lar
+- ABES — Software brasileiro
+- Statista — Dados globais com recorte Brasil
+- Euromonitor — Mercados de consumo
+- BNDES — Relatorios setoriais
+
+### Bottom-Up (do micro para o macro)
+1. Estime o numero de potenciais clientes na regiao
+2. Multiplique pelo ticket medio
+3. Aplique taxa de conversao realista
+
+**Quando usar:** Quando o segmento e muito nicho ou nao ha dados macro.
+
+**Exemplo:**
+```
+Clientes potenciais na regiao: 500 empresas
+Ticket medio mensal: R$ 2.000
+Conversao realista: 5% no primeiro ano
+SOM = 500 x R$ 2.000 x 12 x 5% = R$ 600.000/ano
+```
+
+### Mista (recomendada)
+1. Use top-down para TAM e SAM
+2. Use bottom-up para SOM
+3. Valide cruzando os dois
+
+## Erros comuns ao estimar mercado para PMEs
+
+### Erro 1: TAM inflado
+**Errado:** "O mercado de saude no Brasil e R$ 700 bilhoes"
+**Correto:** "O mercado de clinicas de estetica no Brasil fatura R$ 12 bilhoes" (segmento especifico)
+
+### Erro 2: SAM sem filtros reais
+**Errado:** "Nosso SAM e 50% do TAM"
+**Correto:** "Filtrando por Grande Porto Alegre, clinicas com 2-10 funcionarios, com presenca digital: 1.200 clinicas, R$ 3.6 bilhoes"
+
+### Erro 3: SOM otimista demais
+**Errado:** "Vamos capturar 20% do SAM no primeiro ano"
+**Correto:** "Com 3 vendedores e R$ 5K/mes em midia, estimamos converter 25 clientes novos em 12 meses"
+
+### Erro 4: Fontes genericas
+**Errado:** "Segundo pesquisas, o mercado cresce 10% ao ano"
+**Correto:** "Segundo o SEBRAE (Perfil dos Pequenos Negocios, 2025), o segmento de beleza e estetica cresceu 8.3% no ultimo ano"
+
+### Erro 5: SOM derivado da meta da cliente
+**Errado:** "SOM = triplicar o faturamento atual de R$650K para R$2M em 3 anos"
+**Correto:** "SOM de mercado: R$ 7M (20% do SAM, metrica independente da ambicao da empresa). Meta da cliente registrada separadamente: R$ 1,32M/ano (18,9% do SOM — fonte: Formulario V4MOS)"
+
+O SOM precisa ser uma metrica de MERCADO, nao de ambicao interna. Se voce esta usando o numero que a cliente disse como meta, voce perdeu a oportunidade de mostrar a ela o potencial real do mercado — que tipicamente e MAIOR que ela imagina.
+
+### Erro 6: SOM = capacidade operacional
+**Errado:** "Ela so tem 1 veterinaria trabalhando, entao o SOM dela e R$ 1,5M (teto produtivo)"
+**Correto:** "SOM de mercado: R$ 7M (o mercado permite). Capacidade atual: R$ 1,5M (a empresa produz). Gap de R$ 5,5M = necessidade de expansao futura."
+
+Capacidade e restricao INTERNA, nao de mercado. Deve ser registrada separadamente como `operational_ceiling_note` e NUNCA usada para reduzir o SOM.
+
+### Erro 7: SOM sem triangulacao
+**Errado:** "Calculei SOM como 5% do SAM, apenas."
+**Correto:** "Triangulei tres metodos: (1) capacidade operacional R$5,4M; (2) market share 10% do SAM = R$3,4M; (3) segmento premium 40% captura = R$3,8M. Convergencia em R$3,5M, usado como SOM."
+
+Um metodo so e chute. Tres metodos independentes que convergem e diagnostico.
+
+### Erro 8: Conflacao entre SOM e "meta 12m"
+**Errado:** "SOM em 12 meses e R$ 1,2M (igual a meta do cliente)"
+**Correto:** SOM e teto de mercado sem amarra temporal rigida; meta comercial e aspiracao operacional, pode ter horizonte de 12 ou 24 meses.
+
+Se registrar SOM, seja claro sobre a leitura escolhida (mercado vs operacional). Se registrar meta do cliente, registrar com fonte (V4MOS, kickoff, etc).
+
+## Heuristicas por segmento
+
+| Segmento | TAM Brasil estimado | Ticket medio mensal PME | Fontes recomendadas |
+|---|---|---|---|
+| Odontologia | R$ 45 bi | R$ 1.500-5.000 | CFO, ANS, SEBRAE |
+| Clinicas estetica | R$ 12 bi | R$ 2.000-8.000 | ABIHPEC, SEBRAE |
+| Imobiliarias | R$ 170 bi | R$ 3.000-10.000 | SECOVI, CRECI |
+| Restaurantes | R$ 230 bi | R$ 1.000-3.000 | ABRASEL, ANR |
+| Academias | R$ 12 bi | R$ 1.500-4.000 | IHRSA, ACAD |
+| E-commerce moda | R$ 55 bi | R$ 2.000-5.000 | ABComm, Neotrust |
+| Advocacia | R$ 80 bi | R$ 2.000-6.000 | OAB, CNJ |
+| Contabilidade | R$ 25 bi | R$ 800-2.500 | CFC, FENACON |
+| Educacao/cursos | R$ 40 bi | R$ 1.500-5.000 | ABED, MEC |
+| SaaS B2B | R$ 30 bi | R$ 3.000-15.000 | ABES, Gartner |
+
+**ATENCAO:** Esses valores sao heuristicas para referencia. Sempre busque dados atualizados e cite a fonte especifica.
+
+## Template de apresentacao
+
+```
+TAM: R$ [valor]
+[Descricao em 1 frase]
+Fonte: [nome] ([ano]) — [link se disponivel]
+
+SAM: R$ [valor]
+[Descricao em 1 frase]
+Filtros: [lista de filtros aplicados]
+Calculo: [como chegou no numero]
+
+SOM: R$ [valor] (12 meses)
+[Descricao em 1 frase]
+Premissas: [lista de premissas]
+Calculo: [detalhamento]
+
+Metodologia: [top-down / bottom-up / mista]
+Confianca: [alta / media / baixa]
+```

--- a/.agents/skills/geral-pesquisa-mercado/references/padrao-output.md
+++ b/.agents/skills/geral-pesquisa-mercado/references/padrao-output.md
@@ -1,0 +1,202 @@
+# Padrão de Output das Skills — V4 Estruturação IA
+
+Este documento define a **estrutura canônica** que todos os outputs de skill devem seguir para renderizar no portal com hierarquia visual consistente. O objetivo é que o operador e o stakeholder final abram qualquer entregável e encontrem o mesmo ritmo: manchete → KPIs → achados categorizados → ponto de alavancagem destacado → detalhes expansíveis.
+
+---
+
+## Princípios
+
+1. **Manchete antes de texto.** Toda skill abre com uma frase única e específica que resume a conclusão. Não é parágrafo, é headline.
+2. **Números em destaque, não escondidos no corpo do texto.** KPIs que importam viram cards. Texto corrido é para contexto, não para fato quantitativo.
+3. **Achados categorizados por intenção.** Cada insight é classificado como `vantagem | contexto | ameaca | acao` — o leitor identifica o tom antes de ler.
+4. **Ponto de alavancagem visualmente isolado.** Toda skill tem UM ponto onde a conversa com o stakeholder precisa acontecer. Esse ponto ganha hero visual (border, gradient, quote destacada).
+5. **Detalhe denso → colapsável.** Listas longas (concorrentes, itens de checklist, fontes) ficam em `<details>` para não afogar a leitura.
+
+---
+
+## Campos obrigatórios no JSON
+
+Todo output de skill DEVE ter estes campos no topo (antes dos campos específicos da skill):
+
+```json
+{
+  "client_name": "Nome do Cliente",
+  "summary": "Resumo em 1-2 frases. Específico, com dados reais. Alimenta o resumo executivo do portal.",
+
+  "summary_headline": "Manchete em 1 linha (max 120 caracteres). A frase que o stakeholder lê primeiro.",
+
+  "summary_highlights": [
+    {
+      "category": "posicao | competicao | janela | maturidade | oportunidade | risco",
+      "label": "Rótulo curto (max 30 char)",
+      "value": "Valor em destaque (número, %, status)",
+      "subtext": "Contexto em 1 linha (max 60 char)",
+      "tone": "green | yellow | red | blue | gray"
+    }
+  ],
+
+  "summary_key_findings": [
+    {
+      "category": "vantagem | contexto | ameaca | acao",
+      "text": "Achado em 1-2 linhas. Específico, acionável."
+    }
+  ]
+}
+```
+
+### Regras dos campos de summary
+
+**`summary_headline`**: É a ÚNICA frase que o stakeholder precisa ler se só tiver 5 segundos. Deve conter o veredito da skill. Exemplos bons:
+- ✓ "[Cliente] é o ÚNICO player premium da microrregião com [diferencial declarado] — janela competitiva de 12-18 meses."
+- ✗ "Análise de mercado concluída com sucesso."
+
+**`summary_highlights`** (4-6 itens): KPIs visuais. Categorias sugeridas:
+- `posicao` — onde o cliente está hoje vs potencial
+- `competicao` — quem disputa o mesmo espaço
+- `janela` — tempo/urgência
+- `maturidade` — estágio atual em algum eixo
+- `oportunidade` — tamanho do ganho possível
+- `risco` — tamanho da ameaça
+
+Agrupar de 2 em 2 por categoria no renderer (dá layout balanceado 3x2 ou 2x2).
+
+**`summary_key_findings`** (3-5 itens): Achados que embasam a manchete. Categorias:
+- `vantagem` (✓ verde) — o que o cliente tem a favor
+- `contexto` (i azul) — o que é fato do mercado, neutro
+- `ameaca` (! vermelho) — o que pode dar errado
+- `acao` (▸ laranja) — o que precisa ser feito
+
+---
+
+## Ponto de Alavancagem (hero block)
+
+Toda skill deve identificar **UM bloco que merece destaque visual especial** — o ponto onde a conversa estratégica precisa acontecer. O nome do campo varia por skill, mas a estrutura é consistente:
+
+```json
+{
+  "key_leverage_point": {
+    "headline": "Frase-manchete do ponto (pode ir como quote)",
+    "context": "Contexto em 2-3 linhas explicando o cenário",
+    "numbered_reasons": [
+      "Razão 1 (parse-friendly, pode começar com texto direto)",
+      "Razão 2",
+      "Razão 3"
+    ],
+    "discussion_anchor": "Frase curta sobre POR QUE este é o ponto de conversa com o stakeholder"
+  }
+}
+```
+
+Exemplos por skill:
+- `pesquisa-mercado` → `unexploited_opportunity` (whitespace estratégico)
+- `persona-icp` → persona principal + dor mais ignorada
+- `swot` → combinação força × oportunidade mais assimétrica
+- `posicionamento` → PUV vs alternativas descartadas
+- `diagnostico-midia` → canal mais subotimizado + upside estimado
+- `diagnostico-maturidade` → pilar mais fraco com maior impacto
+
+O renderer aplica:
+- Border verde 2px + gradient sutil
+- Selo "Whitespace Estratégico · Discussão com Stakeholder" no topo
+- Pill de viabilidade/urgência à direita
+- Quote/headline em card branco isolado
+- Razões numeradas em 3 círculos
+- Footer "💬 Momento de validar com a stakeholder"
+
+---
+
+## Alerta de honestidade
+
+Se a pesquisa/análise revelou fragilidade do cliente (não há diferencial real, ICP mal definido, mercado saturado, etc.), inclua:
+
+```json
+{
+  "honesty_alert": "Texto explicando a fragilidade encontrada e o que precisa ser feito antes de seguir."
+}
+```
+
+Esse campo renderiza em box amarelo/vermelho após os achados. **Nunca omita** se a realidade justifica. O valor do sistema depende de não vender aspiracional como real.
+
+---
+
+## Instrução para a IA da skill
+
+Em cada `SKILL.md`, incluir esta seção na geração:
+
+> ### Estrutura visual (obrigatória)
+>
+> Além dos campos específicos desta skill, gere SEMPRE:
+>
+> - `summary_headline` — manchete em 1 linha com o veredito
+> - `summary_highlights` — 4-6 KPIs categorizados (`posicao|competicao|janela|maturidade|oportunidade|risco`) com `{label, value, subtext, tone}`
+> - `summary_key_findings` — 3-5 achados categorizados (`vantagem|contexto|ameaca|acao`)
+> - `honesty_alert` se houver fragilidade
+>
+> Identifique o **ponto de alavancagem** desta skill (o bloco que merece hero visual) e estruture-o com headline + contexto + razões numeradas + discussion anchor.
+>
+> Consulte `references/padrao-output.md` para especificação completa.
+
+E na auto-validação:
+
+> - [ ] Tem `summary_headline` específico (não "análise concluída")?
+> - [ ] `summary_highlights` tem 4-6 itens com categorias válidas?
+> - [ ] `summary_key_findings` cobre pelo menos 3 dos 4 tipos (vantagem/contexto/ameaça/ação)?
+> - [ ] Identificou o ponto de alavancagem para discussão com stakeholder?
+> - [ ] Se há fragilidade, incluiu `honesty_alert`?
+
+---
+
+## Completude (regra crítica)
+
+**Todo campo definido no schema da skill é obrigatório no output.** Não omitir campos — o renderer assume que os campos do schema existem e quebra/fica vazio silenciosamente quando faltam.
+
+Se um dado **não pode ser obtido** (GA4 não instalado, conector não conectado, cliente não sabe, etc.), preencher com `null` E adicionar `unavailable_reason` no objeto pai:
+
+```json
+{
+  "current_conversion_rate": null,
+  "current_bounce_rate": null,
+  "avg_time_on_page": null,
+  "unavailable_reason": "GA4 não instalado no site — métricas de analytics não coletadas nesta auditoria"
+}
+```
+
+Para arrays vazios legitimamente (ex: nenhum competidor identificado), preencher com `[]` e adicionar uma nota no campo irmão `{campo}_note`:
+
+```json
+{
+  "competitors": [],
+  "competitors_note": "Nenhum concorrente direto identificado na microrregião após busca em Google Maps + Instagram."
+}
+```
+
+Para valores **estimados** (sem fonte pública), adicionar flag `[E]` no texto OU campo `estimated: true` no objeto:
+
+```json
+{ "tam_brl": 450000000, "estimated": true, "estimation_basis": "IBGE população × SEBRAE ticket médio" }
+```
+
+**Nunca** deixar string vazia (`""`), zero falso (`0` quando não é zero real), ou omitir o campo. Essas três formas são invisíveis para o renderer e geram o bug "coluna vazia".
+
+Valide o JSON contra o `schema.json` empacotado na skill e corrija campos ausentes ou `null` sem `unavailable_reason`.
+
+### Checklist adicional de auto-validação
+
+> - [ ] Todos os campos do schema estão presentes (preenchidos ou com `null` + `unavailable_reason`)?
+> - [ ] Nenhuma string vazia (`""`) — substituí por `null` + reason quando o dado não existe?
+> - [ ] Arrays vazios legítimos têm `{campo}_note` explicando por quê?
+> - [ ] Estimativas marcadas com `estimated: true` ou `[E]`?
+
+---
+
+## Tons de voz
+
+- `green` — oportunidade/vantagem/confirmado
+- `yellow` — atenção/potencial/médio
+- `red` — risco/ameaça/fraco
+- `blue` — contexto/informativo/neutro
+- `gray` — desativado/aspiracional/ausente
+
+Usar tons consistentemente: nunca pintar ameaça de verde ou vantagem de vermelho para "chamar atenção". O tom é semântico.
+
+---

--- a/.agents/skills/geral-pesquisa-mercado/references/template-analise-concorrente.md
+++ b/.agents/skills/geral-pesquisa-mercado/references/template-analise-concorrente.md
@@ -1,0 +1,151 @@
+# Template de Analise de Concorrente
+
+Framework para analisar cada concorrente de forma sistematica e acionavel.
+
+## Dimensoes de analise
+
+### 1. Posicionamento e PUV
+**O que observar:**
+- Headline do site (primeira coisa que o visitante le)
+- Tagline ou slogan
+- Bio do Instagram
+- Descricao do Google Meu Negocio
+- Como se descreve em anuncios
+
+**Perguntas-chave:**
+- O geral-posicionamento-estrategico e claro em 5 segundos?
+- A PUV e especifica ou generica ("qualidade e compromisso")?
+- Ele se posiciona por preco, qualidade, especializacao ou conveniencia?
+
+**Red flags de geral-posicionamento-estrategico fraco:**
+- "Solucoes completas" sem definir o que
+- "Mais de X anos de experiencia" como unico diferencial
+- Nenhuma especificidade sobre para quem serve
+- Copy generica que serve para qualquer empresa do setor
+
+### 2. Canais de aquisicao
+**O que investigar:**
+- Google Ads: busque as palavras-chave do setor e veja se o concorrente aparece
+- Meta Ads Library: acesse facebook.com/ads/library e busque o nome do concorrente
+- Instagram: frequencia de postagem, engajamento, uso de reels/stories
+- Google organico: busque o nome + segmento e veja o ranking
+- YouTube: tem canal? Que tipo de conteudo?
+- Google Meu Negocio: esta otimizado? Quantas avaliacoes?
+- Email marketing: inscreveu-se na newsletter? Qual a cadencia?
+- WhatsApp: usa como canal de atendimento/venda?
+
+**Classificacao de maturidade por canal:**
+| Nivel | Descricao |
+|---|---|
+| 0 — Ausente | Nao usa o canal |
+| 1 — Presente | Tem presenca mas sem estrategia |
+| 2 — Ativo | Publica/anuncia regularmente |
+| 3 — Otimizado | Boa execucao, testes, segmentacao |
+| 4 — Lider | Referencia no canal para o segmento |
+
+### 3. Pontos fortes observados
+**Categorias comuns:**
+- **Marca forte:** Reconhecimento, tempo de mercado, reputacao
+- **Conteudo educativo:** Produz material que gera confianca
+- **Prova social:** Muitas avaliacoes, cases, depoimentos
+- **Tecnologia:** Site rapido, app, automacoes
+- **Atendimento:** Resposta rapida, multi-canal
+- **Especializacao:** Foco em nicho especifico
+- **Preco competitivo:** Oferta agressiva
+- **Distribuicao:** Presenca fisica + digital
+
+**Regra:** Cite EVIDENCIA, nao suposicao. "Site carrega em 1.5s e tem 4.8 estrelas com 230 avaliacoes no Google" > "Parece ter boa presenca digital"
+
+### 4. Pontos fracos observados
+**Categorias comuns:**
+- **Site lento/desatualizado:** PageSpeed abaixo de 50, design antigo
+- **Copy generica:** Nenhum diferencial claro
+- **Anuncios fracos:** Criativos sem hook, copy padrao
+- **Sem prova social:** Poucas avaliacoes, sem cases
+- **Precificacao opaca:** Nao mostra precos, dificulta comparacao
+- **Canais abandonados:** Instagram com ultima postagem ha 3 meses
+- **Nao segmentado:** Fala para todo mundo (e portanto para ninguem)
+- **Sem funil:** Manda trafego direto para homepage, sem LP
+
+**Regra:** So liste fraquezas que podem ser EXPLORADAS pelo seu cliente. "Atendimento ruim" so importa se o seu cliente pode fazer melhor.
+
+### 5. Estimativa de preco/ticket medio
+**Como estimar quando nao ha preco publico:**
+1. Peca orcamento como cliente oculto (se viavel)
+2. Verifique sites de comparacao (ex: Glassdoor para salarios, comparadores setoriais)
+3. Procure menções de preço em avaliacoes de clientes
+4. Analise o geral-posicionamento-estrategico: premium/mid/value
+5. Verifique ofertas em anuncios (ex: "a partir de R$ X")
+6. Pergunte ao operador — ele provavelmente sabe o range do mercado
+
+**Formato:** "R$ 2.000-3.000/mes (estimativa baseada em anuncios + geral-posicionamento-estrategico mid-market)"
+
+### 6. Presenca digital — Score 1-10
+**Criterios de pontuacao:**
+
+| Score | Descricao |
+|---|---|
+| 1-2 | Quase inexistente. Site basico ou inexistente. Sem redes ativas. |
+| 3-4 | Presente mas fraco. Site funcional, redes com pouca frequencia, sem anuncios. |
+| 5-6 | Mediano. Site razoavel, posta nas redes, investe pouco em midia paga. |
+| 7-8 | Bom. Site profissional, redes ativas com engajamento, anuncios rodando, Google My Business otimizado. |
+| 9-10 | Excelente. Lider digital no segmento/regiao. Conteudo, midia paga, SEO, reviews — tudo bem executado. |
+
+**Detalhe por canal:**
+- Site: velocidade, design, mobile, SEO basico, CTA claro
+- Instagram: frequencia, engajamento rate, qualidade visual, uso de stories/reels
+- Google: ranking para termos do segmento, Google Meu Negocio, avaliacoes
+- Anuncios: quantidade ativa, qualidade criativa, variedade de formatos
+
+## Template de output por concorrente
+
+```
+CONCORRENTE: [Nome]
+Site: [URL]
+━━━━━━━━━━━━━━━━━━━
+
+Posicionamento: [frase que resume como se posiciona]
+PUV declarada: [o que diz ser o diferencial]
+PUV real percebida: [o que de fato diferencia na pratica]
+
+Canais de aquisicao:
+  - Google Ads: [nivel 0-4 + observacao]
+  - Meta Ads: [nivel 0-4 + observacao]
+  - Instagram organico: [nivel 0-4 + observacao]
+  - Google organico/SEO: [nivel 0-4 + observacao]
+  - Outros: [quais e nivel]
+
+Pontos fortes:
+  1. [ponto forte + evidencia]
+  2. [ponto forte + evidencia]
+
+Pontos fracos:
+  1. [ponto fraco + evidencia]
+  2. [ponto fraco + evidencia]
+
+Estimativa de preco: R$ [range] / [periodo]
+Fonte da estimativa: [como estimou]
+
+Presenca digital: [score]/10
+  - Site: [observacao]
+  - Instagram: [seguidores] — [observacao]
+  - Google My Business: [avaliacoes] estrelas — [observacao]
+  - Anuncios ativos: [sim/nao] — [observacao]
+```
+
+## Mapa competitivo 2x2
+
+Apos analisar todos os concorrentes, posicione-os em um mapa 2x2. Os eixos mais comuns para PMEs:
+
+**Eixos recomendados por segmento:**
+
+| Segmento | Eixo X | Eixo Y |
+|---|---|---|
+| Servicos profissionais | Generalista vs Especialista | Premium vs Acessivel |
+| Comercio/varejo | Local vs Online | Preco vs Experiencia |
+| Saude/estetica | Tratamento generico vs Nicho | Clinica popular vs Clinica premium |
+| Educacao | Presencial vs Digital | Certificacao vs Pratica |
+| SaaS | Self-service vs Assistido | Feature-rich vs Simples |
+| Alimentacao | Fast food vs Gourmet | Delivery vs Presencial |
+
+**Regra:** Escolha eixos que REVELEM ESPACOS VAZIOS. Se todos os concorrentes estao no mesmo quadrante, o mapa e util porque mostra oportunidade. Se estao espalhados, escolha eixos que agrupem de forma mais reveladora.

--- a/.agents/skills/geral-pesquisa-mercado/schema.json
+++ b/.agents/skills/geral-pesquisa-mercado/schema.json
@@ -1,0 +1,585 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PesquisaMercado",
+  "description": "Output estruturado da pesquisa de mercado: TAM/SAM/SOM, concorrentes, tendencias, JTBD e diferenciais reais.",
+  "type": "object",
+  "required": [
+    "summary",
+    "client_name",
+    "segment",
+    "region",
+    "tam_sam_som",
+    "competitors",
+    "trends",
+    "threats",
+    "unexploited_opportunity",
+    "market_jtbd",
+    "real_differentials",
+    "summary_headline",
+    "summary_highlights",
+    "summary_key_findings"
+  ],
+  "properties": {
+    "client_name": {
+      "type": "string",
+      "description": "Nome do cliente"
+    },
+    "summary": {
+      "type": "string",
+      "description": "Resumo de 1-2 frases da pesquisa de mercado. Inclui oportunidade principal e diferencial real do cliente."
+    },
+    "summary_headline": {
+      "type": "string",
+      "maxLength": 200,
+      "description": "Manchete em 1 linha com o veredito da pesquisa (para hero do resumo executivo no portal)"
+    },
+    "summary_highlights": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 8,
+      "description": "KPIs visuais categorizados para o resumo executivo",
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "label",
+          "value"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "posicao",
+              "competicao",
+              "janela",
+              "maturidade",
+              "oportunidade",
+              "risco"
+            ]
+          },
+          "label": {
+            "type": "string",
+            "maxLength": 40
+          },
+          "value": {
+            "type": "string"
+          },
+          "subtext": {
+            "type": "string",
+            "maxLength": 80
+          },
+          "tone": {
+            "type": "string",
+            "enum": [
+              "green",
+              "yellow",
+              "red",
+              "blue",
+              "gray"
+            ]
+          }
+        }
+      }
+    },
+    "summary_key_findings": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 6,
+      "description": "Achados categorizados por intenção (vantagem/contexto/ameaça/ação)",
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "text"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "vantagem",
+              "contexto",
+              "ameaca",
+              "acao"
+            ]
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "segment": {
+      "type": "string",
+      "description": "Segmento de atuacao"
+    },
+    "region": {
+      "type": "string",
+      "description": "Regiao de atuacao"
+    },
+    "tam_sam_som": {
+      "type": "object",
+      "description": "Sizing de mercado com metodologia e fontes",
+      "required": [
+        "tam",
+        "sam",
+        "som",
+        "methodology",
+        "sources"
+      ],
+      "properties": {
+        "tam": {
+          "type": "object",
+          "required": [
+            "value_brl",
+            "description"
+          ],
+          "properties": {
+            "value_brl": {
+              "type": "number",
+              "description": "Valor do TAM em reais"
+            },
+            "description": {
+              "type": "string",
+              "description": "Descricao do que o TAM representa"
+            }
+          }
+        },
+        "sam": {
+          "type": "object",
+          "required": [
+            "value_brl",
+            "description",
+            "filters"
+          ],
+          "properties": {
+            "value_brl": {
+              "type": "number",
+              "description": "Valor do SAM em reais"
+            },
+            "description": {
+              "type": "string",
+              "description": "Descricao do que o SAM representa"
+            },
+            "filters": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Filtros aplicados para chegar ao SAM (regiao, perfil, etc.)"
+            }
+          }
+        },
+        "som": {
+          "type": "object",
+          "required": [
+            "value_brl",
+            "description",
+            "assumptions"
+          ],
+          "properties": {
+            "value_brl": {
+              "type": "number",
+              "description": "Valor do SOM em reais (anual). Teto de mercado capturavel — NAO derivar da meta do cliente, NAO limitar pela capacidade interna."
+            },
+            "description": {
+              "type": "string",
+              "description": "Descricao do que o SOM representa. Inclua a triangulacao metodologica (capacidade + market share + segmento) e explicite: (1) que nao e derivado da meta do cliente; (2) que e metrica de mercado, nao de capacidade."
+            },
+            "assumptions": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Premissas usadas para estimar o SOM (posicionamento, competicao, dinamica de nicho, nao premissas operacionais de capacidade)."
+            },
+            "operational_ceiling_note": {
+              "type": "string",
+              "description": "Nota opcional descrevendo o teto de capacidade operacional atual (ex: 'estrutura atual de 3 vets topa em R$ 5,4M — R$ 1,6M entre capacidade e SOM exigem expansao futura'). Separa restricao INTERNA (capacidade) do SOM (mercado)."
+            },
+            "related_but_separate": {
+              "type": "object",
+              "description": "Metricas relacionadas mas SEPARADAS do SOM: meta comercial do cliente de fontes diversas. Ajuda a comparar aspiracao da cliente vs potencial de mercado sem conflatar.",
+              "properties": {
+                "client_annual_revenue_goal_brl_v4mos": {
+                  "type": "number",
+                  "description": "Meta anual registrada no Formulario V4MOS (campo 'Meta 12M')"
+                },
+                "client_annual_revenue_goal_source_v4mos": {
+                  "type": "string",
+                  "description": "Fonte exata (ex: 'Formulario V4MOS - campo Meta 12M preenchido pela cliente')"
+                },
+                "client_monthly_revenue_goal_kickoff": {
+                  "type": "string",
+                  "description": "Meta mensal negociada no kickoff (se houver), em formato livre (ex: 'R$ 90.000 = R$ 1,08M/ano')"
+                },
+                "note": {
+                  "type": "string",
+                  "description": "Narrativa explicando relacao entre metas e SOM — enfatizando que metas sao aspiracao operacional, nao metrica de mercado."
+                }
+              }
+            }
+          }
+        },
+        "methodology": {
+          "type": "string",
+          "enum": [
+            "top-down",
+            "bottom-up",
+            "mixed"
+          ],
+          "description": "Metodologia usada para estimar o mercado"
+        },
+        "sources": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "name",
+              "url"
+            ],
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Nome da fonte (ex: SEBRAE, IBGE, Statista)"
+              },
+              "url": {
+                "type": "string",
+                "description": "URL da fonte ou referencia"
+              },
+              "year": {
+                "type": "integer",
+                "description": "Ano dos dados"
+              }
+            }
+          },
+          "description": "Fontes usadas para os dados de mercado"
+        }
+      }
+    },
+    "competitors": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 7,
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "positioning",
+          "channels",
+          "strengths",
+          "weaknesses",
+          "estimated_pricing",
+          "digital_score"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Nome do concorrente"
+          },
+          "positioning": {
+            "type": "string",
+            "description": "Como o concorrente se posiciona (PUV, mensagem principal)"
+          },
+          "channels": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Canais de aquisicao usados (Google Ads, Meta, organico, etc.)"
+          },
+          "strengths": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Pontos fortes observados"
+          },
+          "weaknesses": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Pontos fracos observados"
+          },
+          "estimated_pricing": {
+            "type": "string",
+            "description": "Estimativa de preco/ticket medio (ex: R$ 2.000/mes)"
+          },
+          "digital_score": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 10,
+            "description": "Score de presenca digital (1-10)"
+          },
+          "digital_details": {
+            "type": "object",
+            "properties": {
+              "website": {
+                "type": "string"
+              },
+              "instagram": {
+                "type": "string"
+              },
+              "google": {
+                "type": "string"
+              },
+              "active_ads": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "description": "Analise de cada concorrente"
+    },
+    "competitive_map": {
+      "type": "object",
+      "description": "Mapa competitivo 2x2",
+      "properties": {
+        "axis_x": {
+          "type": "string",
+          "description": "Eixo horizontal (ex: Generalista vs Especialista)"
+        },
+        "axis_y": {
+          "type": "string",
+          "description": "Eixo vertical (ex: Premium vs Acessivel)"
+        },
+        "positions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "quadrant": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "empty_spaces": {
+          "type": "string",
+          "description": "Espacos nao ocupados no mapa"
+        },
+        "crowded_spaces": {
+          "type": "string",
+          "description": "Espacos mais disputados"
+        }
+      }
+    },
+    "trends": {
+      "type": "array",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "trend",
+          "evidence"
+        ],
+        "properties": {
+          "trend": {
+            "type": "string",
+            "description": "Descricao da tendencia"
+          },
+          "evidence": {
+            "type": "string",
+            "description": "Evidencia ou fonte que comprova a tendencia"
+          }
+        }
+      },
+      "description": "Tendencias em crescimento no setor"
+    },
+    "threats": {
+      "type": "array",
+      "minItems": 2,
+      "items": {
+        "type": "object",
+        "required": [
+          "threat",
+          "potential_impact"
+        ],
+        "properties": {
+          "threat": {
+            "type": "string",
+            "description": "Descricao da ameaca"
+          },
+          "potential_impact": {
+            "type": "string",
+            "description": "Impacto potencial nos proximos 12 meses"
+          }
+        }
+      },
+      "description": "Ameacas que podem impactar o mercado"
+    },
+    "unexploited_opportunity": {
+      "type": "object",
+      "required": [
+        "description",
+        "why_nobody_does_it",
+        "feasibility"
+      ],
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Oportunidade nao explorada pelos concorrentes"
+        },
+        "why_nobody_does_it": {
+          "type": "string",
+          "description": "Motivo pelo qual ninguem explora essa oportunidade"
+        },
+        "feasibility": {
+          "type": "string",
+          "enum": [
+            "alta",
+            "media",
+            "baixa"
+          ],
+          "description": "Viabilidade para o cliente"
+        }
+      }
+    },
+    "market_jtbd": {
+      "type": "object",
+      "required": [
+        "current_solutions",
+        "alternatives"
+      ],
+      "properties": {
+        "current_solutions": {
+          "type": "string",
+          "description": "Como o mercado resolve hoje o problema do cliente"
+        },
+        "alternatives": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "type",
+              "description"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "direct",
+                  "indirect",
+                  "diy",
+                  "inaction"
+                ],
+                "description": "Tipo de alternativa"
+              },
+              "description": {
+                "type": "string",
+                "description": "Descricao da alternativa"
+              }
+            }
+          },
+          "description": "Alternativas que o mercado considera"
+        },
+        "cost_of_inaction": {
+          "type": "string",
+          "description": "O que acontece se o cliente nao resolver o problema"
+        }
+      }
+    },
+    "real_differentials": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "differential",
+          "status",
+          "icp_relevance"
+        ],
+        "properties": {
+          "differential": {
+            "type": "string",
+            "description": "Descricao do diferencial"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "confirmed",
+              "potential",
+              "aspirational"
+            ],
+            "description": "Se o diferencial ja existe, e potencial, ou aspiracional"
+          },
+          "icp_relevance": {
+            "type": "string",
+            "description": "Por que este diferencial importa para o ICP"
+          },
+          "action_needed": {
+            "type": "string",
+            "description": "Acao necessaria para ativar o diferencial (se potencial/aspiracional)"
+          }
+        }
+      },
+      "description": "Diferenciais competitivos reais e potenciais"
+    },
+    "honesty_alert": {
+      "type": "string",
+      "description": "Alerta se nao ha diferencial claro ou se a pesquisa revelou fragilidades"
+    },
+    "completed_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Data/hora de conclusao"
+    },
+    "market_share": {
+      "type": "object",
+      "description": "Comparação do faturamento atual do cliente vs SAM/SOM + meta da cliente separada + camada enderecavel opcional.",
+      "properties": {
+        "current_revenue_brl": {
+          "type": "number",
+          "description": "Faturamento atual anual (12 meses) em reais."
+        },
+        "current_share_of_sam_pct": {
+          "type": "number",
+          "description": "% do SAM que o cliente captura hoje."
+        },
+        "target_share_of_sam_pct": {
+          "type": "number",
+          "description": "% do SAM que o SOM representa. Sem 'target_scenario' — SOM e metrica unica, nao cenarios."
+        },
+        "gap_to_som_brl": {
+          "type": "number",
+          "description": "Diferenca absoluta entre SOM e faturamento atual."
+        },
+        "gap_to_som_pct": {
+          "type": "number",
+          "description": "% de crescimento sobre atual necessario para atingir SOM."
+        },
+        "commentary": {
+          "type": "string",
+          "description": "Narrativa do market share: onde esta, onde pode chegar, porque."
+        },
+        "client_annual_revenue_goal_brl": {
+          "type": "number",
+          "description": "Meta comercial anual registrada pela cliente — SEPARADA do SOM. Use a meta oficial (V4MOS se houver). NAO usar como SOM."
+        },
+        "client_annual_revenue_goal_source": {
+          "type": "string",
+          "description": "Fonte documentada da meta do cliente (ex: 'Formulario V4MOS - campo Meta 12M', 'Kickoff V4', 'Briefing inicial'). Obrigatorio quando client_annual_revenue_goal_brl esta presente."
+        },
+        "client_goal_vs_som_note": {
+          "type": "string",
+          "description": "Narrativa explicando a relacao entre a meta da cliente e o SOM. Se houver MAIS de uma meta em fontes diferentes (V4MOS + kickoff), registrar ambas aqui com suas fontes respectivas."
+        },
+        "enderecavel_value_brl": {
+          "type": "number",
+          "description": "Tamanho do Mercado Enderecavel (subset do SAM onde a oferta do cliente e relevante). Usar quando SAM tem perfis heterogeneos e o cliente escolhe competir apenas em um subsegmento (tipicamente premium humanizado + upgrading medium)."
+        },
+        "enderecavel_composition": {
+          "type": "string",
+          "description": "Como chegou ao valor do enderecavel — composicao dos subsegmentos somados (ex: 'Premium humanizado R$17M + 20% do medio R$2,9M = R$20M')."
+        },
+        "enderecavel_note": {
+          "type": "string",
+          "description": "Explicacao pedagogica da camada enderecavel — renderizada no portal abaixo do grafico Market Share. Tipicamente explica: (1) que o SAM tem perfis diversos; (2) quais perfis o cliente NAO persegue por decisao estrategica; (3) separa barreira de escolha (SAM->Enderecavel) de barreira competitiva (Enderecavel->SOM)."
+        }
+      }
+    }
+  }
+}

--- a/.agents/skills/geral-posicionamento-estrategico/SKILL.md
+++ b/.agents/skills/geral-posicionamento-estrategico/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: geral-posicionamento-estrategico
+description: "Canvas de posicionamento estrategico completo: PUV, 4Ps, territorio de marca e taglines. A skill mais importante da Semana 2 — tudo que sera produzido na Semana 3 nasce daqui. Use quando o operador disser /geral-posicionamento-estrategico ou 'definir posicionamento' ou 'PUV' ou 'proposta de valor' ou 'canvas de posicionamento'."
+area: geral
+author: luizfreitasv4
+version: 1.0.0
+dependencies:
+  - geral-pesquisa-mercado
+  - geral-persona-icp
+  - geral-analise-swot
+tools: []
+week: 2
+estimated_time: "2.5h"
+output_file: "geral-posicionamento-estrategico.json"
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta versao foi portada do sistema de Estruturacao Estrategica. As regras abaixo tem precedencia sobre caminhos e persistencia citados no fluxo original:
+
+- Trabalhe somente em `squads/{squad}/clientes/{cliente}/`, nunca em um diretorio `clientes/` solto na raiz.
+- Leia primeiro o `CLAUDE.md` ou `AGENTS.md` da KB, `mission-control/`, `calls/`, `docs/` e `campanhas/`.
+- Se `client.json` existir, use-o como fonte complementar. Se nao existir, derive o contexto da KB e do Mission Control; nao exija nem invente esse arquivo.
+- Salve entregaveis em `squads/{squad}/clientes/{cliente}/outputs/`, em JSON e Markdown quando o fluxo pedir ambos.
+- Registre decisoes e progresso no `mission-control/historico-checkins.md` ou no arquivo de historico equivalente encontrado na KB.
+- Resolva recursos empacotados a partir do proprio diretorio desta skill. Se uma integracao externa nao estiver configurada, declare o gap e continue apenas com os dados reais disponiveis.
+
+
+# Canvas de Posicionamento Estrategico (POP 2.5)
+
+> **Posição no fluxo:** Semana 2 — síntese final, comum a todos os modelos. Consome todos os diagnósticos da S1/S2 e é a raiz da Semana 3 inteira (cabeça por modelo + cauda comum).
+
+Voce e um brand strategist senior especializado em posicionamento para PMEs brasileiras. Vai definir o posicionamento estrategico completo do cliente — o DNA de toda a producao da Semana 3 (brandbook, landing page, criativos, copy).
+
+**IMPORTANCIA:** Esta e a skill mais critica do processo. Se o posicionamento for generico, TUDO que vier depois sera generico. Se for afiado e verdadeiro, toda a producao ganha forca.
+
+## Dados necessários
+
+1. Leia `client.json` (seção `briefing`) — extraia: NOME_CLIENTE, SEGMENTO, PRODUTO_SERVICO, marca_valores
+2. Leia `outputs/geral-persona-icp.json` — extraia: RESUMO_ICP, dores, desejos, linguagem, Jobs-to-be-Done
+3. Leia `outputs/geral-pesquisa-mercado.json` — extraia: DIFERENCIAIS_REAIS, POSICIONAMENTOS_CONCORRENTES, mapa_competitivo, oportunidade_inexplorada
+4. Leia `outputs/geral-analise-swot.json` — extraia: RESUMO_SWOT (forcas + oportunidades prioritarias)
+
+Se algum input critico estiver faltando, alerte o operador e sugira completar a dependencia primeiro.
+
+Antes de gerar, confirme com o operador a direcao estrategica (se não encontrar estas informações no client.json):
+- "Diferencial mais forte que voce sente no dia a dia — dos que mapeamos, qual o cliente elogia mais?"
+- "Onde quer estar no mapa competitivo? O espaco vazio identificado faz sentido?"
+- "Restricao de posicionamento — algo que o cliente NAO quer ser associado?"
+- "Tom de comunicacao — mais tecnico/profissional, mais proximo/informal, ou mais aspiracional/premium?"
+
+---
+
+## Geração
+
+Gere o output COMPLETO de uma vez usando os dados de `client.json` (briefing, connectors) e outputs de skills dependentes em `outputs/`.
+
+### Mapa de posicionamento 2x2
+
+Posicione concorrentes e a posição recomendada para o cliente num mapa com eixos estratégicos (ex: Generalista → Especialista × Acessível → Premium). Justifique a posição recomendada.
+
+### 3 Declarações de posicionamento
+
+Gere 3 opções com direções diferentes usando o formato clássico:
+> "Para **[ICP]**, **{NOME_CLIENTE}** e o **[categoria]** que **[beneficio principal]** porque **[razao para acreditar]**."
+
+Para cada opção: aposta (o que prioriza) + risco (onde pode falhar).
+
+### PUV (Proposta Unica de Valor)
+
+Baseada na direção escolhida pelo operador (ou na recomendada). Inclua teste de qualidade:
+- É verdadeira? (diferencial real, não aspiracional)
+- É específica? (não serve para nenhum concorrente)
+- É relevante? (resolve a dor principal do ICP)
+- É memorável? (o ICP consegue repetir)
+- É diferente? (nenhum concorrente diz isso)
+
+### Canvas de Posicionamento (4Ps Estrategico)
+
+Consulte `references/exemplos-puv.md` e `references/canvas-4p-guide.md`.
+
+**PRODUTO:** Transformação entregue + antes/depois concreto + limitações honestas
+**PREÇO:** Posicionamento (premium/mid/value) + justificativa na comunicação + ancoragem
+**PRAÇA (CANAIS):** Canal principal + justificativa + canal secundário + canais a evitar (com motivo)
+**PROMOÇÃO:** Tom e estilo + mensagem topo de funil + mensagem fundo de funil
+
+### Territorio de marca
+
+Consulte `references/territorio-de-marca.md`.
+- Em 3 palavras: o que a marca representa
+- O que significa na prática
+- Territórios dos concorrentes (para diferenciação)
+- Por que o território escolhido está disponível
+
+### 3 opções de tagline
+
+Para cada: tom + justificativa + melhor uso (site, assinatura, anúncios).
+
+### Estrutura visual (obrigatória)
+
+Siga o padrão canônico de `references/padrao-output.md`. Além dos campos acima, SEMPRE inclua:
+
+- **`summary_headline`** (max 200 char) — manchete com o veredito do posicionamento. Ex: "[Cliente] ocupa '[Território Premium do nicho]' — território único na microrregião com janela de 12-18 meses".
+- **`summary_highlights`** (4-6 itens, `{category, label, value, subtext, tone}`) — sugestões:
+  - `posicao`: território de 3 palavras escolhido
+  - `competicao`: território ocupado pelo concorrente #1 (contraste)
+  - `janela`: tempo até concorrência relevante chegar
+  - `oportunidade`: ICP principal + ticket esperado
+  - `risco`: pior cenário de posicionamento forçado
+- **`summary_key_findings`** (3-5 itens, `{category, text}`) — `vantagem|contexto|ameaca|acao`.
+
+### Ponto de alavancagem
+
+Em posicionamento, o ponto de alavancagem é o **território × janela de oportunidade** — o espaço competitivo disponível combinado com o tempo que o cliente tem para ocupá-lo antes da concorrência chegar. Estruture em `key_insight`:
+```json
+"key_insight": {
+  "headline": "Frase sobre território + janela (ex: 'Território [Especialista do nicho] está vago por 12-18 meses')",
+  "context": "2-3 linhas sobre por que ninguém ocupou ainda e por que a janela é finita",
+  "numbered_reasons": ["(1) evidência de que está vago", "(2) o que fecha a janela", "(3) o que o cliente ganha ao ocupar primeiro"],
+  "discussion_anchor": "Por que o stakeholder precisa agir AGORA e não esperar validação"
+}
+```
+
+Se o território escolhido é aspiracional (diferencial ainda não construído), ou a janela é curtíssima e exige decisão imediata, inclua `honesty_alert`.
+
+## Auto-validação
+
+Antes de mostrar ao operador, verifique:
+
+- [ ] Mencionou o cliente pelo nome?
+- [ ] Usou dados reais do client.json (não inventou)?
+- [ ] Nenhum item genérico (ex: "quer crescer", "qualidade e compromisso")?
+- [ ] Schema da skill validou?
+- [ ] Todos os campos do schema preenchidos (ou com `null` + `unavailable_reason` no pai)?
+- [ ] Nenhuma string vazia (`""`) — substituí por `null` + reason quando o dado não existe?
+- [ ] Estimativas marcadas com `estimated: true` ou `[E]`?
+- [ ] Consistente com outputs anteriores (ICP, pesquisa de mercado, SWOT)?
+- [ ] PUV passa nos 5 testes de qualidade?
+- [ ] Cada declaração de posicionamento é diferente das outras (não variações do mesmo)?
+- [ ] Território de marca não está ocupado por concorrente?
+- [ ] Tem `summary_headline` específico?
+- [ ] `summary_highlights` tem 4-6 itens com categorias e tons válidos?
+- [ ] `summary_key_findings` cobre pelo menos 3 dos 4 tipos?
+- [ ] Identificou `key_insight` (território × janela)?
+- [ ] Se território é aspiracional ou janela curtíssima, incluiu `honesty_alert`?
+
+Se falhou → regenere silenciosamente. Não avise o operador.
+
+## Apresentação e decisões
+
+Apresente o output COMPLETO ao operador.
+
+**DECISÃO 1:** Direção de posicionamento — qual das 3 declarações?
+- Opção A: "[nome da direção]" — "[declaração]"
+- Opção B: "[nome da direção]" — "[declaração]"
+- Opção C: "[nome da direção]" — "[declaração]"
+
+**RECOMENDAÇÃO:** Opção [X]. [Justificativa baseada nos dados da pesquisa de mercado e SWOT, não opinião genérica.]
+
+**PROVOCAÇÃO:** [Ex: "Essa direção implica abandonar o público Y. O cliente está pronto pra essa escolha?"]
+
+**DECISÃO 2:** Tagline — qual direção?
+- Opção A: "[tagline]"
+- Opção B: "[tagline]"
+- Opção C: "[tagline]"
+
+**RECOMENDAÇÃO:** Opção [X]. [Justificativa baseada no território de marca e tom de voz.]
+
+**PROVOCAÇÃO:** [Ex: "Essa tagline funciona em outdoor ou só em contexto digital?"]
+
+Valide também:
+- O canvas 4P está alinhado com a realidade do cliente?
+- O que "não entregamos" está honesto?
+- O tom de comunicação soa como o cliente falaria?
+- As 3 palavras do território representam como o cliente quer ser percebido?
+
+## Finalização
+
+Operador aprova (com ou sem ajustes).
+1. Salve em `squads/{squad}/clientes/{cliente}/outputs/geral-posicionamento-estrategico.json` (com campo `summary` no topo)
+2. Atualize `client.json`: progress.skills → completed, version++, append em history[]
+3. Salve também uma versão Markdown do entregável na mesma pasta de outputs.
+4. Sugira próxima skill do dependency_graph
+   - "Posicionamento concluído. PUV: '{puv}'. Tagline: '{tagline}'. Território: {3 palavras}."
+   - "Este posicionamento é a raiz da Semana 3 inteira: a cabeça do modelo de venda + a cauda comum (/designer-manual-marca, /designer-landing-page, /copy-anuncios, /designer-criativos-anuncios, forecast)."
+   - "Proximo passo recomendado: /gt-diagnostico-midia-paga ou /gt-diagnostico-criativos"
+
+
+## Campo obrigatório: summary
+
+Sempre inclua no JSON de saída:
+```json
+"summary": "Resumo de 1-2 frases do posicionamento: PUV definida e território de marca escolhido. Seja específico — mencione o cliente, números reais e a conclusão principal."
+```
+
+Este campo alimenta o Resumo Executivo do portal de entregas. Deve ser objetivo, com dados reais, sem genéricos.

--- a/.agents/skills/geral-posicionamento-estrategico/references/canvas-4p-guide.md
+++ b/.agents/skills/geral-posicionamento-estrategico/references/canvas-4p-guide.md
@@ -1,0 +1,153 @@
+# Guia do Canvas 4P Estrategico
+
+O Canvas 4P nao e o mix de marketing academico. E uma ferramenta de POSICIONAMENTO que traduz a estrategia em decisoes operacionais de comunicacao e canal.
+
+## PRODUTO — O que entregamos de verdade
+
+### Perguntas-chave
+- O que o cliente COMPRA vs o que ele QUER? (ninguem compra "broca de 6mm" — compra "buraco na parede")
+- Qual e a transformacao? Descreva o ANTES e o DEPOIS do cliente
+- O que NAO entregamos? (isso e tao importante quanto o que entregamos)
+
+### Como preencher
+
+**"O que entregamos de verdade"**
+Nao liste features. Descreva o resultado que o cliente experimenta.
+
+Ruim: "Gestao de midias sociais com 20 posts por mes"
+Bom: "Presenca digital profissional que gera leads quentes — o cliente para de depender de indicacao"
+
+**"Qual transformacao o cliente vive"**
+Formato antes/depois:
+
+```
+ANTES: [situacao real que o ICP vive hoje]
+DEPOIS: [situacao apos usar o produto/servico]
+```
+
+Exemplo:
+```
+ANTES: Dona de clinica que posta no Instagram quando lembra, nao sabe se funciona, e depende 100% de indicacao
+DEPOIS: Recebe 30+ leads por mes do digital, sabe exatamente quanto custa cada lead, e tem previsibilidade de faturamento
+```
+
+**"O que NAO entregamos"**
+Isso cria confianca e evita expectativa errada. Exemplos:
+- "Nao fazemos milagre em 7 dias — resultados consistentes aparecem a partir do mes 2"
+- "Nao atendemos empresas que querem ser as mais baratas do mercado"
+- "Nao criamos conteudo para TikTok — nosso foco e performance no Meta e Google"
+
+### Armadilhas
+- Listar features em vez de beneficios
+- Prometer transformacao irreal ("6 digitos em 30 dias")
+- Nao delimitar o que nao faz (gera frustração)
+
+---
+
+## PRECO — Posicionamento, nao tabela
+
+### Posicionamentos possiveis
+
+| Posicionamento | Descricao | Quando usar |
+|---|---|---|
+| **Premium** | Mais caro que a media, justificado por resultado/exclusividade | Diferencial claro e comprovado, ICP valoriza resultado acima de preco |
+| **Mid-market** | Faixa media do mercado, custo-beneficio | Mercado com opcoes baratas ruins e premium inacessiveis |
+| **Value** | Mais acessivel, volume alto | Escala e eficiencia operacional, ICP sensivel a preco |
+
+### Justificativa do preco na comunicacao
+
+O preco nunca deve ser comunicado isolado. Sempre com contexto:
+
+**Para premium:**
+- Ancoragem pelo custo da inacao: "Quanto voce perde por mes sem isso?"
+- Ancoragem pelo resultado: "Se gera R$ 50K em vendas, R$ 5K de investimento e 10x de retorno"
+- Exclusividade: "Atendemos no maximo 15 clientes por consultor"
+
+**Para mid-market:**
+- Comparacao explicita: "Resultado de agencia premium, investimento justo"
+- Transparencia: "Sem taxa de setup, sem contrato de fidelidade, sem surpresas"
+- ROI claro: "CPL medio dos nossos clientes no segmento: R$ X"
+
+**Para value:**
+- Acessibilidade sem parecer barato: "Democratizamos o acesso a [beneficio]"
+- Volume como prova: "Mais de X clientes atendidos"
+- Simplicidade: "Um plano, um preco, tudo incluso"
+
+### Estrategia de ancoragem
+
+Tecnicas comuns para PMEs:
+1. **Ancora pelo concorrente:** "Agencias cobram R$ 5K+. Nos entregamos o mesmo por R$ 2.5K"
+2. **Ancora pelo custo interno:** "Um social media CLT custa R$ 4K+/mes. Voce tem um time inteiro por R$ 2K"
+3. **Ancora pelo resultado:** "Se cada lead vale R$ 500, 30 leads = R$ 15K. Investimento: R$ 3K"
+4. **Ancora pelo prejuizo:** "Cada dia sem LP otimizada sao X leads perdidos"
+
+---
+
+## PRACA (CANAIS) — Onde encontrar o ICP
+
+### Como escolher o canal principal
+
+| Se o ICP... | Canal principal recomendado |
+|---|---|
+| Busca ativamente a solucao | Google Ads (Search) |
+| Nao sabe que precisa, mas tem a dor | Meta Ads (Instagram/Facebook) |
+| E decisor B2B em empresas medias | LinkedIn Ads + conteudo |
+| E local e busca servico proximo | Google Meu Negocio + Google Ads Local |
+| E jovem (18-30) e visual | Instagram + TikTok organico |
+| Ja comprou algo similar | Retargeting + Email marketing |
+| Confia em indicacao | Programa de referral + parcerias |
+
+### Canais a evitar (e quando)
+
+| Canal | Evitar quando... |
+|---|---|
+| TikTok Ads | ICP e 40+, produto e B2B, ou nao ha capacidade de produzir video |
+| LinkedIn Ads | Budget < R$ 5K/mes (CPL altissimo), produto B2C |
+| Google Display | Sem retargeting configurado (display frio tem CTR minimo) |
+| Pinterest | Segmento sem apelo visual, ICP masculino 50+ |
+| Twitter/X Ads | Quase qualquer caso de PME (inventory pequeno no Brasil) |
+| Programatica | Budget < R$ 10K/mes, sem equipe para otimizar |
+
+### Canal de suporte
+
+O canal de suporte complementa o principal:
+- Principal = Google Ads → Suporte = Retargeting Meta Ads
+- Principal = Meta Ads → Suporte = Email nurturing
+- Principal = Organico Instagram → Suporte = Stories + WhatsApp
+- Principal = Indicacao → Suporte = Google Meu Negocio (prova social)
+
+---
+
+## PROMOCAO — Como comunicar
+
+### Tom e estilo de comunicacao
+
+| Tom | Descricao | Quando usar | Exemplo |
+|---|---|---|---|
+| **Tecnico/profissional** | Dados, metodologia, credibilidade | B2B, saude, financeiro | "Reduzimos o CAC medio em 40% com otimizacao de funil" |
+| **Proximo/informal** | Conversa, humor leve, empatia | Varejo, servicos locais, wellness | "A gente sabe como e dificil — por isso simplificamos tudo" |
+| **Aspiracional/premium** | Exclusividade, resultado, status | Luxo, estetica, coaching | "Para quem nao aceita o comum" |
+| **Didatico/educativo** | Ensina, gera autoridade, conquista confianca | SaaS, consultoria, educacao | "Antes de contratar qualquer agencia, entenda isso..." |
+| **Direto/performance** | CTA forte, urgencia, oferta clara | E-commerce, lancamentos, promocoes | "50 vagas. Comeca segunda. Inscricao aberta." |
+
+### Mensagem de topo de funil
+
+O objetivo no topo e PARAR o scroll e gerar curiosidade. Nao vender.
+
+**Formulas que funcionam:**
+1. **Dor direta:** "Voce posta todo dia e nao gera um lead sequer?"
+2. **Dado chocante:** "83% das clinicas de estetica perdem dinheiro com anuncios mal feitos"
+3. **Pergunta provocativa:** "Quanto custa cada lead que voce perde por nao ter uma LP?"
+4. **Resultado concreto:** "Como a [tipo de empresa] saiu de 5 para 50 leads/mes em 90 dias"
+5. **Contra-intuitivo:** "O problema nao e seu anuncio — e o que acontece DEPOIS do clique"
+
+### Mensagem de fundo de funil
+
+O objetivo no fundo e CONVERTER. O lead ja sabe quem voce e.
+
+**Formulas que funcionam:**
+1. **Prova + CTA:** "97% dos nossos clientes renovam. Agenda uma conversa."
+2. **Garantia:** "Se nao gerar X em 90 dias, devolvemos o fee"
+3. **Escassez real:** "Atendemos 15 clientes por cidade. 3 vagas restantes em [cidade]."
+4. **Simplicidade:** "Sem contrato. Sem setup. Comeca em 48h."
+5. **Resultado especifico:** "Em 90 dias: LP no ar, 30+ leads/mes, CPL abaixo de R$ X"

--- a/.agents/skills/geral-posicionamento-estrategico/references/exemplos-puv.md
+++ b/.agents/skills/geral-posicionamento-estrategico/references/exemplos-puv.md
@@ -1,0 +1,117 @@
+# Exemplos de PUV: Boas vs Ruins
+
+A PUV (Proposta Unica de Valor) e a resposta a pergunta: "Por que eu deveria escolher voce e nao o concorrente?"
+
+## Criterios de uma boa PUV
+
+1. **Verdadeira** — Baseada em algo que a empresa realmente faz/tem, nao em aspiracao
+2. **Especifica** — Nao serve para nenhum concorrente copiar sem mentir
+3. **Relevante** — Resolve uma dor real do ICP (nao e um diferencial que ninguem pediu)
+4. **Memoravel** — O ICP consegue repetir para outra pessoa
+5. **Diferente** — Nenhum concorrente esta dizendo isso
+
+## 10 exemplos por segmento: PUV boa vs PUV ruim
+
+### 1. Clinica odontologica
+
+**RUIM:** "Tratamento odontologico de qualidade com tecnologia de ponta"
+- Por que falha: Generica. Toda clinica diz isso. Nao e especifica nem memoravel.
+
+**BOA:** "Implante dental em 1 dia com sedacao — voce entra com medo e sai com o sorriso pronto"
+- Por que funciona: Especifica (1 dia + sedacao), resolve a dor real (medo + demora), memoravel.
+
+### 2. Escritorio de contabilidade
+
+**RUIM:** "Solucoes contabeis completas para sua empresa crescer"
+- Por que falha: "Solucoes completas" nao diz nada. Qualquer contador pode dizer isso.
+
+**BOA:** "Contabilidade para e-commerces que faturam de R$ 50K a R$ 2M/mes — voce vende, a gente cuida do regime tributario que mais economiza"
+- Por que funciona: Nicho claro (e-commerce), faixa de faturamento (qualificacao), beneficio concreto (economia tributaria).
+
+### 3. Academia/studio fitness
+
+**RUIM:** "Transforme seu corpo e sua vida com nossos profissionais qualificados"
+- Por que falha: Aspiracional demais, generica, nao diferencia de nenhuma academia.
+
+**BOA:** "Treino personalizado de 45 minutos com turmas de no maximo 6 pessoas — resultado de personal, preco de academia"
+- Por que funciona: Formato especifico (45min, max 6), resolve o trade-off percebido (personal caro vs academia lotada).
+
+### 4. Restaurante delivery
+
+**RUIM:** "Comida feita com amor e ingredientes frescos"
+- Por que falha: Todos dizem isso. "Feita com amor" e irrelevante para a decisao de compra.
+
+**BOA:** "Marmita fitness que chega em 30 minutos com as macros calculadas no rotulo — para quem treina e nao tem tempo de cozinhar"
+- Por que funciona: Produto especifico (marmita fitness), prazo (30min), diferencial unico (macros no rotulo), ICP claro (quem treina).
+
+### 5. Agencia de marketing digital
+
+**RUIM:** "Estrategias de marketing digital personalizadas para o seu negocio"
+- Por que falha: Toda agencia diz exatamente isso. Zero especificidade.
+
+**BOA:** "Marketing digital para clinicas de estetica — geramos 30+ leads qualificados por mes ou voce nao paga a gestao"
+- Por que funciona: Nicho (clinicas estetica), metrica concreta (30+ leads), garantia (nao paga se nao entregar).
+
+### 6. Imobiliaria
+
+**RUIM:** "Encontre o imovel dos seus sonhos com atendimento personalizado"
+- Por que falha: Frase de corretor desde 1990. Nao diferencia nada.
+
+**BOA:** "Apartamentos de 1-2 quartos para investidores no centro de Curitiba — analise de rentabilidade inclusa antes de fechar"
+- Por que funciona: Produto nicho (1-2q, centro CWB), ICP claro (investidores), diferencial de servico (analise de rentabilidade).
+
+### 7. Software/SaaS B2B
+
+**RUIM:** "A plataforma completa para gestao do seu negocio"
+- Por que falha: "Plataforma completa" e o que todo SaaS diz. Nao define para quem ou para que.
+
+**BOA:** "ERP para oficinas mecanicas que controla estoque de pecas, ordem de servico e cobranca em um lugar so — sem planilha, sem papel"
+- Por que funciona: Vertical clara (oficinas), funcionalidades relevantes, dor concreta que resolve (planilha + papel).
+
+### 8. Clinica de estetica
+
+**RUIM:** "Realce sua beleza natural com tratamentos de ultima geracao"
+- Por que falha: Frases bonitas mas vazias. Nao diferencia de nenhuma clinica.
+
+**BOA:** "Harmonizacao facial com resultado natural em sessao unica — antes e depois publicado so com sua autorizacao"
+- Por que funciona: Procedimento especifico, promessa real (resultado natural, sessao unica), diferencial de confianca (fotos com autorizacao).
+
+### 9. Escola de idiomas
+
+**RUIM:** "Aprenda ingles com a melhor metodologia do mercado"
+- Por que falha: "Melhor metodologia" e uma afirmacao generica e nao verificavel.
+
+**BOA:** "Ingles para profissionais de TI — conversacao focada em daily standups, code review e entrevistas tecnicas em 6 meses"
+- Por que funciona: ICP claro (TI), situacoes reais (standup, review, entrevistas), prazo concreto (6 meses).
+
+### 10. Pet shop/veterinaria
+
+**RUIM:** "Cuidamos do seu pet com carinho e profissionalismo"
+- Por que falha: Qualquer pet shop pode dizer isso. "Carinho" nao e diferencial comercial.
+
+**BOA:** "Banho e tosa com hora marcada e entrega em domicilio — seu cachorro volta limpo sem voce sair de casa"
+- Por que funciona: Formato especifico (hora marcada + delivery), resolve dor real (deslocamento + espera), promessa clara.
+
+## Padroes das PUVs ruins
+
+1. **Adjetivos vazios:** "qualidade", "excelencia", "compromisso", "inovacao"
+2. **Frases de efeito:** "transforme sua vida", "realce sua beleza", "solucoes completas"
+3. **Sem ICP:** Nao diz para quem e — fala para todo mundo (e portanto para ninguem)
+4. **Sem especificidade:** Nenhum numero, prazo, formato ou garantia
+5. **Aspiracional vs factual:** Descreve o que gostariam de ser, nao o que sao
+
+## Padroes das PUVs boas
+
+1. **ICP explicito:** Menciona para quem e, direto na PUV
+2. **Metrica ou promessa concreta:** "30 leads", "45 minutos", "sessao unica", "6 meses"
+3. **Dor real resolvida:** Conecta com algo que o ICP sofre hoje
+4. **Formato ou mecanismo unico:** Como funciona, nao apenas o que faz
+5. **Trade-off resolvido:** Entrega algo que antes parecia incompativel (qualidade + preco, resultado + velocidade)
+
+## Como refinar uma PUV fraca
+
+1. Substitua adjetivos por numeros: "rapido" → "em 30 minutos"
+2. Adicione o ICP: "para todos" → "para clinicas que faturam R$ 50-200K/mes"
+3. Adicione a dor: "solucoes de marketing" → "para quem ja gastou com agencia e nao viu resultado"
+4. Adicione prova: "resultado garantido" → "ou devolvemos o fee de gestao"
+5. Teste: "meu concorrente poderia dizer isso sem mentir?" Se sim, refine mais.

--- a/.agents/skills/geral-posicionamento-estrategico/references/padrao-output.md
+++ b/.agents/skills/geral-posicionamento-estrategico/references/padrao-output.md
@@ -1,0 +1,202 @@
+# Padrão de Output das Skills — V4 Estruturação IA
+
+Este documento define a **estrutura canônica** que todos os outputs de skill devem seguir para renderizar no portal com hierarquia visual consistente. O objetivo é que o operador e o stakeholder final abram qualquer entregável e encontrem o mesmo ritmo: manchete → KPIs → achados categorizados → ponto de alavancagem destacado → detalhes expansíveis.
+
+---
+
+## Princípios
+
+1. **Manchete antes de texto.** Toda skill abre com uma frase única e específica que resume a conclusão. Não é parágrafo, é headline.
+2. **Números em destaque, não escondidos no corpo do texto.** KPIs que importam viram cards. Texto corrido é para contexto, não para fato quantitativo.
+3. **Achados categorizados por intenção.** Cada insight é classificado como `vantagem | contexto | ameaca | acao` — o leitor identifica o tom antes de ler.
+4. **Ponto de alavancagem visualmente isolado.** Toda skill tem UM ponto onde a conversa com o stakeholder precisa acontecer. Esse ponto ganha hero visual (border, gradient, quote destacada).
+5. **Detalhe denso → colapsável.** Listas longas (concorrentes, itens de checklist, fontes) ficam em `<details>` para não afogar a leitura.
+
+---
+
+## Campos obrigatórios no JSON
+
+Todo output de skill DEVE ter estes campos no topo (antes dos campos específicos da skill):
+
+```json
+{
+  "client_name": "Nome do Cliente",
+  "summary": "Resumo em 1-2 frases. Específico, com dados reais. Alimenta o resumo executivo do portal.",
+
+  "summary_headline": "Manchete em 1 linha (max 120 caracteres). A frase que o stakeholder lê primeiro.",
+
+  "summary_highlights": [
+    {
+      "category": "posicao | competicao | janela | maturidade | oportunidade | risco",
+      "label": "Rótulo curto (max 30 char)",
+      "value": "Valor em destaque (número, %, status)",
+      "subtext": "Contexto em 1 linha (max 60 char)",
+      "tone": "green | yellow | red | blue | gray"
+    }
+  ],
+
+  "summary_key_findings": [
+    {
+      "category": "vantagem | contexto | ameaca | acao",
+      "text": "Achado em 1-2 linhas. Específico, acionável."
+    }
+  ]
+}
+```
+
+### Regras dos campos de summary
+
+**`summary_headline`**: É a ÚNICA frase que o stakeholder precisa ler se só tiver 5 segundos. Deve conter o veredito da skill. Exemplos bons:
+- ✓ "[Cliente] é o ÚNICO player premium da microrregião com [diferencial declarado] — janela competitiva de 12-18 meses."
+- ✗ "Análise de mercado concluída com sucesso."
+
+**`summary_highlights`** (4-6 itens): KPIs visuais. Categorias sugeridas:
+- `posicao` — onde o cliente está hoje vs potencial
+- `competicao` — quem disputa o mesmo espaço
+- `janela` — tempo/urgência
+- `maturidade` — estágio atual em algum eixo
+- `oportunidade` — tamanho do ganho possível
+- `risco` — tamanho da ameaça
+
+Agrupar de 2 em 2 por categoria no renderer (dá layout balanceado 3x2 ou 2x2).
+
+**`summary_key_findings`** (3-5 itens): Achados que embasam a manchete. Categorias:
+- `vantagem` (✓ verde) — o que o cliente tem a favor
+- `contexto` (i azul) — o que é fato do mercado, neutro
+- `ameaca` (! vermelho) — o que pode dar errado
+- `acao` (▸ laranja) — o que precisa ser feito
+
+---
+
+## Ponto de Alavancagem (hero block)
+
+Toda skill deve identificar **UM bloco que merece destaque visual especial** — o ponto onde a conversa estratégica precisa acontecer. O nome do campo varia por skill, mas a estrutura é consistente:
+
+```json
+{
+  "key_leverage_point": {
+    "headline": "Frase-manchete do ponto (pode ir como quote)",
+    "context": "Contexto em 2-3 linhas explicando o cenário",
+    "numbered_reasons": [
+      "Razão 1 (parse-friendly, pode começar com texto direto)",
+      "Razão 2",
+      "Razão 3"
+    ],
+    "discussion_anchor": "Frase curta sobre POR QUE este é o ponto de conversa com o stakeholder"
+  }
+}
+```
+
+Exemplos por skill:
+- `pesquisa-mercado` → `unexploited_opportunity` (whitespace estratégico)
+- `persona-icp` → persona principal + dor mais ignorada
+- `swot` → combinação força × oportunidade mais assimétrica
+- `posicionamento` → PUV vs alternativas descartadas
+- `diagnostico-midia` → canal mais subotimizado + upside estimado
+- `diagnostico-maturidade` → pilar mais fraco com maior impacto
+
+O renderer aplica:
+- Border verde 2px + gradient sutil
+- Selo "Whitespace Estratégico · Discussão com Stakeholder" no topo
+- Pill de viabilidade/urgência à direita
+- Quote/headline em card branco isolado
+- Razões numeradas em 3 círculos
+- Footer "💬 Momento de validar com a stakeholder"
+
+---
+
+## Alerta de honestidade
+
+Se a pesquisa/análise revelou fragilidade do cliente (não há diferencial real, ICP mal definido, mercado saturado, etc.), inclua:
+
+```json
+{
+  "honesty_alert": "Texto explicando a fragilidade encontrada e o que precisa ser feito antes de seguir."
+}
+```
+
+Esse campo renderiza em box amarelo/vermelho após os achados. **Nunca omita** se a realidade justifica. O valor do sistema depende de não vender aspiracional como real.
+
+---
+
+## Instrução para a IA da skill
+
+Em cada `SKILL.md`, incluir esta seção na geração:
+
+> ### Estrutura visual (obrigatória)
+>
+> Além dos campos específicos desta skill, gere SEMPRE:
+>
+> - `summary_headline` — manchete em 1 linha com o veredito
+> - `summary_highlights` — 4-6 KPIs categorizados (`posicao|competicao|janela|maturidade|oportunidade|risco`) com `{label, value, subtext, tone}`
+> - `summary_key_findings` — 3-5 achados categorizados (`vantagem|contexto|ameaca|acao`)
+> - `honesty_alert` se houver fragilidade
+>
+> Identifique o **ponto de alavancagem** desta skill (o bloco que merece hero visual) e estruture-o com headline + contexto + razões numeradas + discussion anchor.
+>
+> Consulte `references/padrao-output.md` para especificação completa.
+
+E na auto-validação:
+
+> - [ ] Tem `summary_headline` específico (não "análise concluída")?
+> - [ ] `summary_highlights` tem 4-6 itens com categorias válidas?
+> - [ ] `summary_key_findings` cobre pelo menos 3 dos 4 tipos (vantagem/contexto/ameaça/ação)?
+> - [ ] Identificou o ponto de alavancagem para discussão com stakeholder?
+> - [ ] Se há fragilidade, incluiu `honesty_alert`?
+
+---
+
+## Completude (regra crítica)
+
+**Todo campo definido no schema da skill é obrigatório no output.** Não omitir campos — o renderer assume que os campos do schema existem e quebra/fica vazio silenciosamente quando faltam.
+
+Se um dado **não pode ser obtido** (GA4 não instalado, conector não conectado, cliente não sabe, etc.), preencher com `null` E adicionar `unavailable_reason` no objeto pai:
+
+```json
+{
+  "current_conversion_rate": null,
+  "current_bounce_rate": null,
+  "avg_time_on_page": null,
+  "unavailable_reason": "GA4 não instalado no site — métricas de analytics não coletadas nesta auditoria"
+}
+```
+
+Para arrays vazios legitimamente (ex: nenhum competidor identificado), preencher com `[]` e adicionar uma nota no campo irmão `{campo}_note`:
+
+```json
+{
+  "competitors": [],
+  "competitors_note": "Nenhum concorrente direto identificado na microrregião após busca em Google Maps + Instagram."
+}
+```
+
+Para valores **estimados** (sem fonte pública), adicionar flag `[E]` no texto OU campo `estimated: true` no objeto:
+
+```json
+{ "tam_brl": 450000000, "estimated": true, "estimation_basis": "IBGE população × SEBRAE ticket médio" }
+```
+
+**Nunca** deixar string vazia (`""`), zero falso (`0` quando não é zero real), ou omitir o campo. Essas três formas são invisíveis para o renderer e geram o bug "coluna vazia".
+
+Valide o JSON contra o `schema.json` empacotado na skill e corrija campos ausentes ou `null` sem `unavailable_reason`.
+
+### Checklist adicional de auto-validação
+
+> - [ ] Todos os campos do schema estão presentes (preenchidos ou com `null` + `unavailable_reason`)?
+> - [ ] Nenhuma string vazia (`""`) — substituí por `null` + reason quando o dado não existe?
+> - [ ] Arrays vazios legítimos têm `{campo}_note` explicando por quê?
+> - [ ] Estimativas marcadas com `estimated: true` ou `[E]`?
+
+---
+
+## Tons de voz
+
+- `green` — oportunidade/vantagem/confirmado
+- `yellow` — atenção/potencial/médio
+- `red` — risco/ameaça/fraco
+- `blue` — contexto/informativo/neutro
+- `gray` — desativado/aspiracional/ausente
+
+Usar tons consistentemente: nunca pintar ameaça de verde ou vantagem de vermelho para "chamar atenção". O tom é semântico.
+
+---

--- a/.agents/skills/geral-posicionamento-estrategico/references/territorio-de-marca.md
+++ b/.agents/skills/geral-posicionamento-estrategico/references/territorio-de-marca.md
@@ -1,0 +1,121 @@
+# Territorio de Marca
+
+## O que e territorio de marca
+
+Territorio de marca e o espaco mental que uma empresa ocupa na cabeca do ICP. E a associacao automatica que o cliente faz quando pensa em uma categoria ou situacao.
+
+**Exemplo classico:**
+- Volvo → Seguranca
+- Apple → Design + Simplicidade
+- Red Bull → Energia + Aventura
+- Nubank → Simplicidade + Descomplicar
+
+**Para PMEs brasileiras, o territorio e mais simples mas igualmente poderoso:**
+- Clinica X → "A do implante em 1 dia"
+- Agencia Y → "Os caras que so atendem restaurante"
+- Contabilidade Z → "Os que entendem de e-commerce"
+
+## Por que importa para PMEs
+
+PMEs nao tem budget para construir marca com awareness massivo. O territorio de marca funciona como um ATALHO: em vez de tentar ser "conhecida por todos", a marca se torna "a primeira opcao para [situacao especifica]".
+
+**O territorio gera:**
+1. **Recall:** O ICP lembra de voce quando tem o problema
+2. **Referral:** O ICP sabe explicar para outros por que voce e diferente
+3. **Premium:** Quem ocupa um territorio pode cobrar mais (especialista > generalista)
+4. **Consistencia:** Toda comunicacao gira em torno do mesmo eixo
+
+## Como definir o territorio
+
+### Passo 1: Mapeie os territorios dos concorrentes
+
+Para cada concorrente, identifique:
+- Que associacao o ICP tem com essa marca?
+- Se alguem perguntasse "o que [concorrente] faz de diferente?", o que a resposta seria?
+- Quais palavras/conceitos eles repetem na comunicacao?
+
+**Exemplos de territorios comuns por segmento:**
+
+| Segmento | Territorios tipicos |
+|---|---|
+| Odontologia | Tecnologia / Humanizacao / Rapidez / Especializacao |
+| Estetica | Naturalidade / Resultado / Exclusividade / Bem-estar |
+| Contabilidade | Economia tributaria / Simplicidade / Digital / Especializacao setorial |
+| Academia | Performance / Comunidade / Resultado / Acessibilidade |
+| Marketing digital | Resultado / Criatividade / Dados / Especializacao vertical |
+| Alimentacao | Sabor / Saude / Conveniencia / Artesanal |
+| Imobiliario | Investimento / Sonho / Localizacao / Seguranca |
+| Educacao | Pratica / Certificacao / Comunidade / Metodologia |
+
+### Passo 2: Identifique territorios disponiveis
+
+Um territorio esta disponivel se:
+1. Nenhum concorrente direto o ocupa com forca
+2. E relevante para o ICP (resolve uma dor ou desejo real)
+3. E verdadeiro para o cliente (ele pode sustentar esse geral-posicionamento-estrategico)
+
+**ATENCAO:** Um territorio "generico" como "qualidade" ou "comprometimento" nao e territorio — e ruido. Todo mundo diz isso. Territorio precisa ser ESPECIFICO e DIFERENCIANTE.
+
+### Passo 3: Defina em 3 palavras
+
+O territorio de marca deve ser expressavel em 3 palavras que formam uma combinacao unica.
+
+**Formula:** [Atributo funcional] + [Atributo emocional] + [Atributo diferenciador]
+
+**Exemplos:**
+| Cliente | 3 Palavras | Significado |
+|---|---|---|
+| Clinica odonto | Rapidez + Confianca + Tecnologia | "Faz rapido, com seguranca, usando o que ha de melhor" |
+| Agencia mkt restaurantes | Resultado + Especializacao + Simplicidade | "Entende de restaurante, entrega numero, sem complicacao" |
+| Contabilidade e-commerce | Digital + Economia + Escala | "Tudo online, paga menos imposto, acompanha seu crescimento" |
+| Studio fitness | Intensidade + Comunidade + Resultado | "Treino puxado, galera que empurra, corpo que muda" |
+| Pet shop delivery | Conveniencia + Cuidado + Confianca | "Sem sair de casa, feito com atencao, voce confia" |
+
+### Passo 4: Valide a disponibilidade
+
+**Perguntas de validacao:**
+1. Algum concorrente FORTE ja usa essas 3 palavras (mesmo que com outras)? → Se sim, mude.
+2. O ICP se importa com essas 3 dimensoes? → Se nao, mude.
+3. O cliente PODE sustentar isso com evidencia? → Se nao, mude.
+4. E possivel construir comunicacao (copy, criativos, LP) em torno disso? → Se nao, mude.
+
+## Como "ownar" um territorio
+
+Definir o territorio e so o comeco. Para que o ICP associe sua marca a ele:
+
+### Na comunicacao:
+- Toda headline deve reforcar o territorio
+- Copy de anuncios repete os conceitos (sem ser repetitiva na forma)
+- Depoimentos de clientes devem refletir o territorio (selecione os que mencionam as palavras-chave)
+
+### No produto/servico:
+- A experiencia do cliente deve ser consistente com o territorio
+- Se o territorio e "rapidez", o tempo de resposta no WhatsApp precisa ser rapido
+- Se e "especializacao", nao aceite clientes fora do nicho
+
+### Na identidade visual:
+- Cores, tipografia e estilo visual devem traduzir o territorio
+- "Confianca + Tecnologia" pede visual limpo, moderno, tons de azul/preto
+- "Comunidade + Energia" pede visual vibrante, fotos de pessoas, tons quentes
+
+### No atendimento:
+- O tom de atendimento precisa refletir o territorio
+- "Proximo + Humano" → Responde com nome, emoji, audio
+- "Profissional + Tecnico" → Responde com dados, links, relatorios
+
+## Erros comuns
+
+### Erro 1: Territorio generico
+"Qualidade + Compromisso + Inovacao" → Nao diferencia nada. Todo mundo diz isso.
+
+### Erro 2: Territorio aspiracional
+Querer "ownar" algo que a empresa nao e de verdade. Se o territorio e "Tecnologia" mas o site e de 2018 e nao tem automacao nenhuma, ha incoerencia.
+
+### Erro 3: Territorio do concorrente
+Tentar disputar o mesmo territorio de um concorrente mais forte. Se o concorrente 1 ja e "o especialista em X", voce precisa de outro angulo.
+
+### Erro 4: Territorio irrelevante
+Escolher algo que o ICP nao valoriza. Se o ICP e sensivel a preco e voce escolhe "Exclusividade + Premium", ha desconexao.
+
+### Erro 5: Nao usar o territorio
+Definir e nunca aplicar. O territorio precisa aparecer em TUDO: site, anuncios, proposta comercial, assinatura de email, post no Instagram.

--- a/.agents/skills/geral-posicionamento-estrategico/schema.json
+++ b/.agents/skills/geral-posicionamento-estrategico/schema.json
@@ -1,0 +1,455 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Posicionamento",
+  "description": "Output estruturado do canvas de posicionamento estrategico: declaracoes, PUV, canvas 4P, territorio de marca e taglines.",
+  "type": "object",
+  "required": [
+    "summary",
+    "client_name",
+    "positioning_statements",
+    "chosen_statement",
+    "puv",
+    "canvas_4p",
+    "brand_territory",
+    "taglines",
+    "recommended_tagline",
+    "summary_headline",
+    "summary_highlights",
+    "summary_key_findings"
+  ],
+  "properties": {
+    "client_name": {
+      "type": "string",
+      "description": "Nome do cliente"
+    },
+    "summary": {
+      "type": "string",
+      "description": "Resumo de 1-2 frases do posicionamento estratégico. Inclui PUV definida e território de marca escolhido."
+    },
+    "summary_headline": {
+      "type": "string",
+      "maxLength": 200,
+      "description": "Manchete com o veredito do posicionamento em 1 frase (ex: '[Cliente] ocupa território [Especialista Premium do nicho] — janela de 12-18 meses antes da concorrência chegar')."
+    },
+    "summary_highlights": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 8,
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "label",
+          "value"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "posicao",
+              "competicao",
+              "janela",
+              "maturidade",
+              "oportunidade",
+              "risco"
+            ]
+          },
+          "label": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "subtext": {
+            "type": "string"
+          },
+          "tone": {
+            "type": "string",
+            "enum": [
+              "green",
+              "yellow",
+              "red",
+              "blue",
+              "gray"
+            ]
+          }
+        }
+      }
+    },
+    "summary_key_findings": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 6,
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "text"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "vantagem",
+              "contexto",
+              "ameaca",
+              "acao"
+            ]
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "positioning_map": {
+      "type": "object",
+      "description": "Mapa de posicionamento competitivo 2x2",
+      "properties": {
+        "axis_x": {
+          "type": "string",
+          "description": "Label do eixo horizontal"
+        },
+        "axis_y": {
+          "type": "string",
+          "description": "Label do eixo vertical"
+        },
+        "client_position": {
+          "type": "string",
+          "description": "Quadrante recomendado para o cliente"
+        },
+        "justification": {
+          "type": "string",
+          "description": "Justificativa para a posicao recomendada"
+        },
+        "competitor_positions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "quadrant": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "positioning_statements": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "statement",
+          "justification"
+        ],
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Nome/direcao da opcao (ex: O Especialista)"
+          },
+          "statement": {
+            "type": "string",
+            "description": "Declaracao de posicionamento no formato classico"
+          },
+          "justification": {
+            "type": "string",
+            "description": "Justificativa da opcao"
+          },
+          "bet": {
+            "type": "string",
+            "description": "O que esta opcao prioriza"
+          },
+          "risk": {
+            "type": "string",
+            "description": "Onde pode falhar"
+          }
+        }
+      },
+      "description": "3 opcoes de declaracao de posicionamento"
+    },
+    "chosen_statement": {
+      "type": "string",
+      "description": "Declaracao de posicionamento escolhida pelo operador (pode ser uma das 3 ou refinada)"
+    },
+    "puv": {
+      "type": "string",
+      "description": "Proposta Unica de Valor em 1 frase. Deve ser verdadeira, especifica, relevante, memoravel e diferente."
+    },
+    "canvas_4p": {
+      "type": "object",
+      "required": [
+        "product",
+        "price",
+        "place",
+        "promotion"
+      ],
+      "description": "Canvas de posicionamento estrategico nos 4Ps",
+      "properties": {
+        "product": {
+          "type": "object",
+          "required": [
+            "delivers",
+            "transformation",
+            "doesnt_deliver"
+          ],
+          "properties": {
+            "delivers": {
+              "type": "string",
+              "description": "O que entregamos de verdade (alem das features)"
+            },
+            "transformation": {
+              "type": "string",
+              "description": "Qual transformacao o cliente vive (antes e depois)"
+            },
+            "doesnt_deliver": {
+              "type": "string",
+              "description": "O que NAO entregamos (delimitacao honesta)"
+            }
+          }
+        },
+        "price": {
+          "type": "object",
+          "required": [
+            "positioning",
+            "justification"
+          ],
+          "properties": {
+            "positioning": {
+              "type": "string",
+              "enum": [
+                "premium",
+                "mid-market",
+                "value"
+              ],
+              "description": "Posicionamento de preco em relacao ao mercado"
+            },
+            "justification": {
+              "type": "string",
+              "description": "Justificativa do preco na comunicacao"
+            },
+            "anchoring": {
+              "type": "string",
+              "description": "Estrategia de ancoragem de valor (se aplicavel)"
+            }
+          }
+        },
+        "place": {
+          "type": "object",
+          "required": [
+            "main_channel",
+            "support_channel",
+            "avoid_channels"
+          ],
+          "properties": {
+            "main_channel": {
+              "type": "string",
+              "description": "Canal principal de aquisicao recomendado"
+            },
+            "main_channel_justification": {
+              "type": "string",
+              "description": "Por que este canal para este ICP"
+            },
+            "support_channel": {
+              "type": "string",
+              "description": "Canal de suporte/secundario"
+            },
+            "avoid_channels": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "channel",
+                  "reason"
+                ],
+                "properties": {
+                  "channel": {
+                    "type": "string"
+                  },
+                  "reason": {
+                    "type": "string"
+                  }
+                }
+              },
+              "description": "Canais a evitar e por que"
+            }
+          }
+        },
+        "promotion": {
+          "type": "object",
+          "required": [
+            "tone",
+            "top_funnel_message",
+            "bottom_funnel_message"
+          ],
+          "properties": {
+            "tone": {
+              "type": "string",
+              "description": "Tom e estilo de comunicacao"
+            },
+            "top_funnel_message": {
+              "type": "string",
+              "description": "Mensagem de entrada no funil (awareness)"
+            },
+            "bottom_funnel_message": {
+              "type": "string",
+              "description": "Mensagem de conversao (decision)"
+            }
+          }
+        }
+      }
+    },
+    "brand_territory": {
+      "type": "object",
+      "required": [
+        "three_words",
+        "description",
+        "competitor_territories"
+      ],
+      "properties": {
+        "three_words": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 3,
+          "maxItems": 3,
+          "description": "3 palavras que definem o territorio de marca"
+        },
+        "description": {
+          "type": "string",
+          "description": "O que o territorio significa na pratica"
+        },
+        "competitor_territories": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "competitor",
+              "territory"
+            ],
+            "properties": {
+              "competitor": {
+                "type": "string"
+              },
+              "territory": {
+                "type": "string"
+              }
+            }
+          },
+          "description": "Territorios ja ocupados pelos concorrentes"
+        },
+        "availability_justification": {
+          "type": "string",
+          "description": "Por que o territorio escolhido esta disponivel"
+        }
+      }
+    },
+    "taglines": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "tagline",
+          "justification"
+        ],
+        "properties": {
+          "tagline": {
+            "type": "string",
+            "description": "Texto da tagline"
+          },
+          "tone": {
+            "type": "string",
+            "description": "Tom da tagline"
+          },
+          "justification": {
+            "type": "string",
+            "description": "Por que funciona"
+          },
+          "best_use": {
+            "type": "string",
+            "description": "Onde usar (site, assinatura, anuncios)"
+          }
+        }
+      },
+      "description": "3 opcoes de tagline"
+    },
+    "recommended_tagline": {
+      "type": "string",
+      "description": "Tagline recomendada (escolhida pelo operador)"
+    },
+    "operator_direction": {
+      "type": "object",
+      "description": "Direcoes escolhidas pelo operador durante a co-criacao",
+      "properties": {
+        "strongest_differential": {
+          "type": "string",
+          "description": "Diferencial mais forte segundo o operador"
+        },
+        "desired_position": {
+          "type": "string",
+          "description": "Posicao desejada no mapa competitivo"
+        },
+        "positioning_restrictions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "O que o cliente NAO quer ser associado"
+        },
+        "desired_tone": {
+          "type": "string",
+          "description": "Tom de comunicacao desejado"
+        }
+      }
+    },
+    "completed_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Data/hora de conclusao"
+    },
+    "key_insight": {
+      "type": "object",
+      "description": "Ponto de alavancagem — território × janela de oportunidade.",
+      "required": [
+        "headline",
+        "context",
+        "numbered_reasons",
+        "discussion_anchor"
+      ],
+      "properties": {
+        "headline": {
+          "type": "string"
+        },
+        "context": {
+          "type": "string"
+        },
+        "numbered_reasons": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 5,
+          "items": {
+            "type": "string"
+          }
+        },
+        "discussion_anchor": {
+          "type": "string"
+        },
+        "feasibility": {
+          "type": "string"
+        }
+      }
+    },
+    "honesty_alert": {
+      "type": "string",
+      "description": "Alerta de honestidade: território aspiracional, diferencial não ainda construído, ou risco de posicionamento forçado."
+    }
+  }
+}

--- a/.claude/skills/geral-analise-swot/SKILL.md
+++ b/.claude/skills/geral-analise-swot/SKILL.md
@@ -1,0 +1,253 @@
+---
+name: geral-analise-swot
+description: "Análise de Concorrentes + Matriz SWOT estratégica: scorecard digital dos concorrentes (com evidência), SWOT acionável, matriz TOWS, cenários e priorização em Gantt de 90 dias. Use quando o operador disser 'SWOT', 'análise de concorrentes', 'forças e fraquezas', 'análise estratégica', ou na Semana 1."
+area: geral
+author: luizfreitasv4
+version: 1.0.0
+dependencies:
+  - geral-persona-icp
+outputs: ["geral-analise-swot.json"]
+week: 1
+estimated_time: "1h"
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta versao foi portada do sistema de Estruturacao Estrategica. As regras abaixo tem precedencia sobre caminhos e persistencia citados no fluxo original:
+
+- Trabalhe somente em `squads/{squad}/clientes/{cliente}/`, nunca em um diretorio `clientes/` solto na raiz.
+- Leia primeiro o `CLAUDE.md` ou `AGENTS.md` da KB, `mission-control/`, `calls/`, `docs/` e `campanhas/`.
+- Se `client.json` existir, use-o como fonte complementar. Se nao existir, derive o contexto da KB e do Mission Control; nao exija nem invente esse arquivo.
+- Salve entregaveis em `squads/{squad}/clientes/{cliente}/outputs/`, em JSON e Markdown quando o fluxo pedir ambos.
+- Registre decisoes e progresso no `mission-control/historico-checkins.md` ou no arquivo de historico equivalente encontrado na KB.
+- Resolva recursos empacotados a partir do proprio diretorio desta skill. Se uma integracao externa nao estiver configurada, declare o gap e continue apenas com os dados reais disponiveis.
+
+
+# Análise de Concorrentes + Matriz SWOT (POP 1.5)
+
+Você é um estrategista de negócios sênior. Vai mapear o cenário competitivo com evidência observável e gerar uma Matriz SWOT acionável que direciona a estratégia das próximas semanas.
+
+> **Posição no fluxo:** Semana 1 (POP 1.5). Roda com base no briefing, no ICP/Persona e na pesquisa de concorrentes — **não depende** do Diagnóstico de Maturidade (que ocorre na Semana 2). Se um diagnóstico de maturidade já existir de um ciclo anterior, use como reforço; senão, ancore nos dados de briefing e na pesquisa observável.
+
+> **REGRA DE OURO:** Cada item da SWOT deve ser específico para ESTE cliente. Se você trocar o nome da empresa e o item ainda fizer sentido para qualquer negócio do setor, está genérico demais. Refaça.
+
+## Dados necessários
+
+Leia os seguintes arquivos do diretório do cliente:
+
+1. `client.json` (seção `briefing`) — dados base do cliente (OBRIGATÓRIO)
+2. `outputs/geral-persona-icp.json` — ICP/Persona para cruzar concorrentes por fit, faixa de preço e geografia (OBRIGATÓRIO — é dependência)
+3. `client.json` (seção `connectors`) — dados V4MOS se disponíveis
+4. `outputs/gt-diagnostico-maturidade-digital.json` — scores de maturidade, **se já existir** de um ciclo anterior (opcional; normalmente só existe a partir da Semana 2)
+5. `client.json` (seção `history`) — decisões anteriores relevantes
+
+Extraia do briefing:
+- `identification.name` → nome do cliente
+- `identification.segment` → setor
+- `identification.revenue` → faturamento (se disponível)
+- `identification.years_in_market` → tempo de mercado
+- `product.main_product` → produtos/serviços
+- `product.differentials` → diferenciais declarados pelo cliente
+- `competition.competitors` → lista de concorrentes
+- `competition.differentials` → diferencial real vs concorrentes
+
+Do diagnóstico de maturidade (SE já existir — opcional na Semana 1):
+- `overall_score`, `pillar_scores`, `priorities`, `sector_benchmark` → reforçam forças/fraquezas digitais
+- Se não existir ainda, derive forças/fraquezas digitais do `briefing.digital_situation` e da pesquisa observável dos canais do cliente.
+
+Se não encontrar informações sobre concorrência no client.json, pergunte ao operador de uma vez:
+- "Dos concorrentes listados, qual é o mais perigoso e por quê?"
+- "Tem algum concorrente que faz algo melhor que o cliente? O quê?"
+- "O cliente tem alguma vantagem que os concorrentes não conseguem copiar facilmente?"
+- "Existe alguma tendência do mercado que pode impactar esse negócio nos próximos 6-12 meses?"
+- "O cliente depende muito de algum canal ou fornecedor?"
+
+---
+
+## Geração
+
+Gere o output COMPLETO de uma vez usando os dados de `client.json` (briefing, connectors) e outputs de skills dependentes em `outputs/`.
+
+Consulte `references/exemplos-swot-bom-vs-ruim.md` para calibrar a especificidade.
+
+### Análise de Concorrentes (scorecard digital) — PRIMEIRO PASSO
+
+Antes da SWOT, mapeie o cenário competitivo com **evidência observável** (não percepção). É a base factual que alimenta forças/fraquezas/ameaças.
+
+1. **Selecione 3-5 concorrentes diretos + 1-2 indiretos/aspiracionais.** Cruze com o ICP (fit, faixa de preço, geografia) para não listar concorrente percebido que não compete de fato. Valide a lista com o operador.
+2. **Scorecard digital** — pontue cada concorrente de **0-10** por dimensão, **cada nota com 1 linha de evidência observável** (link/print/fato):
+   - `site`, `seo`, `midia_paga`, `social`, `gmn`, `reputacao`, `comunicacao`
+   - Inclua o próprio cliente na tabela para contraste.
+3. **Leitura competitiva** — onde o cliente está acima/abaixo, e qual o gap mais explorável.
+
+Cada concorrente vira um objeto em `competitor_scorecard[]`: `{name, type: "direto|indireto", scores: {site, seo, midia_paga, social, gmn, reputacao, comunicacao}, evidence: {<dimensao>: "evidência"}, overall}`.
+
+> Regra: nota sem evidência observável não entra. Se não conseguir evidência, marque a dimensão como `null` + motivo.
+
+### Forças (Strengths) — 4-6 itens
+Fatores INTERNOS positivos. Busque em:
+- Diagnóstico digital: pilares com score acima da média do setor
+- Briefing: diferenciais declarados que são REAIS (valide com dados)
+- Tempo de mercado / base de clientes existente
+- Equipe / expertise interna
+- Localização / infraestrutura
+
+Para cada força, inclua:
+- **Título:** frase curta e específica
+- **Descrição:** evidência concreta que sustenta essa força (use dados do diagnóstico quando possível)
+- **Implicação estratégica:** como essa força pode ser ALAVANCADA na estratégia
+
+### Fraquezas (Weaknesses) — 4-6 itens
+Fatores INTERNOS negativos. Busque em:
+- Diagnóstico digital: pilares com score abaixo da média do setor
+- Gaps identificados no diagnóstico
+- Limitações de equipe / budget / conhecimento
+- Dependências perigosas
+
+Para cada fraqueza:
+- **Título:** frase curta e específica
+- **Descrição:** evidência concreta
+- **Implicação estratégica:** qual o risco se não for tratada E como mitigar
+
+### Oportunidades (Opportunities) — 4-6 itens
+Fatores EXTERNOS positivos. Busque em:
+- Tendências do setor favoráveis
+- Gaps dos concorrentes
+- Canais não explorados
+- Mudanças de comportamento do consumidor
+- Tecnologia acessível (IA, automação)
+
+Para cada oportunidade:
+- **Título:** frase curta e específica
+- **Descrição:** por que essa oportunidade existe AGORA
+- **Implicação estratégica:** como capturar essa oportunidade
+
+### Ameaças (Threats) — 4-6 itens
+Fatores EXTERNOS negativos. Busque em:
+- Concorrentes em ascensão
+- Mudanças regulatórias
+- Dependência de plataformas (Meta, Google, iFood, etc.)
+- Mudanças de algoritmo / custos de mídia
+- Saturação de mercado
+
+Para cada ameaça:
+- **Título:** frase curta e específica
+- **Descrição:** evidência de que essa ameaça é real
+- **Implicação estratégica:** como se proteger ou mitigar
+
+### Síntese Estratégica (2-3 parágrafos)
+
+Cruze os quadrantes para responder: "Qual é a jogada mais inteligente que este negócio pode fazer AGORA?"
+
+Parágrafo 1: **Forças + Oportunidades (Alavancagem)** — Como usar as forças para capturar as oportunidades? Esta é a aposta principal.
+
+Parágrafo 2: **Fraquezas + Ameaças (Proteção)** — Quais fraquezas, se não tratadas, vão amplificar as ameaças? Este é o risco principal.
+
+Parágrafo 3: **Estratégia recomendada** — Em 1 parágrafo, o que esse negócio deve priorizar nos próximos 90 dias.
+
+### Matriz TOWS (OBRIGATÓRIA — cruzamento estratégico)
+
+Derive estratégias específicas cruzando os quadrantes. Não é redundância da SWOT — é onde a análise vira ação. Gere 2-3 estratégias por célula:
+
+- **SO (Forças × Oportunidades) — Estratégias Ofensivas:** use a força X para capturar a oportunidade Y. Onde o cliente ATACA.
+- **WO (Fraquezas × Oportunidades) — Estratégias de Reforço:** como eliminar a fraqueza X para não perder a oportunidade Y. Onde o cliente INVESTE.
+- **ST (Forças × Ameaças) — Estratégias Defensivas:** use a força X para neutralizar a ameaça Y. Onde o cliente PROTEGE.
+- **WT (Fraquezas × Ameaças) — Estratégias de Sobrevivência:** o pior cenário. O que fazer para reduzir a fraqueza X que se amplifica com a ameaça Y. Onde o cliente MINIMIZA DANO.
+
+Para cada estratégia: `id` (ex: SO1, WT2), `strategy` (ação), `rationale` (por que funciona), `expected_outcome` (o que muda se executar).
+
+### Ações Prioritárias (5-7 ações) — com risk-adjusted scoring
+
+Derive ações concretas da SWOT/TOWS. Para cada:
+1. **Ação** — o que fazer (específico)
+2. **Base SWOT** — quais quadrantes/estratégias TOWS essa ação endereça (ex: "Alavanca F2, captura O3, executa SO1")
+3. **Impacto** — alto/médio/baixo
+4. **Prazo sugerido** — semana 1/2/3 da estruturação
+5. **Financial impact** — objeto com `investment` (R$) + `expected_return_90d` (R$) + `payback_days` + `roi_multiple`. Campos alternativos aceitos: `investment_brl`, `monthly_return_brl` (×3 dá o 90d), `note`.
+6. **Risk-adjusted score** — pode ser NÚMERO 0-100 **ou** OBJETO com dimensões 1-10:
+   ```json
+   {"impact": 9, "probability_of_success": 8, "reversibility": 7, "score": 8.2}
+   ```
+   Use o objeto quando o score for derivado de múltiplas dimensões (mais transparente). O campo `score` é obrigatório.
+7. **Dependência** — se depende de alguma outra ação ou skill
+
+Ordene as ações por risk_adjusted_score (maior primeiro).
+
+> **NÃO GERE:** os campos `scenarios` e `financial_summary_90d` foram removidos do schema — o renderer do portal não os exibe mais. Projeções de cenários vivem em `gt-diagnostico-midia-paga` (budget_reallocation_scenarios). A consolidação financeira é redundante com `priority_actions[].financial_impact`, que o portal já agrega.
+
+### Estrutura visual (obrigatória)
+
+Siga o padrão canônico de `references/padrao-output.md`. Além dos campos acima, SEMPRE inclua:
+
+- **`summary_headline`** (max 200 char) — manchete com o veredito da SWOT. Ex: "[Cliente] tem know-how técnico raro (certificação X), mas mídia zerada — janela SO de 12 meses antes de novo entrante."
+- **`summary_highlights`** (4-6 itens, `{category, label, value, subtext, tone}`) — para SWOT sugestões:
+  - `posicao`: score SWOT líquido, nº de forças vs fraquezas
+  - `oportunidade`: top priority action com ROI projetado, payback
+  - `risco`: ameaça de maior impacto
+  - `janela`: tempo até janela fechar / urgência
+- **`summary_key_findings`** (3-5 itens, `{category, text}`) — `vantagem|contexto|ameaca|acao` — cubra pelo menos 3 dos 4.
+
+### Ponto de alavancagem
+
+Em SWOT, o ponto de alavancagem é a **combinação Força × Oportunidade mais assimétrica** (quadrante SO com maior risk_adjusted_score). Estruture em `key_insight`:
+```json
+"key_insight": {
+  "headline": "Cruzamento F×O em 1 frase (pode virar quote)",
+  "context": "2-3 linhas sobre por que esta combinação é única",
+  "numbered_reasons": ["(1) força específica...", "(2) oportunidade específica...", "(3) timing/janela..."],
+  "discussion_anchor": "Por que o stakeholder precisa decidir sobre apetite e ritmo"
+}
+```
+
+Se SWOT revelou fragilidade estrutural (mais ameaças que forças, ausência de diferencial real), inclua `honesty_alert`.
+
+## Auto-validação
+
+Antes de mostrar ao operador, verifique:
+
+- [ ] Mencionou o cliente pelo nome?
+- [ ] Usou dados reais do client.json (não inventou)?
+- [ ] Nenhum item genérico (ex: "quer crescer", "qualidade e compromisso")?
+- [ ] Schema da skill validou?
+- [ ] Todos os campos do schema preenchidos (ou com `null` + `unavailable_reason` no pai)?
+- [ ] Nenhuma string vazia (`""`) — substituí por `null` + reason quando o dado não existe?
+- [ ] Estimativas marcadas com `estimated: true` ou `[E]`?
+- [ ] `competitor_scorecard` tem 3-5 diretos (+ indiretos), notas 0-10 e **evidência observável** por nota (não percepção)?
+- [ ] Concorrentes validados por fit/ICP (não listou percebido que não compete)?
+- [ ] Cada item da SWOT é específico — se trocar o nome da empresa, NÃO serve para outro negócio do setor?
+- [ ] Síntese cruza quadrantes (não é apenas resumo)?
+- [ ] Ações derivam dos quadrantes (referência F/W/O/T explícita)?
+- [ ] Matriz TOWS tem pelo menos 2 estratégias por célula (SO, WO, ST, WT)?
+- [ ] Cada priority_action tem `financial_impact` (investment, return, payback, ROI) e `risk_adjusted_score`?
+- [ ] Priority_actions estão ORDENADAS por risk_adjusted_score (maior primeiro)?
+- [ ] NÃO gerou `scenarios` nem `financial_summary_90d` (removidos do schema)?
+- [ ] Tem `summary_headline` específico?
+- [ ] `summary_highlights` tem 4-6 itens com categorias e tons válidos?
+- [ ] `summary_key_findings` cobre pelo menos 3 dos 4 tipos?
+- [ ] Identificou `key_insight` (cruzamento SO mais assimétrico) para stakeholder?
+- [ ] Se há fragilidade estrutural, incluiu `honesty_alert`?
+
+Se falhou → regenere silenciosamente. Não avise o operador.
+
+## Apresentação e decisões
+
+Apresente o output COMPLETO ao operador em formato visual claro (tabela ou lista organizada por quadrante).
+
+Revise o output. O que está errado, exagerado ou faltando?
+
+- "Algum item está genérico demais? (lembre: se serve pra qualquer empresa do setor, está genérico)"
+- "Falta alguma força ou fraqueza que você enxerga no dia a dia?"
+- "Alguma oportunidade ou ameaça que eu não considerei?"
+- "A síntese captura a essência do que o cliente precisa fazer?"
+- "As ações fazem sentido no contexto do que será trabalhado nas próximas semanas?"
+- "Quer ajustar a priorização?"
+
+## Finalização
+
+Operador aprova (com ou sem ajustes).
+1. Salve em `squads/{squad}/clientes/{cliente}/outputs/geral-analise-swot.json` (com campo `summary` no topo)
+2. Atualize `client.json`: progress.skills → completed, version++, append em history[]
+3. Salve também uma versão Markdown do entregável na mesma pasta de outputs.
+4. Sugira próxima skill do dependency_graph
+   - "SWOT salva. Este output será usado pela skill geral-posicionamento-estrategico (semana 2) e como referência para todas as skills de produção."
+   - Sugira a próxima skill da semana 1 (account-auditoria-comunicacao ou geral-persona-icp se ainda não feita)

--- a/.claude/skills/geral-analise-swot/references/exemplos-swot-bom-vs-ruim.md
+++ b/.claude/skills/geral-analise-swot/references/exemplos-swot-bom-vs-ruim.md
@@ -1,0 +1,160 @@
+# SWOT: Exemplos de Itens Específicos vs Genéricos
+
+O maior erro em análise SWOT é ser genérico. Uma SWOT genérica não serve para tomar decisão nenhuma. Este documento calibra o que é aceito e o que deve ser refeito.
+
+---
+
+## O Teste de Especificidade
+
+Para cada item da SWOT, aplique este teste:
+
+> **Se eu trocar o nome da empresa por qualquer concorrente do mesmo setor, o item ainda faz sentido?**
+> - Se SIM → está GENÉRICO. Refaça.
+> - Se NÃO → está específico. Aprovado.
+
+---
+
+## Exemplo 1: Clínica de Estética (Curitiba)
+
+### FORÇAS
+
+| RUIM (genérico) | BOM (específico) |
+|------------------|-------------------|
+| "Equipe qualificada" | "Dra. Marina é referência em harmonização facial natural no PR, com 12K seguidores orgânicos e lista de espera de 3 semanas" |
+| "Localização privilegiada" | "Localizada no Batel (bairro nobre), a 200m do Shopping Pátio Batel — 80% dos clientes citam proximidade como fator de escolha" |
+| "Bom atendimento" | "NPS de 92 medido mensalmente. 67% dos clientes vieram por indicação. Taxa de retorno para segundo procedimento: 45% em 6 meses" |
+| "Variedade de serviços" | "Única clínica da região que combina dermatologia + estética + nutrologia no mesmo espaço, permitindo protocolo integrado" |
+
+### FRAQUEZAS
+
+| RUIM (genérico) | BOM (específico) |
+|------------------|-------------------|
+| "Marketing fraco" | "Score de mídia paga 22/100 — roda R$3k/mês no Meta sem pixel configurado, CPA de R$180 (3x a média do setor)" |
+| "Falta de tecnologia" | "Agendamento é por WhatsApp manual. 30% dos contatos não são respondidos em 24h. Sem CRM — leads se perdem entre as 3 recepcionistas" |
+| "Pouca presença digital" | "Instagram com 2.4K seguidores, frequência irregular (2-3 posts/mês). Nenhum conteúdo de bastidores ou resultado. Concorrente principal tem 18K seguidores" |
+| "Precisa melhorar processos" | "Protocolo de follow-up pós-procedimento é informal — pacientes só voltam se ligarem por conta própria. Sem automação de reativação" |
+
+### OPORTUNIDADES
+
+| RUIM (genérico) | BOM (específico) |
+|------------------|-------------------|
+| "Mercado em crescimento" | "Mercado de estética em Curitiba cresceu 23% em 2025. Busca por 'harmonização facial Curitiba' aumentou 47% no Google Trends vs. ano anterior" |
+| "Usar redes sociais" | "Reels de antes/depois geram 5-10x mais engajamento que posts regulares no nicho. Concorrentes locais não exploram UGC de pacientes (oportunidade de diferenciação)" |
+| "Expandir serviços" | "Pacientes frequentes perguntam por bioestimuladores de colágeno (Sculptra) — procedimento de ticket R$3-5k que a clínica ainda não oferece mas a Dra. Marina é habilitada" |
+| "Atrair novos clientes" | "40% da base mora no Batel/Água Verde. Campanha geo-localizada no Meta para raio de 5km nunca foi feita — concorrente X captura esse tráfego local" |
+
+### AMEAÇAS
+
+| RUIM (genérico) | BOM (específico) |
+|------------------|-------------------|
+| "Concorrência forte" | "Clínica Belissima (concorrente direto) abriu 2a unidade a 800m, investindo R$20k/mês em Meta Ads com vídeos profissionais. Capturando público do Batel" |
+| "Crise econômica" | "Ticket médio de R$1.500/procedimento posiciona no segmento premium. Em cenário de contração, público A/B corta estética antes de necessidades — risco de queda de 15-25% em demanda" |
+| "Mudanças regulatórias" | "CFM está revisando normas de publicidade médica para 2026. Se aprovar restrição de antes/depois no Instagram (como já ocorre em alguns CRMs), principal canal de aquisição fica comprometido" |
+| "Problemas com fornecedores" | "80% dos insumos vêm de 1 distribuidor (Galderma). Atraso de 15 dias na entrega em fevereiro forçou cancelamento de 8 procedimentos e perda estimada de R$12k" |
+
+---
+
+## Exemplo 2: E-commerce de Suplementos
+
+### FORÇAS
+
+| RUIM | BOM |
+|------|-----|
+| "Produtos de qualidade" | "Fórmula aberta (sem blend proprietário) em todos os 47 SKUs. 23% dos compradores citam 'transparência no rótulo' como motivo da compra (dados da pesquisa pós-venda)" |
+| "Preço competitivo" | "Whey isolado a R$89/900g posiciona 35% abaixo de Growth Supplements e Integralmedica para composição equivalente. Melhor custo-por-grama de proteína do mercado" |
+| "Boa marca" | "DA 38 no site (acima da média do setor = 25). Ranqueia top 5 para 'melhor whey custo beneficio' e 'creatina boa e barata'. 2.1K reviews com nota 4.6/5" |
+| "Logística eficiente" | "Fulfillment próprio em Barueri. Tempo médio de entrega SP capital: 1.2 dias. Frete grátis acima de R$149 (ticket médio = R$167)" |
+
+### FRAQUEZAS
+
+| RUIM | BOM |
+|------|-----|
+| "Pouca variedade" | "Catálogo concentrado em whey e creatina (78% do faturamento). Sem categoria de saúde/wellness que cresce 40% ao ano no setor (colágeno, vitaminas, adaptógenos)" |
+| "Marketing precisa melhorar" | "ROAS caiu de 6.2x para 3.8x nos últimos 6 meses sem mudança de budget (R$45k/mês). Frequência de criativos novos: 1 por mês. Benchmark do setor: 4-6 por semana" |
+| "Dependência de plataforma" | "64% das vendas vêm de tráfego pago no Meta. Orgânico e email representam apenas 12%. Qualquer aumento de CPM impacta diretamente a margem" |
+| "Sem programa de fidelidade" | "Taxa de recompra em 90 dias: 18%. Benchmark do setor para suplementos: 35-45%. Sem régua de reativação, sem desconto progressivo, sem clube de assinatura" |
+
+### OPORTUNIDADES
+
+| RUIM | BOM |
+|------|-----|
+| "Crescer nas redes" | "TikTok Shop lança no Brasil em 2026. Concorrentes diretos ainda não têm presença. Conteúdo de 'review honesto de suplemento' tem média de 500K views na plataforma" |
+| "Lançar novos produtos" | "Creatina monohidratada creapure (matéria-prima premium alemã) — único SKU que esgota todo mês. Lançar versão 500g (hoje só tem 300g) pode capturar R$80k/mês adicionais com base na demanda reprimida" |
+| "Parcerias" | "3 criadores com 100K-500K seguidores no nicho fitness mencionaram a marca organicamente no último trimestre. Nenhum é patrocinado — programa de embaixadores custaria ~R$15k/mês para formalizar" |
+| "Vender mais" | "Clube de assinatura com 10% de desconto + frete grátis. Benchmark: marcas com subscription no setor convertem 25-30% da base ativa. Estimativa: R$120k/mês recorrente em 6 meses" |
+
+### AMEAÇAS
+
+| RUIM | BOM |
+|------|-----|
+| "Muita concorrência" | "Growth Supplements captou R$15M em investimento e está subsidiando frete grátis + cupom de primeira compra agressivamente. Market share deles cresceu 8pp no último ano" |
+| "Mudanças no mercado" | "CPM médio no Meta para e-commerce fitness subiu 42% em 2025. Com ROAS já em queda, margem líquida pode ficar abaixo de 8% em 6 meses se tendência continuar" |
+| "Regulação" | "ANVISA publicou consulta pública sobre rotulagem de suplementos esportivos. Se aprovada, obrigaria reformulação de 12 dos 47 SKUs (custo estimado R$200k + 4 meses)" |
+| "Economia" | "Câmbio acima de R$6.00 impacta matéria-prima importada (whey WPC/WPI vem dos EUA). Cada R$0.50 de alta no dólar comprime R$2.30/kg no custo — margem bruta cai 3pp" |
+
+---
+
+## Exemplo 3: Restaurante Contemporâneo (Campinas)
+
+### FORÇAS
+
+| RUIM | BOM |
+|------|-----|
+| "Comida boa" | "Chef Renato foi finalista do prêmio Prazeres da Mesa 2024 na categoria 'Melhor Novo Restaurante Interior SP'. Nota 4.7/5 no Google (312 reviews)" |
+| "Boa localização" | "Cambuí (bairro gastronômico de Campinas). A 50m da rua mais movimentada de bares/restaurantes. 3 estacionamentos conveniados num raio de 200m" |
+| "Ambiente agradável" | "Projeto arquitetônico premiado (escritório SuperLimão). O espaço é fotografado e postado organicamente — 40% dos posts marcados no Instagram são do ambiente, não da comida" |
+| "Equipe dedicada" | "Sommelier residente (único restaurante contemporâneo de Campinas com sommelier fixo). Carta de vinhos curada com 85 rótulos, ticket médio de bebida R$78" |
+
+### FRAQUEZAS
+
+| RUIM | BOM |
+|------|-----|
+| "Custos altos" | "Food cost em 38% (meta do setor: 28-32%). Menu degustação de 7 etapas usa ingredientes sazonais importados — margem bruta do degustação é 12pp menor que pratos à la carte" |
+| "Pouco marketing" | "Instagram com 4.8K seguidores mas sem padrão visual. Últimas 20 fotos foram tiradas com celular em iluminação ruim. Concorrente Chez Claude tem 22K com fotógrafo semanal" |
+| "Capacidade limitada" | "52 lugares. Sexta e sábado lotam (taxa de ocupação 95%). Terça e quarta ficam em 40%. Sem estratégia de preenchimento para dias fracos (desconto, evento, menu especial)" |
+| "Dependência do iFood" | "iFood responde por 35% do faturamento mas cobra 27% de comissão. Margem líquida do delivery: 4% (vs. 18% do salão). Sem app próprio ou pedido direto" |
+
+### OPORTUNIDADES
+
+| RUIM | BOM |
+|------|-----|
+| "Atrair novos clientes" | "Campinas tem 15 empresas com 500+ funcionários num raio de 10km. Nenhuma tem contrato de catering/eventos corporativos com restaurante contemporâneo. Ticket corporativo médio: R$8-15k/evento" |
+| "Usar delivery" | "Criar menu delivery exclusivo com 5 pratos de margem alta (acima de 65%) e embalagem instagramável. Benchmark: restaurantes que lançam 'menu delivery premium' reduzem dependência do iFood em 40% em 6 meses" |
+| "Fazer eventos" | "Terça e quarta vagas → 'Noite de Harmonização' (R$189/pessoa, vinícola parceira custeia vinho). 30 lugares x 2 noites x 4 semanas = R$45k/mês com margem de 55%" |
+| "Redes sociais" | "Food content no TikTok/Reels de Campinas é dominado por fast food. Restaurante contemporâneo com plating bonito + storytelling do chef tem espaço vazio. 3 concorrentes de SP (Maní, A Casa do Porco) já faturam R$50k+/mês em visibilidade gratuita via Reels" |
+
+### AMEAÇAS
+
+| RUIM | BOM |
+|------|-----|
+| "Concorrência" | "3 novos restaurantes contemporâneos abriram no Cambuí nos últimos 12 meses, incluindo o 'Raíz' (chef ex-D.O.M.) com investimento estimado de R$2M e campanha de lançamento agressiva" |
+| "Custos subindo" | "Azeite extra-virgem subiu 80% em 12 meses. Proteínas nobres (wagyu, polvo) subiram 25%. Sem repasse no menu desde fev/2025 — margem comprimindo mês a mês" |
+| "Economia" | "Campinas tem concentração de funcionários do setor de TI (40% dos clientes do jantar). Layoffs no setor em 2025 reduziram frequência de jantar fora — ticket médio caiu 8% QoQ" |
+| "Mudanças" | "iFood anunciou aumento de comissão de 27% para 30% a partir de jul/2026. Impacto estimado: R$4.5k/mês a menos de margem. Se subir para 33% (rumor), delivery fica no breakeven" |
+
+---
+
+## Checklist de Qualidade para SWOT
+
+Antes de apresentar a SWOT ao operador, verifique:
+
+| # | Critério | Teste |
+|---|----------|-------|
+| 1 | Especificidade | Cada item tem dados, números, nomes, ou evidências concretas? |
+| 2 | Diferenciação | O item é exclusivo deste cliente? Ou serve para qualquer empresa do setor? |
+| 3 | Implicação clara | Cada item diz o que fazer com aquela informação (alavancar, mitigar, capturar, proteger)? |
+| 4 | Base factual | O item é baseado em dado real (diagnóstico, briefing, operador) ou é suposição? Se suposição, marcar e validar |
+| 5 | Equilíbrio | Tem 4-6 itens por quadrante? Nenhum quadrante está inflado ou vazio? |
+| 6 | Forças reais | As forças são REAIS ou são o que o cliente GOSTARIA de ser? (Validar com dados) |
+| 7 | Fraquezas honestas | As fraquezas são honestas? Não amenizou nada por "educação"? |
+| 8 | Oportunidades atingíveis | As oportunidades são capturáveis com os recursos do cliente? Ou são fantasia? |
+| 9 | Ameaças concretas | As ameaças são reais e prováveis? Não colocou "recessão global" como ameaça para uma padaria? |
+| 10 | Síntese coerente | A síntese cruza os quadrantes e gera direcionamento claro? |
+
+## Erros mais comuns em SWOT
+
+1. **Confundir interno com externo.** "Mercado grande" é oportunidade, não força. "Equipe pequena" é fraqueza, não ameaça.
+2. **Listar sintomas, não causas.** "Vendas caindo" é sintoma. A fraqueza é "CRM inexistente com 0% de reativação de clientes inativos".
+3. **SWOT otimista.** 6 forças, 2 fraquezas, 5 oportunidades, 1 ameaça. Se a SWOT parece um pitch de vendas, está enviesada.
+4. **Itens repetidos entre quadrantes.** "Equipe pequena" como fraqueza E "contratar" como oportunidade é redundância.
+5. **SWOT sem dados.** "Acreditamos que..." não é análise. Use dados do diagnóstico, briefing, e pesquisa.

--- a/.claude/skills/geral-analise-swot/references/padrao-output.md
+++ b/.claude/skills/geral-analise-swot/references/padrao-output.md
@@ -1,0 +1,202 @@
+# Padrão de Output das Skills — V4 Estruturação IA
+
+Este documento define a **estrutura canônica** que todos os outputs de skill devem seguir para renderizar no portal com hierarquia visual consistente. O objetivo é que o operador e o stakeholder final abram qualquer entregável e encontrem o mesmo ritmo: manchete → KPIs → achados categorizados → ponto de alavancagem destacado → detalhes expansíveis.
+
+---
+
+## Princípios
+
+1. **Manchete antes de texto.** Toda skill abre com uma frase única e específica que resume a conclusão. Não é parágrafo, é headline.
+2. **Números em destaque, não escondidos no corpo do texto.** KPIs que importam viram cards. Texto corrido é para contexto, não para fato quantitativo.
+3. **Achados categorizados por intenção.** Cada insight é classificado como `vantagem | contexto | ameaca | acao` — o leitor identifica o tom antes de ler.
+4. **Ponto de alavancagem visualmente isolado.** Toda skill tem UM ponto onde a conversa com o stakeholder precisa acontecer. Esse ponto ganha hero visual (border, gradient, quote destacada).
+5. **Detalhe denso → colapsável.** Listas longas (concorrentes, itens de checklist, fontes) ficam em `<details>` para não afogar a leitura.
+
+---
+
+## Campos obrigatórios no JSON
+
+Todo output de skill DEVE ter estes campos no topo (antes dos campos específicos da skill):
+
+```json
+{
+  "client_name": "Nome do Cliente",
+  "summary": "Resumo em 1-2 frases. Específico, com dados reais. Alimenta o resumo executivo do portal.",
+
+  "summary_headline": "Manchete em 1 linha (max 120 caracteres). A frase que o stakeholder lê primeiro.",
+
+  "summary_highlights": [
+    {
+      "category": "posicao | competicao | janela | maturidade | oportunidade | risco",
+      "label": "Rótulo curto (max 30 char)",
+      "value": "Valor em destaque (número, %, status)",
+      "subtext": "Contexto em 1 linha (max 60 char)",
+      "tone": "green | yellow | red | blue | gray"
+    }
+  ],
+
+  "summary_key_findings": [
+    {
+      "category": "vantagem | contexto | ameaca | acao",
+      "text": "Achado em 1-2 linhas. Específico, acionável."
+    }
+  ]
+}
+```
+
+### Regras dos campos de summary
+
+**`summary_headline`**: É a ÚNICA frase que o stakeholder precisa ler se só tiver 5 segundos. Deve conter o veredito da skill. Exemplos bons:
+- ✓ "[Cliente] é o ÚNICO player premium da microrregião com [diferencial declarado] — janela competitiva de 12-18 meses."
+- ✗ "Análise de mercado concluída com sucesso."
+
+**`summary_highlights`** (4-6 itens): KPIs visuais. Categorias sugeridas:
+- `posicao` — onde o cliente está hoje vs potencial
+- `competicao` — quem disputa o mesmo espaço
+- `janela` — tempo/urgência
+- `maturidade` — estágio atual em algum eixo
+- `oportunidade` — tamanho do ganho possível
+- `risco` — tamanho da ameaça
+
+Agrupar de 2 em 2 por categoria no renderer (dá layout balanceado 3x2 ou 2x2).
+
+**`summary_key_findings`** (3-5 itens): Achados que embasam a manchete. Categorias:
+- `vantagem` (✓ verde) — o que o cliente tem a favor
+- `contexto` (i azul) — o que é fato do mercado, neutro
+- `ameaca` (! vermelho) — o que pode dar errado
+- `acao` (▸ laranja) — o que precisa ser feito
+
+---
+
+## Ponto de Alavancagem (hero block)
+
+Toda skill deve identificar **UM bloco que merece destaque visual especial** — o ponto onde a conversa estratégica precisa acontecer. O nome do campo varia por skill, mas a estrutura é consistente:
+
+```json
+{
+  "key_leverage_point": {
+    "headline": "Frase-manchete do ponto (pode ir como quote)",
+    "context": "Contexto em 2-3 linhas explicando o cenário",
+    "numbered_reasons": [
+      "Razão 1 (parse-friendly, pode começar com texto direto)",
+      "Razão 2",
+      "Razão 3"
+    ],
+    "discussion_anchor": "Frase curta sobre POR QUE este é o ponto de conversa com o stakeholder"
+  }
+}
+```
+
+Exemplos por skill:
+- `pesquisa-mercado` → `unexploited_opportunity` (whitespace estratégico)
+- `persona-icp` → persona principal + dor mais ignorada
+- `swot` → combinação força × oportunidade mais assimétrica
+- `posicionamento` → PUV vs alternativas descartadas
+- `diagnostico-midia` → canal mais subotimizado + upside estimado
+- `diagnostico-maturidade` → pilar mais fraco com maior impacto
+
+O renderer aplica:
+- Border verde 2px + gradient sutil
+- Selo "Whitespace Estratégico · Discussão com Stakeholder" no topo
+- Pill de viabilidade/urgência à direita
+- Quote/headline em card branco isolado
+- Razões numeradas em 3 círculos
+- Footer "💬 Momento de validar com a stakeholder"
+
+---
+
+## Alerta de honestidade
+
+Se a pesquisa/análise revelou fragilidade do cliente (não há diferencial real, ICP mal definido, mercado saturado, etc.), inclua:
+
+```json
+{
+  "honesty_alert": "Texto explicando a fragilidade encontrada e o que precisa ser feito antes de seguir."
+}
+```
+
+Esse campo renderiza em box amarelo/vermelho após os achados. **Nunca omita** se a realidade justifica. O valor do sistema depende de não vender aspiracional como real.
+
+---
+
+## Instrução para a IA da skill
+
+Em cada `SKILL.md`, incluir esta seção na geração:
+
+> ### Estrutura visual (obrigatória)
+>
+> Além dos campos específicos desta skill, gere SEMPRE:
+>
+> - `summary_headline` — manchete em 1 linha com o veredito
+> - `summary_highlights` — 4-6 KPIs categorizados (`posicao|competicao|janela|maturidade|oportunidade|risco`) com `{label, value, subtext, tone}`
+> - `summary_key_findings` — 3-5 achados categorizados (`vantagem|contexto|ameaca|acao`)
+> - `honesty_alert` se houver fragilidade
+>
+> Identifique o **ponto de alavancagem** desta skill (o bloco que merece hero visual) e estruture-o com headline + contexto + razões numeradas + discussion anchor.
+>
+> Consulte `references/padrao-output.md` para especificação completa.
+
+E na auto-validação:
+
+> - [ ] Tem `summary_headline` específico (não "análise concluída")?
+> - [ ] `summary_highlights` tem 4-6 itens com categorias válidas?
+> - [ ] `summary_key_findings` cobre pelo menos 3 dos 4 tipos (vantagem/contexto/ameaça/ação)?
+> - [ ] Identificou o ponto de alavancagem para discussão com stakeholder?
+> - [ ] Se há fragilidade, incluiu `honesty_alert`?
+
+---
+
+## Completude (regra crítica)
+
+**Todo campo definido no schema da skill é obrigatório no output.** Não omitir campos — o renderer assume que os campos do schema existem e quebra/fica vazio silenciosamente quando faltam.
+
+Se um dado **não pode ser obtido** (GA4 não instalado, conector não conectado, cliente não sabe, etc.), preencher com `null` E adicionar `unavailable_reason` no objeto pai:
+
+```json
+{
+  "current_conversion_rate": null,
+  "current_bounce_rate": null,
+  "avg_time_on_page": null,
+  "unavailable_reason": "GA4 não instalado no site — métricas de analytics não coletadas nesta auditoria"
+}
+```
+
+Para arrays vazios legitimamente (ex: nenhum competidor identificado), preencher com `[]` e adicionar uma nota no campo irmão `{campo}_note`:
+
+```json
+{
+  "competitors": [],
+  "competitors_note": "Nenhum concorrente direto identificado na microrregião após busca em Google Maps + Instagram."
+}
+```
+
+Para valores **estimados** (sem fonte pública), adicionar flag `[E]` no texto OU campo `estimated: true` no objeto:
+
+```json
+{ "tam_brl": 450000000, "estimated": true, "estimation_basis": "IBGE população × SEBRAE ticket médio" }
+```
+
+**Nunca** deixar string vazia (`""`), zero falso (`0` quando não é zero real), ou omitir o campo. Essas três formas são invisíveis para o renderer e geram o bug "coluna vazia".
+
+Valide o JSON contra o `schema.json` empacotado na skill e corrija campos ausentes ou `null` sem `unavailable_reason`.
+
+### Checklist adicional de auto-validação
+
+> - [ ] Todos os campos do schema estão presentes (preenchidos ou com `null` + `unavailable_reason`)?
+> - [ ] Nenhuma string vazia (`""`) — substituí por `null` + reason quando o dado não existe?
+> - [ ] Arrays vazios legítimos têm `{campo}_note` explicando por quê?
+> - [ ] Estimativas marcadas com `estimated: true` ou `[E]`?
+
+---
+
+## Tons de voz
+
+- `green` — oportunidade/vantagem/confirmado
+- `yellow` — atenção/potencial/médio
+- `red` — risco/ameaça/fraco
+- `blue` — contexto/informativo/neutro
+- `gray` — desativado/aspiracional/ausente
+
+Usar tons consistentemente: nunca pintar ameaça de verde ou vantagem de vermelho para "chamar atenção". O tom é semântico.
+
+---

--- a/.claude/skills/geral-analise-swot/schema.json
+++ b/.claude/skills/geral-analise-swot/schema.json
@@ -1,0 +1,566 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "SWOT",
+  "description": "Output estruturado da skill swot: análise SWOT completa com síntese estratégica e ações prioritárias.",
+  "type": "object",
+  "required": [
+    "summary",
+    "strengths",
+    "weaknesses",
+    "opportunities",
+    "threats",
+    "strategic_synthesis",
+    "priority_actions",
+    "client_name",
+    "summary_headline",
+    "summary_highlights",
+    "summary_key_findings"
+  ],
+  "properties": {
+    "client_name": {
+      "type": "string",
+      "description": "Nome do cliente — sempre presente em todo output."
+    },
+    "competitor_scorecard": {
+      "type": "array",
+      "description": "POP 1.5 — scorecard digital dos concorrentes (3-5 diretos + 1-2 indiretos), com nota 0-10 por dimensão e evidência observável. Inclua o próprio cliente para contraste.",
+      "items": {
+        "type": "object",
+        "required": ["name", "type", "scores"],
+        "properties": {
+          "name": { "type": "string" },
+          "type": { "type": "string", "enum": ["cliente", "direto", "indireto", "aspiracional"] },
+          "scores": {
+            "type": "object",
+            "description": "Notas 0-10 por dimensão.",
+            "properties": {
+              "site": { "type": ["number", "null"] },
+              "seo": { "type": ["number", "null"] },
+              "midia_paga": { "type": ["number", "null"] },
+              "social": { "type": ["number", "null"] },
+              "gmn": { "type": ["number", "null"] },
+              "reputacao": { "type": ["number", "null"] },
+              "comunicacao": { "type": ["number", "null"] }
+            }
+          },
+          "evidence": { "type": "object", "description": "1 linha de evidência observável por dimensão pontuada." },
+          "overall": { "type": ["number", "null"], "description": "Média/leitura geral 0-10." }
+        }
+      }
+    },
+    "summary": {
+      "type": "string",
+      "description": "Resumo de 1-2 frases da análise SWOT. Usado como referência rápida por outras skills."
+    },
+    "summary_headline": {
+      "type": "string",
+      "maxLength": 200,
+      "description": "Manchete em 1 linha com o veredito desta skill (hero do resumo executivo no portal). Ver references/padrao-output.md"
+    },
+    "summary_highlights": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 8,
+      "description": "KPIs visuais categorizados para o resumo executivo. Cada item: {category, label, value, subtext, tone}.",
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "label",
+          "value"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "posicao",
+              "competicao",
+              "janela",
+              "maturidade",
+              "oportunidade",
+              "risco"
+            ]
+          },
+          "label": {
+            "type": "string",
+            "maxLength": 40
+          },
+          "value": {
+            "type": "string"
+          },
+          "subtext": {
+            "type": "string",
+            "maxLength": 80
+          },
+          "tone": {
+            "type": "string",
+            "enum": [
+              "green",
+              "yellow",
+              "red",
+              "blue",
+              "gray"
+            ]
+          }
+        }
+      }
+    },
+    "summary_key_findings": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 6,
+      "description": "Achados categorizados por intenção (vantagem/contexto/ameaça/ação). Pelo menos 3 dos 4 tipos cobertos.",
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "text"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "vantagem",
+              "contexto",
+              "ameaca",
+              "acao"
+            ]
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "strengths": {
+      "type": "array",
+      "minItems": 4,
+      "maxItems": 6,
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "description",
+          "implication"
+        ],
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "Frase curta e específica descrevendo a força."
+          },
+          "description": {
+            "type": "string",
+            "description": "Evidência concreta que sustenta essa força (com dados quando possível)."
+          },
+          "implication": {
+            "type": "string",
+            "description": "Como essa força pode ser alavancada na estratégia."
+          },
+          "source": {
+            "type": "string",
+            "enum": [
+              "diagnostico",
+              "briefing",
+              "operador",
+              "v4mos"
+            ],
+            "description": "De onde veio a evidência."
+          }
+        }
+      },
+      "description": "Fatores internos positivos do negócio."
+    },
+    "weaknesses": {
+      "type": "array",
+      "minItems": 4,
+      "maxItems": 6,
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "description",
+          "implication"
+        ],
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "Frase curta e específica descrevendo a fraqueza."
+          },
+          "description": {
+            "type": "string",
+            "description": "Evidência concreta da fraqueza."
+          },
+          "implication": {
+            "type": "string",
+            "description": "Risco se não tratada + sugestão de mitigação."
+          },
+          "severity": {
+            "type": "string",
+            "enum": [
+              "critical",
+              "high",
+              "medium"
+            ],
+            "description": "Severidade da fraqueza."
+          },
+          "source": {
+            "type": "string",
+            "enum": [
+              "diagnostico",
+              "briefing",
+              "operador",
+              "v4mos"
+            ],
+            "description": "De onde veio a evidência."
+          }
+        }
+      },
+      "description": "Fatores internos negativos do negócio."
+    },
+    "opportunities": {
+      "type": "array",
+      "minItems": 4,
+      "maxItems": 6,
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "description",
+          "implication"
+        ],
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "Frase curta e específica descrevendo a oportunidade."
+          },
+          "description": {
+            "type": "string",
+            "description": "Por que essa oportunidade existe AGORA."
+          },
+          "implication": {
+            "type": "string",
+            "description": "Como capturar essa oportunidade."
+          },
+          "time_sensitivity": {
+            "type": "string",
+            "enum": [
+              "urgent",
+              "medium_term",
+              "long_term"
+            ],
+            "description": "Janela de oportunidade."
+          },
+          "source": {
+            "type": "string",
+            "enum": [
+              "diagnostico",
+              "briefing",
+              "operador",
+              "v4mos",
+              "market_trend"
+            ],
+            "description": "De onde veio a evidência."
+          }
+        }
+      },
+      "description": "Fatores externos positivos (oportunidades de mercado)."
+    },
+    "threats": {
+      "type": "array",
+      "minItems": 4,
+      "maxItems": 6,
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "description",
+          "implication"
+        ],
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "Frase curta e específica descrevendo a ameaça."
+          },
+          "description": {
+            "type": "string",
+            "description": "Evidência de que essa ameaça é real."
+          },
+          "implication": {
+            "type": "string",
+            "description": "Como se proteger ou mitigar."
+          },
+          "probability": {
+            "type": "string",
+            "enum": [
+              "high",
+              "medium",
+              "low"
+            ],
+            "description": "Probabilidade de materialização."
+          },
+          "impact": {
+            "type": "string",
+            "enum": [
+              "high",
+              "medium",
+              "low"
+            ],
+            "description": "Impacto se materializar."
+          },
+          "source": {
+            "type": "string",
+            "enum": [
+              "diagnostico",
+              "briefing",
+              "operador",
+              "v4mos",
+              "market_trend"
+            ],
+            "description": "De onde veio a evidência."
+          }
+        }
+      },
+      "description": "Fatores externos negativos (ameaças de mercado)."
+    },
+    "strategic_synthesis": {
+      "type": "object",
+      "required": [
+        "leverage",
+        "protection",
+        "recommended_strategy"
+      ],
+      "properties": {
+        "leverage": {
+          "type": "string",
+          "description": "Parágrafo: como usar forças para capturar oportunidades (Forças x Oportunidades)."
+        },
+        "protection": {
+          "type": "string",
+          "description": "Parágrafo: quais fraquezas amplificam ameaças e como proteger (Fraquezas x Ameaças)."
+        },
+        "recommended_strategy": {
+          "type": "string",
+          "description": "Parágrafo: estratégia recomendada para os próximos 90 dias."
+        }
+      }
+    },
+    "priority_actions": {
+      "type": "array",
+      "minItems": 5,
+      "maxItems": 7,
+      "items": {
+        "type": "object",
+        "required": [
+          "action",
+          "swot_basis",
+          "impact",
+          "suggested_timeline"
+        ],
+        "properties": {
+          "action": {
+            "type": "string",
+            "description": "O que fazer (específico e acionável)."
+          },
+          "swot_basis": {
+            "type": "string",
+            "description": "Quais quadrantes/itens essa ação endereça (ex: 'Alavanca F2, captura O3, executa SO1')."
+          },
+          "impact": {
+            "type": "string",
+            "enum": [
+              "high",
+              "medium",
+              "low"
+            ],
+            "description": "Impacto esperado da ação."
+          },
+          "suggested_timeline": {
+            "type": "string",
+            "description": "Quando executar (semana 1/2/3 ou prazo específico)."
+          },
+          "dependencies": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Dependências desta ação."
+          },
+          "financial_impact": {
+            "type": "object",
+            "description": "Impacto financeiro projetado da ação. Aceita nomenclatura com ou sem sufixo '_brl'.",
+            "properties": {
+              "investment": {
+                "type": "number",
+                "description": "Investimento em R$ (mensal ou único). Alternativa: 'investment_brl'."
+              },
+              "investment_brl": {
+                "type": "number",
+                "description": "Alternativa a 'investment'."
+              },
+              "expected_return_90d": {
+                "type": "number",
+                "description": "Retorno esperado em 90 dias em R$. Alternativa: 'monthly_return_brl' (será multiplicado por 3)."
+              },
+              "monthly_return_brl": {
+                "type": "number",
+                "description": "Retorno mensal em R$. Se presente, retorno 90d = monthly × 3."
+              },
+              "payback_days": {
+                "type": "number",
+                "description": "Dias até o payback."
+              },
+              "roi_multiple": {
+                "type": "number",
+                "description": "Múltiplo de ROI (ex: 5.2 = 5.2x). Se ausente, calculado como retorno/investment."
+              },
+              "note": {
+                "type": "string",
+                "description": "Observação textual opcional."
+              }
+            }
+          },
+          "risk_adjusted_score": {
+            "description": "Score de priorização. Aceita dois formatos: número 0-100 OU objeto com dimensões avaliadas em escala 1-10. O renderer do portal ordena e exibe ambos.",
+            "oneOf": [
+              {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 100,
+                "description": "Score agregado 0-100."
+              },
+              {
+                "type": "object",
+                "required": [
+                  "score"
+                ],
+                "properties": {
+                  "impact": {
+                    "type": "number",
+                    "minimum": 1,
+                    "maximum": 10,
+                    "description": "Impacto esperado (1-10)."
+                  },
+                  "probability_of_success": {
+                    "type": "number",
+                    "minimum": 1,
+                    "maximum": 10,
+                    "description": "Probabilidade de sucesso (1-10)."
+                  },
+                  "reversibility": {
+                    "type": "number",
+                    "minimum": 1,
+                    "maximum": 10,
+                    "description": "Reversibilidade se der errado (1-10, maior = mais reversível)."
+                  },
+                  "score": {
+                    "type": "number",
+                    "description": "Score final agregado (1-10 ou 0-100)."
+                  }
+                }
+              }
+            ]
+          }
+        }
+      },
+      "description": "Ações prioritárias derivadas do cruzamento SWOT/TOWS, ordenadas por risk_adjusted_score."
+    },
+    "tows_matrix": {
+      "type": "object",
+      "description": "Matriz TOWS: cruzamento estratégico dos quadrantes SWOT para derivar estratégias acionáveis.",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Breve explicação do que é a matriz."
+        },
+        "so_strategies": {
+          "type": "array",
+          "description": "Estratégias Ofensivas (Forças × Oportunidades). Onde o cliente ataca.",
+          "items": {
+            "$ref": "#/definitions/towsStrategy"
+          }
+        },
+        "wo_strategies": {
+          "type": "array",
+          "description": "Estratégias de Reforço (Fraquezas × Oportunidades). Onde o cliente investe.",
+          "items": {
+            "$ref": "#/definitions/towsStrategy"
+          }
+        },
+        "st_strategies": {
+          "type": "array",
+          "description": "Estratégias Defensivas (Forças × Ameaças). Onde o cliente protege.",
+          "items": {
+            "$ref": "#/definitions/towsStrategy"
+          }
+        },
+        "wt_strategies": {
+          "type": "array",
+          "description": "Estratégias de Sobrevivência (Fraquezas × Ameaças). Onde o cliente minimiza dano.",
+          "items": {
+            "$ref": "#/definitions/towsStrategy"
+          }
+        }
+      }
+    },
+    "_deprecated_notes": {
+      "type": "string",
+      "description": "NÃO usar. Campos descontinuados que o renderer do portal ignora: 'scenarios', 'financial_summary_90d', 'risk_adjusted_ranking'. A projeção de cenários é feita em gt-diagnostico-midia-paga (budget_reallocation_scenarios); a consolidação financeira é redundante com priority_actions[].financial_impact."
+    },
+    "key_insight": {
+      "type": "object",
+      "description": "Ponto de alavancagem desta skill — o bloco que merece destaque visual para conversa com o stakeholder. Ver PADRAO-OUTPUT.md.",
+      "properties": {
+        "headline": {
+          "type": "string",
+          "description": "Frase-manchete do ponto (pode virar quote destacada no renderer)"
+        },
+        "context": {
+          "type": "string",
+          "description": "Contexto em 2-3 linhas explicando o cenário"
+        },
+        "numbered_reasons": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Razões numeradas (o renderer vira 3 cards numerados)"
+        },
+        "discussion_anchor": {
+          "type": "string",
+          "description": "Por que este é o ponto para stakeholder decidir/validar"
+        }
+      }
+    },
+    "honesty_alert": {
+      "type": "string",
+      "description": "Alerta se a análise revelou fragilidade real do cliente (não há diferencial claro, premissa contraditória, etc.). Nunca omitir se justificado."
+    }
+  },
+  "definitions": {
+    "towsStrategy": {
+      "type": "object",
+      "required": [
+        "id",
+        "strategy"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Identificador (ex: SO1, WT2)."
+        },
+        "strategy": {
+          "type": "string",
+          "description": "Ação específica de cruzamento."
+        },
+        "rationale": {
+          "type": "string",
+          "description": "Por que essa estratégia funciona (cita a força/fraqueza e a oportunidade/ameaça)."
+        },
+        "expected_outcome": {
+          "type": "string",
+          "description": "O que muda se executar (resultado tangível)."
+        }
+      }
+    }
+  }
+}

--- a/.claude/skills/geral-persona-icp/SKILL.md
+++ b/.claude/skills/geral-persona-icp/SKILL.md
@@ -1,0 +1,279 @@
+---
+name: geral-persona-icp
+description: "Cria o ICP (Ideal Customer Profile) e Persona do cliente usando framework JTBD. Skill raiz que alimenta toda a estratégia. Use quando o operador disser 'persona', 'ICP', 'cliente ideal', 'Jobs-to-be-Done', ou quando iniciar a semana 1."
+area: geral
+author: luizfreitasv4
+version: 1.0.0
+dependencies: []
+outputs: ["geral-persona-icp.json"]
+week: 1
+estimated_time: "45-60 min"
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta versao foi portada do sistema de Estruturacao Estrategica. As regras abaixo tem precedencia sobre caminhos e persistencia citados no fluxo original:
+
+- Trabalhe somente em `squads/{squad}/clientes/{cliente}/`, nunca em um diretorio `clientes/` solto na raiz.
+- Leia primeiro o `CLAUDE.md` ou `AGENTS.md` da KB, `mission-control/`, `calls/`, `docs/` e `campanhas/`.
+- Se `client.json` existir, use-o como fonte complementar. Se nao existir, derive o contexto da KB e do Mission Control; nao exija nem invente esse arquivo.
+- Salve entregaveis em `squads/{squad}/clientes/{cliente}/outputs/`, em JSON e Markdown quando o fluxo pedir ambos.
+- Registre decisoes e progresso no `mission-control/historico-checkins.md` ou no arquivo de historico equivalente encontrado na KB.
+- Resolva recursos empacotados a partir do proprio diretorio desta skill. Se uma integracao externa nao estiver configurada, declare o gap e continue apenas com os dados reais disponiveis.
+
+
+# Persona e ICP — Perfil do Cliente Ideal (POP 1.7)
+
+Você é um especialista em Jobs-to-be-Done e pesquisa de cliente. Vai construir, junto com o operador, o perfil do cliente ideal (ICP) e a persona que vai orientar TODA a comunicação, criativos e estratégia de mídia do cliente.
+
+> **Posição no fluxo:** Semana 1 — skill raiz, comum a todos os modelos de venda (e-commerce / inside-sales / pdv). É dependência de quase tudo que vem depois.
+> **IMPORTANCIA:** Este é o documento mais referenciado em todos os squads seguintes. Se o ICP estiver errado, tudo que vem depois estará errado. Invista tempo aqui.
+
+## Dados necessários
+
+Leia os seguintes arquivos do diretório do cliente:
+
+1. `client.json` (seção `briefing`) — dados base do cliente (OBRIGATORIO)
+2. `client.json` (seção `connectors`) — se existir, extraia `MarketingProfile` para pré-popular dados
+
+Extraia do briefing:
+- `identification.name` → nome do cliente
+- `identification.segment` → segmento/setor
+- `identification.region` → região de atuação
+- `product.main_product` → produto/serviço principal
+- `product.ticket` → ticket médio
+- `icp.best_customers` → descrição dos melhores clientes
+- `icp.not_customers` → quem NÃO é cliente (anti-persona)
+- `brand.voice_tone` → tom de voz desejado
+- `competition.competitors` → concorrentes (para diferenciação)
+
+Se `client.json` (seção `connectors`) existir e tiver `workspace.marketingProfile`, use esses dados como ponto de partida mas sempre valide com o operador.
+
+---
+
+## Geração
+
+Carregue todos os dados do `client.json` (seção `briefing`) e conectores.
+
+Se algum campo crítico estiver faltando (`identification.segment`, `product.main_product`, `icp.best_customers` com < 20 caracteres), apresente TUDO que já tem e pergunte APENAS o que falta, numa única interação. Não faça uma pergunta por vez. Se todos os campos críticos estão preenchidos, prossiga sem parar.
+
+Gere o output COMPLETO de uma vez — ICP, Persona, Canais, e Mensagens-chave. Consulte `references/jtbd-framework.md` para aplicar o framework corretamente. Consulte `references/exemplos-bom-vs-ruim.md` para calibrar especificidade.
+
+O output completo inclui:
+
+**A) ICP com Jobs-to-be-Done**
+
+#### Dados Demográficos
+- Se B2B: faturamento anual, setor, número de funcionários, cargo do decisor, localização
+- Se B2C: faixa etária, renda, localização, estado civil, escolaridade, profissão
+- Se misto: ambos os perfis separados
+
+#### Dados Comportamentais
+- Como toma decisão de compra (racional vs emocional, individual vs comitê)
+- Onde pesquisa antes de comprar (Google, Instagram, indicação, YouTube, etc.)
+- Principais objeções na hora da compra
+- O que o faz trocar de fornecedor
+- Frequência de compra e ciclo de decisão
+
+#### Jobs-to-be-Done (SEÇÃO MAIS IMPORTANTE)
+Aplique o framework JTBD rigorosamente:
+
+- **Job funcional:** O que a pessoa precisa FAZER. Não é "comprar [produto]" — é a tarefa que precisa ser cumprida. Use o formato: "Quando [situação], eu quero [motivação], para que [resultado esperado]."
+- **Job emocional:** Como a pessoa quer se SENTIR durante e após a compra. Segurança? Alívio? Orgulho? Confiança?
+- **Job social:** Como a pessoa quer ser VISTA pelos outros. Status? Competência? Cuidado? Modernidade?
+
+#### Dores (3-5 dores ESPECÍFICAS)
+- Ordene por intensidade (da mais dolorosa para a menos)
+- Cada dor deve ser algo que o cliente reconheceria imediatamente
+- Use linguagem do cliente, não jargão de marketing
+
+#### Ganhos Desejados (3-5 ganhos)
+- O que o cliente quer alcançar (não o que o produto oferece)
+- Tangíveis e intangíveis
+- Priorize os ganhos que mais se conectam com os Jobs
+
+**B) Persona**
+
+- **Nome fictício:** Escolha um nome comum para o perfil demográfico identificado
+- **Descrição da foto:** Descreva como seria a foto de perfil dessa pessoa. Seja específico: idade aparente, expressão, contexto (escritório, loja, casa), vestuário
+- **História:** 1 parágrafo (4-6 linhas) contando a situação atual desta pessoa, seus desafios, e por que ela precisa da solução. Use storytelling, não bullet points
+- **Frase-citação:** Uma frase que essa persona diria sobre o problema que o cliente resolve. Deve soar autêntica — como se fosse transcrita de uma entrevista real. Use linguagem coloquial
+
+**C) Onde Encontrar Este ICP**
+
+- **Canais digitais:** Canais ESPECÍFICOS (não genéricos como "redes sociais" — especifique: "grupos de Facebook de [tema]", "hashtags [x] no Instagram")
+- **Palavras-chave:** Termos que essa persona digitaria no Google/YouTube
+- **Influenciadores/referências:** Perfis, podcasts, canais que acompanha
+- **Comunidades:** Grupos, fóruns, associações de classe, eventos
+
+**D-pre1) Anti-Persona (OBRIGATÓRIO — 2-3 perfis)**
+
+A persona define quem você QUER atender. A anti-persona define quem você NÃO QUER atender — clientes que consomem recurso, geram atrito e não convertem. Sem anti-persona definida, a equipe não sabe quando dizer "não".
+
+Para cada anti-persona (2-3):
+- **profile_name** (ou **label**): apelido descritivo (ex: "Caçador de preço", "Emergência única")
+- **description** (ou **who**): 2-3 linhas sobre o comportamento típico
+- **signals** (ou **red_flags**): lista de 3-6 sinais concretos que o time observa na triagem (ex: "pede desconto antes do diagnóstico", "pergunta só preço por WhatsApp sem contexto")
+- **why_not**: por que não é cliente ideal (custo de atendimento, ticket baixo, alta rotatividade, objeção que não resolve)
+- **operational_rule**: regra prática — como o time identifica e o que faz (ex: "Se pedir desconto antes do diagnóstico, encaminhar para tabela padrão")
+
+> Use **profile_name/description/signals** como padrão. O renderer aceita os alternativos (label/who/red_flags) para compatibilidade, mas prefira o conjunto principal.
+
+Feche com um `operational_rule` geral — a regra-mãe que alinha o time.
+
+**D-pre2) Buyer Journey (OBRIGATÓRIO — 5-6 estágios)**
+
+Mapeie a jornada de decisão da persona do gatilho ao pós-compra. Cada estágio com:
+- **Stage:** nome (ex: Gatilho, Pesquisa, Consideração, Decisão, Pós-compra, Recompra)
+- **Trigger:** o que inicia esse estágio (evento externo, interno, emocional)
+- **Mental state:** estado mental dominante (dúvida, ansiedade, urgência, cobrança social)
+- **Primary channel:** onde a persona busca informação neste estágio
+- **Dominant question:** a pergunta que ela está tentando responder
+- **[Cliente] intervention:** como o cliente intervém nesse estágio (conteúdo, anúncio, contato)
+- **Friction today:** qual o atrito/problema atual nesse estágio
+- **Duration estimate:** quanto tempo típico (horas, dias, semanas)
+
+Feche com `critical_leakage_point`: onde o cliente mais perde leads HOJE. Pode ser:
+- **String livre** (preferido quando o vazamento é qualitativo): ex. `"O maior vazamento é na Consideração: a persona pesquisa 3-7 dias e a clínica não aparece no Google Maps local"`.
+- **Objeto estruturado** (use quando tiver número de perda): `{stage, evidence, estimated_loss_pct}`.
+
+**D-pre3) Willingness-to-Pay (OBRIGATÓRIO — por serviço principal)**
+
+Para cada serviço/produto principal (3-5), use o SHAPE PREFERIDO (mais rico que o legado):
+- **service**: nome do serviço
+- **current_ticket_range**: faixa de ticket atual praticada (ex: `"R$180-250"`)
+- **perceived_fair_range**: faixa que a persona percebe como justa (ex: `"R$180-300"`)
+- **premium_ceiling**: teto premium aceito COM justificativa (ex: `"R$400 com exame complementar incluso"`)
+- **elasticity**: palavra-chave + nuance separada por `—` (ex: `"baixa — aceita pagar mais se entender o porquê"`). O portal usa a palavra-chave como tag colorida e o texto após o travessão como nota.
+- **pricing_lever**: o que justifica cobrar mais (especialização, tempo de consulta, garantia, bundle)
+
+> Os campos legados (`current_price`, `fair_range`, `premium_range`) ainda funcionam, mas **prefira** o shape novo — ele comunica range (não ponto) e o teto com justificativa, que é o que a análise realmente pede.
+
+Isso não é exercício de pricing — é alinhar posicionamento e copy ao WTP real da persona.
+
+**D-pre4) Objection Library (OBRIGATÓRIO — 5-7 objeções)**
+
+Catálogo de objeções reais da persona. Para cada:
+- **Objection:** como ela diz (linguagem do cliente)
+- **Subtext:** o que ela REALMENTE está dizendo (medo, dúvida, experiência anterior)
+- **Bad response:** resposta automática que NÃO funciona e por quê
+- **Good response:** resposta que funciona — pequena história, dado, reframe
+- **When to use:** em que canal/momento essa resposta é usada
+
+Essa library alimenta copy, SDR, scripts de atendimento e FAQs.
+
+**E) 3 Opções de Mensagem-Chave**
+
+1. **Opção funcional:** Foco no resultado prático/tangível
+2. **Opção emocional:** Foco no sentimento/transformação
+3. **Opção social:** Foco em como o cliente será visto/percebido
+
+Para cada opção:
+- A mensagem em si (1 frase, máximo 15 palavras)
+- Por que essa abordagem funciona para este ICP
+- Em que contexto usar (anúncios, bio Instagram, headline do site, etc.)
+
+### Estrutura visual (obrigatória)
+
+Siga o padrão canônico de `references/padrao-output.md`. Além dos campos acima, SEMPRE inclua:
+
+- **`summary_headline`** (string, max 200 char) — manchete com o veredito do ICP/Persona. Específica, com dados reais.
+  - Ex: "Mariana (35-50, tutora de gatos premium) é o ICP. Ignorada pelos concorrentes que tratam cão e gato igual."
+
+- **`summary_highlights`** (4-6 itens) — KPIs visuais. Sugestões para persona-ICP:
+  - `posicao`: faixa etária/renda da persona, ticket médio atual vs premium ceiling
+  - `competicao`: nº de concorrentes que atendem o mesmo ICP declaradamente
+  - `janela`: tempo de decisão médio (buyer journey duration)
+  - `oportunidade`: dor mais aguda não endereçada, WTP gap (premium ceiling - current ticket)
+  - `risco`: objeção mais comum / leakage point mais crítico
+  - Cada item: `{category, label, value, subtext, tone}` (tons: `green|yellow|red|blue|gray`)
+
+- **`summary_key_findings`** (3-5 itens) — achados categorizados:
+  - `vantagem | contexto | ameaca | acao`
+  - Cubra pelo menos 3 dos 4 tipos.
+
+### Ponto de alavancagem
+
+Em persona-ICP, o ponto de alavancagem é a **combinação {persona principal + dor mais ignorada pelos concorrentes + frase-citação}** — o que o time precisa internalizar para mudar comunicação/atendimento. Estruture como:
+
+```json
+"key_insight": {
+  "headline": "Frase-manchete (ex: 'Mariana paga R$400 se entender o porquê — e ninguém explica')",
+  "context": "2-3 linhas explicando o insight",
+  "numbered_reasons": ["(1) razão A", "(2) razão B", "(3) razão C"],
+  "discussion_anchor": "Por que este é o ponto para o stakeholder decidir"
+}
+```
+
+Alternativamente, se o renderer da skill tiver um campo específico de destaque (ex: `critical_leakage_point` com objeto estruturado), use a mesma lógica de quote + razões.
+
+Se a pesquisa do ICP revelou fragilidade (persona mal definida, ICP contraditório com o produto, WTP incompatível), inclua `honesty_alert`.
+
+## Auto-validação
+
+Antes de mostrar ao operador, verifique:
+
+- [ ] Mencionou o cliente pelo nome?
+- [ ] Usou dados reais do client.json (não inventou)?
+- [ ] Nenhum item genérico (ex: "quer crescer", "qualidade e compromisso")?
+- [ ] Schema da skill validou?
+- [ ] Todos os campos do schema preenchidos (ou com `null` + `unavailable_reason` no pai)?
+- [ ] Nenhuma string vazia (`""`) — substituí por `null` + reason quando o dado não existe?
+- [ ] Estimativas marcadas com `estimated: true` ou `[E]`?
+- [ ] Consistente com outputs anteriores (se houver)?
+- [ ] Cada dor tem > 20 caracteres e usa linguagem do cliente (não jargão)?
+- [ ] Jobs-to-be-Done seguem formato "Quando [situação], eu quero [motivação], para que [resultado]"?
+- [ ] Nenhum item genérico — se trocar o nome do cliente e ainda servir, refaça?
+- [ ] Persona tem frase-citação que soa como fala real (não corporativês)?
+- [ ] Canais são específicos (não "redes sociais" nem "Google")?
+- [ ] Mensagens-chave têm <= 15 palavras cada?
+- [ ] Cada mensagem é diferente das outras (funcional vs emocional vs social)?
+- [ ] Anti-persona com 2-3 perfis e `operational_rule` clara para o time?
+- [ ] Buyer journey tem 5-6 estágios, cada um com trigger, mental_state, canal, pergunta dominante, intervenção e fricção atual?
+- [ ] `critical_leakage_point` identifica onde o cliente mais perde leads hoje COM evidência?
+- [ ] Willingness-to-pay cobre os serviços principais com preço atual, faixa justa, faixa premium, elasticidade e pricing_lever?
+- [ ] Objection library tem 5-7 objeções com subtext, bad_response e good_response (linguagem real, não corporativês)?
+- [ ] Tem `summary_headline` específico (não "persona definida")?
+- [ ] `summary_highlights` tem 4-6 itens com categorias e tons válidos?
+- [ ] `summary_key_findings` cobre pelo menos 3 dos 4 tipos (vantagem/contexto/ameaça/ação)?
+- [ ] Identificou `key_insight` para ancorar conversa com stakeholder?
+- [ ] Se há fragilidade, incluiu `honesty_alert`?
+
+Se falhou → regenere silenciosamente. Não avise o operador.
+
+## Apresentação e decisões
+
+Apresente o output COMPLETO ao operador de uma vez.
+
+**DECISÃO 1:** Mensagem-chave — qual direção?
+- Opção A: "[mensagem funcional]" — foco no resultado prático
+- Opção B: "[mensagem emocional]" — foco no sentimento
+- Opção C: "[mensagem social]" — foco na percepção
+
+**RECOMENDAÇÃO:** Opção [X]. [Justificativa baseada nos dados — ex: concorrentes já ocupam o território emocional, a funcional diferencia mais. Explique por que as outras são mais fracas.]
+
+**PROVOCAÇÃO:** [Pergunta contraintuitiva que força o operador a pensar — ex: "Se a persona ouvisse essas 3 frases num feed, qual faria ela parar o scroll? E o cliente tem coragem de bancar essa promessa?"]
+
+**DECISÃO 2:** Ajustes no ICP/Persona
+- O ICP faz sentido com o que você conhece deste cliente?
+- As dores são dolorosas de verdade? O cliente se reconheceria?
+- A persona parece real? Você consegue imaginar conversando com ela?
+- Os canais onde encontrá-la fazem sentido?
+- Algum canal ou comunidade que você sabe que esse público frequenta?
+
+Aguarde o operador responder. Ele pode:
+- Escolher uma mensagem e aprovar tudo
+- Pedir ajustes em seções específicas
+- Combinar elementos de mais de uma mensagem
+
+Incorpore todos os ajustes e gere a versão final.
+
+## Finalização
+
+Operador aprova (com ou sem ajustes).
+1. Salve em `squads/{squad}/clientes/{cliente}/outputs/geral-persona-icp.json` (com campo `summary` no topo)
+2. Atualize `client.json`: progress.skills → completed, version++, append em history[]
+3. Salve também uma versão Markdown do entregável na mesma pasta de outputs.
+4. Sugira próxima skill do dependency_graph
+   - "ICP e Persona salvos. Este output será usado por: account-auditoria-comunicacao, geral-pesquisa-mercado, geral-posicionamento-estrategico, e todas as skills de produção."
+   - Sugira a próxima skill da semana 1 (ex: gt-diagnostico-maturidade-digital ou account-auditoria-comunicacao)

--- a/.claude/skills/geral-persona-icp/references/exemplos-bom-vs-ruim.md
+++ b/.claude/skills/geral-persona-icp/references/exemplos-bom-vs-ruim.md
@@ -1,0 +1,213 @@
+# ICP e Persona: Exemplos Bom vs Ruim
+
+Este documento serve de calibracao para garantir que o ICP gerado seja especifico, concreto e util — nao generico e descartavel.
+
+---
+
+## Exemplo 1: Clinica de Estetica em Curitiba
+
+### RUIM (generico, descartavel)
+
+**ICP:**
+- Mulheres, 25-55 anos
+- Classe B/C
+- Se preocupam com aparencia
+- Querem ficar bonitas
+
+**Persona:** Maria, 35 anos, mulher vaidosa que gosta de se cuidar.
+
+**Jobs-to-be-Done:** "Quer ficar mais bonita e se sentir bem consigo mesma."
+
+**Problemas:**
+- Tudo e obvio — qualquer clinica poderia usar
+- "Mulheres 25-55" e metade da populacao feminina
+- O job e tao generico que serve para academia, salao, dermatologista
+- A persona nao e uma pessoa, e um estereotipo
+
+### BOM (especifico, acionavel)
+
+**ICP:**
+- Mulheres 32-48 anos, renda familiar acima de R$12k/mes
+- Moram em Curitiba ou regiao metropolitana (ate 30min de carro)
+- Profissionais ativas (advogadas, medicas, empresarias, gerentes)
+- Ja fizeram pelo menos 1 procedimento estetico na vida (nao sao novatas)
+- Gastam R$500-2000/mes com autocuidado (salao, academia, dermato)
+- Pesquisam no Instagram e Google antes, mas a decisao final vem de indicacao de amiga
+
+**Persona:** Fernanda, 41 anos, advogada tributarista. Trabalha 50h/semana. Percebeu sulcos nasogenianos e flacidez no pescoco depois dos 40. Ja fez botox e preenchimento, mas procura algo mais "natural" — tem medo de ficar com cara de "fez procedimento". Segue @dracarolinebittencourt e @renatavasconcellos no Instagram. Pesquisa "harmonizacao facial natural Curitiba" no Google. A ultima clinica que foi, o medico nem olhou direito pra ela — atendeu em 15 minutos e cobrou R$2.500.
+
+**Frase:** "Eu so quero parecer descansada. Nao quero que ninguem note que fiz algo — quero que perguntem se eu voltei de ferias."
+
+**Jobs-to-be-Done:**
+- Funcional: "Quando olho no espelho e vejo sinais de cansaco que nao saem com creme, quero um tratamento que me rejuvenesca de forma gradual e natural, para que eu continue parecendo eu mesma, so que melhor."
+- Emocional: "Quero me sentir confiante no tribunal e em reunioes sem pensar no que estao olhando no meu rosto."
+- Social: "Quero que as pessoas digam 'voce esta otima!' e nao 'voce fez algo?'."
+
+**Por que e bom:**
+- Faixa etaria restrita e justificada (pos-40 e o gatilho)
+- Renda especifica que valida o ticket
+- Comportamento de pesquisa mapeado com canais reais
+- A persona tem profissao, rotina, experiencia previa, e medo especifico
+- A frase-citacao soa como algo que alguem realmente diria
+- Os jobs sao impossveis de confundir com outro negocio
+
+---
+
+## Exemplo 2: SaaS de Gestao para Restaurantes
+
+### RUIM
+
+**ICP:**
+- Donos de restaurante
+- Querem organizar o negocio
+- Ticket: R$299/mes
+
+**Persona:** Joao, 45 anos, dono de restaurante que nao tem tempo.
+
+**Jobs:** "Quer ter mais controle do negocio."
+
+### BOM
+
+**ICP:**
+- Donos de restaurantes independentes (nao redes/franquias) com faturamento entre R$80k-R$400k/mes
+- 1-3 unidades, equipe de 8-30 funcionarios
+- Cidades com mais de 200k habitantes
+- Ja tentaram planilha mas nao conseguem manter atualizada
+- Pagam contador mas nao tem visao de DRE em tempo real
+- Principal canal de venda: iFood + balcao (hibrido)
+- Decisor: dono que tambem opera (cozinha ou salao)
+- Nao tem gerente financeiro — faz tudo ele mesmo ou com 1 auxiliar
+
+**Persona:** Toninho, 38 anos, dono do "Sabor & Arte" (restaurante contemporaneo em Campinas). Fatura R$180k/mes mas nao sabe quanto sobra. O iFood come 27% do faturamento mas responde por 45% dos pedidos. Tem 14 funcionarios e a folha de pagamento e seu maior custo. Usa uma planilha que o sobrinho fez no Google Sheets, mas so atualiza quando "da tempo" (nunca). O contador manda o DRE com 40 dias de atraso. Na semana passada, vendeu 30 pratos do dia que davam prejuizo por prato porque nao tinha ficha tecnica atualizada.
+
+**Frase:** "Eu trabalho 14 horas por dia e no final do mes nao sei se dei lucro ou prejuizo. So descubro quando o contador manda o balancete — ai ja era."
+
+**Jobs:**
+- Funcional: "Quando chego no restaurante as 7h e preciso decidir o que comprar e quanto produzir, quero ver os numeros de ontem e a projecao da semana em 2 minutos, para que eu nao compre demais nem falte insumo no sabado."
+- Emocional: "Quero a tranquilidade de saber que o restaurante esta saudavel financeiramente mesmo quando nao estou la."
+- Social: "Quero poder dizer pro meu socio e pra minha esposa exatamente quanto o negocio esta dando, com numeros, nao com achismo."
+
+**Por que e bom:**
+- Faturamento especifico que valida o ticket do SaaS
+- Perfil operacional detalhado (iFood, folha, sem gerente financeiro)
+- A persona tem um problema CONCRETO (vendeu prato com prejuizo)
+- O job funcional descreve o momento exato do dia em que o software e usado
+- A frase revela a dor real: trabalha muito e nao tem controle
+
+---
+
+## Exemplo 3: Escritorio de Advocacia Trabalhista
+
+### RUIM
+
+**ICP:**
+- Empresas que precisam de advogado trabalhista
+- PMEs
+- Preocupadas com processos
+
+**Persona:** Carlos, empresario que tem medo de processos trabalhistas.
+
+### BOM
+
+**ICP:**
+- Empresas com 20-150 funcionarios em regime CLT
+- Segmentos com alta rotatividade: varejo, alimentacao, logistica, call center
+- Faturamento entre R$2M-R$20M/ano
+- Ja sofreram pelo menos 1 processo trabalhista nos ultimos 2 anos
+- Nao tem departamento juridico interno — usam advogado sob demanda
+- Decisor: dono ou diretor administrativo/financeiro
+- Localizacao: Grande Sao Paulo (ate 40km do escritorio para reunioes presenciais)
+
+**Persona:** Dona Marcia, 52 anos, dona de uma rede de 3 lojas de roupas femininas no ABC Paulista. 47 funcionarios CLT, rotatividade media de 8 por ano. Ja perdeu R$180k em 2 processos trabalhistas nos ultimos 18 meses (horas extras nao registradas e assedio moral de gerente). Usa um advogado "do primo" que cobra barato mas nao faz preventivo. Vive com medo de ser surpreendida por uma nova notificacao. Tem uma gerente que ela sabe que "fala grosso" com funcionarios mas nao sabe como resolver sem demiti-la (e perder a melhor vendedora da rede).
+
+**Frase:** "Eu nao quero mais apagar incendio. Quero alguem que me diga o que eu tenho que mudar ANTES de virar processo."
+
+**Jobs:**
+- Funcional: "Quando recebo uma notificacao do Tribunal do Trabalho, quero ter um advogado que ja conheca minha empresa e responda em 48h, para que eu nao perca prazo nem pague multa."
+- Emocional: "Quero dormir tranquila sabendo que minha empresa esta protegida e que nao vou ser pega de surpresa."
+- Social: "Quero que meus funcionarios me vejam como uma empresa seria e organizada, nao como aquela que 'enrola' nos direitos."
+
+---
+
+## Exemplo 4: E-commerce de Suplementos
+
+### RUIM
+
+**ICP:**
+- Homens que treinam
+- 18-40 anos
+- Querem resultado rapido
+
+**Persona:** Pedro, 25 anos, treina todo dia e quer ficar grande.
+
+### BOM
+
+**ICP:**
+- Homens 26-38 anos, renda individual R$4k-R$10k/mes
+- Treinam musculacao 4-6x/semana ha mais de 2 anos (nao sao iniciantes)
+- Ja usam whey e creatina — buscam suplementacao mais avancada
+- Gastam R$200-R$600/mes em suplementos
+- Compram online (70% das compras) — preco e informacao sao decisivos
+- Leem rotulo e comparam composicao — nao compram so pela marca
+- Seguem canais de "evidencia cientifica" no YouTube (Leandro Twin, Paulo Muzy)
+- Decisao de compra: comparam 3-4 marcas no Google/Amazon, leem reviews, confiam em creators que mostram evidencia
+- Regiao: sudeste e sul (70% do faturamento)
+
+**Persona:** Gustavo, 31 anos, analista de dados em SP. Treina as 6h da manha antes do trabalho, 5x/semana, ha 4 anos. Ja passou pela fase de comprar o whey mais barato e percebeu que qualidade faz diferenca. Gasta R$400/mes em suplementos. Tem planilha de periodizacao e acompanha macros no MyFitnessPal. Na ultima Black Friday, comprou 3 potes de whey isolado por R$89/cada e ficou satisfeito. Pesquisa composicao no site antes de comprar. Desconfia de marcas que usam "blend proprietario" sem abrir a formula.
+
+**Frase:** "Eu nao compro suplemento por marketing — eu compro por rotulo. Me mostra a dosagem e a evidencia que eu decido."
+
+**Jobs:**
+- Funcional: "Quando estou montando meu proximo ciclo de suplementacao, quero comparar composicao e custo-beneficio entre marcas rapidamente, para que eu nao pague mais por menos produto efetivo."
+- Emocional: "Quero ter certeza de que estou colocando no corpo algo que funciona e e seguro, nao so marketing."
+- Social: "Quero ser o cara do grupo de treino que indica os melhores suplementos porque realmente entende."
+
+---
+
+## Exemplo 5: Curso Online de Confeitaria
+
+### RUIM
+
+**ICP:**
+- Mulheres que gostam de confeitaria
+- Querem aprender a fazer bolos
+- Iniciantes
+
+**Persona:** Ana, 30 anos, gosta de cozinhar e quer fazer bolos bonitos.
+
+### BOM
+
+**ICP:**
+- Mulheres 28-45 anos, maes que estao em casa (licenca, desemprego, ou escolheram sair do CLT)
+- Renda familiar R$4k-R$8k/mes — precisam complementar renda, nao e hobby
+- Ja fazem bolos para familia/amigos mas nunca venderam profissionalmente
+- Moram em cidades medias (50k-500k habitantes) onde encomenda de bolo e forte
+- Dispostas a investir R$200-R$500 num curso se tiver garantia de retorno
+- Pesquisam no Instagram (buscam perfis de confeiteiras) e YouTube (tutoriais gratis)
+- Gatilho de compra: alguem elogiou um bolo que fizeram e disse "voce devia vender"
+
+**Persona:** Renata, 34 anos, mae de 2 filhos (3 e 6 anos), mora em Londrina-PR. Saiu do emprego de auxiliar administrativa ha 1 ano quando nasceu o segundo filho. Faz bolos de aniversario para a familia desde sempre. Mes passado, fez o bolo do aniversario da filha da vizinha e recebeu R$150. Ficou animada mas nao sabe precificar, nao tem Instagram profissional, e tem medo de pegar encomenda e "dar errado". Gasta 2h por dia vendo Reels de confeitaria e pensa "eu consigo fazer isso". O marido apoia mas quer ver resultado — "se for pra gastar com curso, tem que se pagar".
+
+**Frase:** "Todo mundo fala que meu bolo e o melhor, mas eu nao sei cobrar. Tenho medo de montar o Instagram e ninguem encomendar."
+
+**Jobs:**
+- Funcional: "Quando recebo um pedido de bolo e nao sei quanto cobrar nem como organizar a producao, quero um metodo passo-a-passo que me ensine a precificar, produzir e entregar profissionalmente, para que eu consiga atender 8-10 encomendas por mes sem surtar."
+- Emocional: "Quero me sentir profissional e capaz de ter meu proprio negocio, nao so 'a mae que faz bolinho'."
+- Social: "Quero que meu marido e minha familia me vejam como alguem que tem um negocio de verdade, nao um hobby que gasta dinheiro."
+
+---
+
+## Checklist de qualidade
+
+Use este checklist para validar se o ICP e a persona estao no nivel BOM:
+
+| Criterio | Teste |
+|----------|-------|
+| Especificidade | Consigo distinguir este ICP de outro segmento? Se trocar o nome do negocio, o ICP ainda faz sentido? Se sim, esta generico |
+| Reconhecimento | Se eu mostrasse este ICP para o cliente, ele diria "e exatamente isso"? |
+| Acionabilidade | Consigo criar um anuncio no Meta Ads mirando este ICP? Se nao consigo segmentar, faltam dados |
+| Dores reais | As dores descritas causam desconforto de verdade? O cliente perderia sono por causa delas? |
+| Jobs especificos | Os jobs descrevem um MOMENTO (quando) + ACAO (quero) + RESULTADO (para que)? |
+| Persona viva | A persona tem nome, profissao, rotina, problema concreto, e frase autentica? Ou e um boneco generico? |
+| Canais concretos | Os canais listados sao especificos (nome de influencer, hashtag, grupo) ou genericos ("redes sociais")? |
+| Mensagem diferenciada | A mensagem-chave e diferente do que o concorrente diria? Se qualquer empresa do setor poderia usar, esta fraca |

--- a/.claude/skills/geral-persona-icp/references/jtbd-framework.md
+++ b/.claude/skills/geral-persona-icp/references/jtbd-framework.md
@@ -1,0 +1,118 @@
+# Framework Jobs-to-be-Done (JTBD)
+
+## O que e JTBD
+
+Jobs-to-be-Done e um framework de inovacao criado por Clayton Christensen (Harvard) que muda o foco de "quem e o cliente" para "qual tarefa o cliente esta tentando cumprir". A premissa: pessoas nao compram produtos -- elas contratam produtos para fazer um job.
+
+> "As pessoas nao querem uma furadeira de 1/4 de polegada. Elas querem um buraco de 1/4 de polegada." — Theodore Levitt
+
+Mas JTBD vai alem: elas nao querem o buraco. Querem pendurar a foto da familia na parede. E por que querem pendurar? Porque querem se sentir em casa. E querem que visitas vejam que sao uma familia unida.
+
+## Os 3 tipos de Jobs
+
+### 1. Job Funcional
+O que a pessoa precisa FAZER. E a tarefa pratica, objetiva.
+
+**Formato:** "Quando [situacao/gatilho], eu quero [motivacao/acao], para que [resultado esperado]."
+
+**Exemplos BONS:**
+- Clinica odontologica: "Quando sinto dor de dente que nao passa com remedio, quero encontrar um dentista confiavel rapido, para que resolva meu problema sem que eu precise faltar varios dias de trabalho."
+- Software de gestao: "Quando perco o controle do fluxo de caixa no final do mes, quero um sistema que me mostre entradas e saidas em tempo real, para que eu tome decisoes sem depender do contador."
+- Escola particular: "Quando meu filho esta na transicao para o ensino medio, quero uma escola que o prepare para o vestibular sem matar a criatividade, para que ele tenha opcoes de carreira."
+
+**Exemplos RUINS (genericos demais):**
+- "Quero crescer o negocio" — isso nao e um job, e uma aspiracao
+- "Quero um produto de qualidade" — obvio demais, todo mundo quer
+- "Quero economizar tempo" — em que? quando? fazendo o que?
+
+### 2. Job Emocional
+Como a pessoa quer se SENTIR durante e apos a experiencia.
+
+**Exemplos BONS:**
+- Clinica odontologica: "Quero me sentir seguro de que o profissional sabe o que esta fazendo e nao vai me causar mais dor do que o necessario."
+- Software de gestao: "Quero sentir que tenho controle do meu negocio, nao que o negocio me controla."
+- Escola particular: "Quero ter tranquilidade de que fiz a melhor escolha para o futuro do meu filho."
+
+**Exemplos RUINS:**
+- "Quero me sentir bem" — vago
+- "Quero ser feliz" — isso e tudo, nao e nada
+- "Quero ficar satisfeito com a compra" — obvio
+
+### 3. Job Social
+Como a pessoa quer ser VISTA pelos outros ao usar/consumir a solucao.
+
+**Exemplos BONS:**
+- Clinica odontologica: "Quero poder sorrir em fotos sem vergonha e parecer alguem que se cuida."
+- Software de gestao: "Quero parecer um gestor organizado e profissional quando investidores pedirem numeros."
+- Escola particular: "Quero que outros pais reconhecam que fiz uma boa escolha educacional."
+
+**Exemplos RUINS:**
+- "Quero parecer bem-sucedido" — generico
+- "Quero impressionar os amigos" — infantil e pouco util
+
+## Como identificar Jobs reais
+
+### Perguntas para descobrir o Job Funcional
+1. O que aconteceu ANTES de voce decidir procurar essa solucao?
+2. Qual foi o momento exato em que voce pensou "preciso resolver isso"?
+3. Quais alternativas voce tentou antes? Por que nao funcionaram?
+4. Se voce nao tivesse essa solucao, o que faria? (O substituto revela o job real)
+
+### Perguntas para descobrir o Job Emocional
+1. O que mais te incomoda nessa situacao?
+2. Como voce se sente quando o problema aparece?
+3. Quando o problema e resolvido, o que muda no seu dia?
+4. O que te faria dormir tranquilo em relacao a isso?
+
+### Perguntas para descobrir o Job Social
+1. Se alguem perguntasse por que voce escolheu essa solucao, o que diria?
+2. O que seus colegas/amigos/familia pensariam se soubessem?
+3. Existe algum "status" associado a usar/nao usar esse tipo de solucao?
+
+## Aplicacao no ICP V4
+
+Ao construir o ICP para um cliente V4, siga esta ordem:
+
+1. **Comece pelo Job Funcional** — identifique a tarefa que o cliente precisa cumprir
+2. **Mapeie as Dores** — o que impede de cumprir o job hoje?
+3. **Mapeie os Ganhos** — qual o resultado ideal quando o job e cumprido?
+4. **Identifique o Job Emocional** — como o cliente quer se sentir?
+5. **Identifique o Job Social** — como o cliente quer ser percebido?
+6. **Valide com dados** — os "melhores clientes" descritos no briefing se encaixam?
+
+### Armadilhas comuns
+
+| Armadilha | Exemplo | Correcao |
+|-----------|---------|----------|
+| Confundir job com feature | "Quer um app rapido" | "Quer resolver X sem perder tempo" |
+| Job generico demais | "Quer crescer" | "Quer dobrar o faturamento em 12 meses para abrir a segunda unidade" |
+| Projetar desejos do negocio no cliente | "Quer uma marca forte" | "Quer que clientes cheguem ja confiando, sem precisar convencer" |
+| Ignorar o contexto/gatilho | "Quer contratar marketing" | "Quando perdeu 30% das vendas para o concorrente que aparece no Google, decidiu investir em marketing" |
+| Job emocional superficial | "Quer se sentir bem" | "Quer a seguranca de que nao esta desperdicando dinheiro com marketing que nao funciona" |
+
+## Jobs-to-be-Done por segmento (exemplos V4)
+
+### E-commerce de Moda
+- **Funcional:** "Quando preciso renovar o guarda-roupa para a nova estacao, quero encontrar pecas que combinem com meu estilo sem gastar horas em shopping, para que eu esteja sempre bem-vestida sem estresse."
+- **Emocional:** "Quero me sentir estilosa e atual sem gastar uma fortuna."
+- **Social:** "Quero que as pessoas perguntem 'onde voce comprou isso?' quando me virem."
+
+### Clinica de Estetica
+- **Funcional:** "Quando percebo sinais de envelhecimento no espelho que me incomodam, quero um tratamento que de resultado visivel sem parecer artificial, para que eu me sinta como a versao mais jovem de mim mesma."
+- **Emocional:** "Quero recuperar a autoestima sem medo de ficar com aparencia de 'fez procedimento'."
+- **Social:** "Quero que as pessoas digam que estou bem, nao que 'fez algo no rosto'."
+
+### Escritorio de Contabilidade
+- **Funcional:** "Quando o fiscal da empresa fica desatualizado e tenho medo de multas, quero um contador que me avise ANTES dos problemas, nao depois, para que eu foque no negocio sem surpresas tributarias."
+- **Emocional:** "Quero ter certeza de que estou pagando o minimo possivel de imposto dentro da lei, sem risco."
+- **Social:** "Quero parecer um empresario organizado que tem as contas em dia quando um investidor pedir os numeros."
+
+### Escola de Idiomas
+- **Funcional:** "Quando percebo que estou perdendo oportunidades de carreira por nao falar ingles, quero aprender rapido o suficiente para participar de reunioes em 6 meses, sem atrapalhar minha rotina de trabalho."
+- **Emocional:** "Quero parar de sentir vergonha quando alguem fala ingles e eu nao consigo responder."
+- **Social:** "Quero ser visto como alguem qualificado internacionalmente no meu ambiente de trabalho."
+
+### Construtora / Imobiliaria
+- **Funcional:** "Quando decido que e hora de sair do aluguel, quero encontrar um imovel que caiba no meu orcamento sem burocracia que emperre o processo, para que eu mude em menos de 6 meses."
+- **Emocional:** "Quero a seguranca de que estou fazendo o maior investimento da minha vida com uma empresa seria."
+- **Social:** "Quero convidar familia e amigos para a casa nova e sentir orgulho de onde moro."

--- a/.claude/skills/geral-persona-icp/references/padrao-output.md
+++ b/.claude/skills/geral-persona-icp/references/padrao-output.md
@@ -1,0 +1,202 @@
+# Padrão de Output das Skills — V4 Estruturação IA
+
+Este documento define a **estrutura canônica** que todos os outputs de skill devem seguir para renderizar no portal com hierarquia visual consistente. O objetivo é que o operador e o stakeholder final abram qualquer entregável e encontrem o mesmo ritmo: manchete → KPIs → achados categorizados → ponto de alavancagem destacado → detalhes expansíveis.
+
+---
+
+## Princípios
+
+1. **Manchete antes de texto.** Toda skill abre com uma frase única e específica que resume a conclusão. Não é parágrafo, é headline.
+2. **Números em destaque, não escondidos no corpo do texto.** KPIs que importam viram cards. Texto corrido é para contexto, não para fato quantitativo.
+3. **Achados categorizados por intenção.** Cada insight é classificado como `vantagem | contexto | ameaca | acao` — o leitor identifica o tom antes de ler.
+4. **Ponto de alavancagem visualmente isolado.** Toda skill tem UM ponto onde a conversa com o stakeholder precisa acontecer. Esse ponto ganha hero visual (border, gradient, quote destacada).
+5. **Detalhe denso → colapsável.** Listas longas (concorrentes, itens de checklist, fontes) ficam em `<details>` para não afogar a leitura.
+
+---
+
+## Campos obrigatórios no JSON
+
+Todo output de skill DEVE ter estes campos no topo (antes dos campos específicos da skill):
+
+```json
+{
+  "client_name": "Nome do Cliente",
+  "summary": "Resumo em 1-2 frases. Específico, com dados reais. Alimenta o resumo executivo do portal.",
+
+  "summary_headline": "Manchete em 1 linha (max 120 caracteres). A frase que o stakeholder lê primeiro.",
+
+  "summary_highlights": [
+    {
+      "category": "posicao | competicao | janela | maturidade | oportunidade | risco",
+      "label": "Rótulo curto (max 30 char)",
+      "value": "Valor em destaque (número, %, status)",
+      "subtext": "Contexto em 1 linha (max 60 char)",
+      "tone": "green | yellow | red | blue | gray"
+    }
+  ],
+
+  "summary_key_findings": [
+    {
+      "category": "vantagem | contexto | ameaca | acao",
+      "text": "Achado em 1-2 linhas. Específico, acionável."
+    }
+  ]
+}
+```
+
+### Regras dos campos de summary
+
+**`summary_headline`**: É a ÚNICA frase que o stakeholder precisa ler se só tiver 5 segundos. Deve conter o veredito da skill. Exemplos bons:
+- ✓ "[Cliente] é o ÚNICO player premium da microrregião com [diferencial declarado] — janela competitiva de 12-18 meses."
+- ✗ "Análise de mercado concluída com sucesso."
+
+**`summary_highlights`** (4-6 itens): KPIs visuais. Categorias sugeridas:
+- `posicao` — onde o cliente está hoje vs potencial
+- `competicao` — quem disputa o mesmo espaço
+- `janela` — tempo/urgência
+- `maturidade` — estágio atual em algum eixo
+- `oportunidade` — tamanho do ganho possível
+- `risco` — tamanho da ameaça
+
+Agrupar de 2 em 2 por categoria no renderer (dá layout balanceado 3x2 ou 2x2).
+
+**`summary_key_findings`** (3-5 itens): Achados que embasam a manchete. Categorias:
+- `vantagem` (✓ verde) — o que o cliente tem a favor
+- `contexto` (i azul) — o que é fato do mercado, neutro
+- `ameaca` (! vermelho) — o que pode dar errado
+- `acao` (▸ laranja) — o que precisa ser feito
+
+---
+
+## Ponto de Alavancagem (hero block)
+
+Toda skill deve identificar **UM bloco que merece destaque visual especial** — o ponto onde a conversa estratégica precisa acontecer. O nome do campo varia por skill, mas a estrutura é consistente:
+
+```json
+{
+  "key_leverage_point": {
+    "headline": "Frase-manchete do ponto (pode ir como quote)",
+    "context": "Contexto em 2-3 linhas explicando o cenário",
+    "numbered_reasons": [
+      "Razão 1 (parse-friendly, pode começar com texto direto)",
+      "Razão 2",
+      "Razão 3"
+    ],
+    "discussion_anchor": "Frase curta sobre POR QUE este é o ponto de conversa com o stakeholder"
+  }
+}
+```
+
+Exemplos por skill:
+- `pesquisa-mercado` → `unexploited_opportunity` (whitespace estratégico)
+- `persona-icp` → persona principal + dor mais ignorada
+- `swot` → combinação força × oportunidade mais assimétrica
+- `posicionamento` → PUV vs alternativas descartadas
+- `diagnostico-midia` → canal mais subotimizado + upside estimado
+- `diagnostico-maturidade` → pilar mais fraco com maior impacto
+
+O renderer aplica:
+- Border verde 2px + gradient sutil
+- Selo "Whitespace Estratégico · Discussão com Stakeholder" no topo
+- Pill de viabilidade/urgência à direita
+- Quote/headline em card branco isolado
+- Razões numeradas em 3 círculos
+- Footer "💬 Momento de validar com a stakeholder"
+
+---
+
+## Alerta de honestidade
+
+Se a pesquisa/análise revelou fragilidade do cliente (não há diferencial real, ICP mal definido, mercado saturado, etc.), inclua:
+
+```json
+{
+  "honesty_alert": "Texto explicando a fragilidade encontrada e o que precisa ser feito antes de seguir."
+}
+```
+
+Esse campo renderiza em box amarelo/vermelho após os achados. **Nunca omita** se a realidade justifica. O valor do sistema depende de não vender aspiracional como real.
+
+---
+
+## Instrução para a IA da skill
+
+Em cada `SKILL.md`, incluir esta seção na geração:
+
+> ### Estrutura visual (obrigatória)
+>
+> Além dos campos específicos desta skill, gere SEMPRE:
+>
+> - `summary_headline` — manchete em 1 linha com o veredito
+> - `summary_highlights` — 4-6 KPIs categorizados (`posicao|competicao|janela|maturidade|oportunidade|risco`) com `{label, value, subtext, tone}`
+> - `summary_key_findings` — 3-5 achados categorizados (`vantagem|contexto|ameaca|acao`)
+> - `honesty_alert` se houver fragilidade
+>
+> Identifique o **ponto de alavancagem** desta skill (o bloco que merece hero visual) e estruture-o com headline + contexto + razões numeradas + discussion anchor.
+>
+> Consulte `references/padrao-output.md` para especificação completa.
+
+E na auto-validação:
+
+> - [ ] Tem `summary_headline` específico (não "análise concluída")?
+> - [ ] `summary_highlights` tem 4-6 itens com categorias válidas?
+> - [ ] `summary_key_findings` cobre pelo menos 3 dos 4 tipos (vantagem/contexto/ameaça/ação)?
+> - [ ] Identificou o ponto de alavancagem para discussão com stakeholder?
+> - [ ] Se há fragilidade, incluiu `honesty_alert`?
+
+---
+
+## Completude (regra crítica)
+
+**Todo campo definido no schema da skill é obrigatório no output.** Não omitir campos — o renderer assume que os campos do schema existem e quebra/fica vazio silenciosamente quando faltam.
+
+Se um dado **não pode ser obtido** (GA4 não instalado, conector não conectado, cliente não sabe, etc.), preencher com `null` E adicionar `unavailable_reason` no objeto pai:
+
+```json
+{
+  "current_conversion_rate": null,
+  "current_bounce_rate": null,
+  "avg_time_on_page": null,
+  "unavailable_reason": "GA4 não instalado no site — métricas de analytics não coletadas nesta auditoria"
+}
+```
+
+Para arrays vazios legitimamente (ex: nenhum competidor identificado), preencher com `[]` e adicionar uma nota no campo irmão `{campo}_note`:
+
+```json
+{
+  "competitors": [],
+  "competitors_note": "Nenhum concorrente direto identificado na microrregião após busca em Google Maps + Instagram."
+}
+```
+
+Para valores **estimados** (sem fonte pública), adicionar flag `[E]` no texto OU campo `estimated: true` no objeto:
+
+```json
+{ "tam_brl": 450000000, "estimated": true, "estimation_basis": "IBGE população × SEBRAE ticket médio" }
+```
+
+**Nunca** deixar string vazia (`""`), zero falso (`0` quando não é zero real), ou omitir o campo. Essas três formas são invisíveis para o renderer e geram o bug "coluna vazia".
+
+Valide o JSON contra o `schema.json` empacotado na skill e corrija campos ausentes ou `null` sem `unavailable_reason`.
+
+### Checklist adicional de auto-validação
+
+> - [ ] Todos os campos do schema estão presentes (preenchidos ou com `null` + `unavailable_reason`)?
+> - [ ] Nenhuma string vazia (`""`) — substituí por `null` + reason quando o dado não existe?
+> - [ ] Arrays vazios legítimos têm `{campo}_note` explicando por quê?
+> - [ ] Estimativas marcadas com `estimated: true` ou `[E]`?
+
+---
+
+## Tons de voz
+
+- `green` — oportunidade/vantagem/confirmado
+- `yellow` — atenção/potencial/médio
+- `red` — risco/ameaça/fraco
+- `blue` — contexto/informativo/neutro
+- `gray` — desativado/aspiracional/ausente
+
+Usar tons consistentemente: nunca pintar ameaça de verde ou vantagem de vermelho para "chamar atenção". O tom é semântico.
+
+---

--- a/.claude/skills/geral-persona-icp/schema.json
+++ b/.claude/skills/geral-persona-icp/schema.json
@@ -1,0 +1,664 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PersonaICP",
+  "description": "Output estruturado da skill persona-icp: ICP completo com JTBD, persona detalhada, canais de aquisição e mensagem-chave.",
+  "type": "object",
+  "required": [
+    "summary",
+    "icp",
+    "persona",
+    "where_to_find",
+    "key_message",
+    "client_name",
+    "summary_headline",
+    "summary_highlights",
+    "summary_key_findings"
+  ],
+  "properties": {
+    "client_name": {
+      "type": "string",
+      "description": "Nome do cliente — sempre presente em todo output."
+    },
+    "summary": {
+      "type": "string",
+      "description": "Resumo executivo de 2-3 frases do ICP e persona. Usado como referência rápida por outras skills."
+    },
+    "summary_headline": {
+      "type": "string",
+      "maxLength": 200,
+      "description": "Manchete em 1 linha com o veredito desta skill (hero do resumo executivo no portal). Ver references/padrao-output.md"
+    },
+    "summary_highlights": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 8,
+      "description": "KPIs visuais categorizados para o resumo executivo. Cada item: {category, label, value, subtext, tone}.",
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "label",
+          "value"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "posicao",
+              "competicao",
+              "janela",
+              "maturidade",
+              "oportunidade",
+              "risco"
+            ]
+          },
+          "label": {
+            "type": "string",
+            "maxLength": 40
+          },
+          "value": {
+            "type": "string"
+          },
+          "subtext": {
+            "type": "string",
+            "maxLength": 80
+          },
+          "tone": {
+            "type": "string",
+            "enum": [
+              "green",
+              "yellow",
+              "red",
+              "blue",
+              "gray"
+            ]
+          }
+        }
+      }
+    },
+    "summary_key_findings": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 6,
+      "description": "Achados categorizados por intenção (vantagem/contexto/ameaça/ação). Pelo menos 3 dos 4 tipos cobertos.",
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "text"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "vantagem",
+              "contexto",
+              "ameaca",
+              "acao"
+            ]
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "icp": {
+      "type": "object",
+      "required": [
+        "demographics",
+        "behavior",
+        "jobs",
+        "pains",
+        "gains"
+      ],
+      "properties": {
+        "demographics": {
+          "type": "object",
+          "description": "Perfil demográfico do cliente ideal.",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "B2B",
+                "B2C",
+                "mixed"
+              ],
+              "description": "Tipo de cliente: B2B, B2C, ou misto."
+            },
+            "age_range": {
+              "type": "string",
+              "description": "Faixa etária (B2C) ou faixa de faturamento (B2B)."
+            },
+            "income_or_revenue": {
+              "type": "string",
+              "description": "Renda mensal (B2C) ou faturamento anual (B2B)."
+            },
+            "location": {
+              "type": "string",
+              "description": "Região geográfica principal."
+            },
+            "company_size": {
+              "type": "string",
+              "description": "B2B: número de funcionários. B2C: omitir ou null."
+            },
+            "decision_maker_role": {
+              "type": "string",
+              "description": "B2B: cargo do decisor. B2C: perfil pessoal."
+            },
+            "education": {
+              "type": "string",
+              "description": "Nível de escolaridade típico."
+            },
+            "other": {
+              "type": "object",
+              "description": "Campos adicionais específicos do segmento.",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "behavior": {
+          "type": "object",
+          "description": "Como o ICP se comporta no processo de compra.",
+          "properties": {
+            "decision_process": {
+              "type": "string",
+              "description": "Como toma decisão de compra (racional/emocional, individual/comitê)."
+            },
+            "research_channels": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Onde pesquisa antes de comprar."
+            },
+            "main_objections": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Principais objeções na hora da compra."
+            },
+            "switching_triggers": {
+              "type": "string",
+              "description": "O que faz trocar de fornecedor."
+            },
+            "purchase_frequency": {
+              "type": "string",
+              "description": "Frequência de compra e ciclo de decisão."
+            }
+          }
+        },
+        "jobs": {
+          "type": "object",
+          "required": [
+            "functional",
+            "emotional",
+            "social"
+          ],
+          "description": "Jobs-to-be-Done: tarefas que o cliente está tentando cumprir.",
+          "properties": {
+            "functional": {
+              "type": "string",
+              "description": "Job funcional no formato: 'Quando [situação], eu quero [motivação], para que [resultado]'."
+            },
+            "emotional": {
+              "type": "string",
+              "description": "Job emocional: como o cliente quer se sentir durante e após a compra."
+            },
+            "social": {
+              "type": "string",
+              "description": "Job social: como o cliente quer ser visto pelos outros."
+            }
+          }
+        },
+        "pains": {
+          "type": "array",
+          "minItems": 3,
+          "maxItems": 5,
+          "items": {
+            "type": "object",
+            "required": [
+              "pain",
+              "intensity"
+            ],
+            "properties": {
+              "pain": {
+                "type": "string",
+                "description": "Descrição da dor na linguagem do cliente."
+              },
+              "intensity": {
+                "type": "string",
+                "enum": [
+                  "critical",
+                  "high",
+                  "medium"
+                ],
+                "description": "Intensidade da dor."
+              },
+              "current_workaround": {
+                "type": "string",
+                "description": "Como o cliente lida com essa dor hoje (se aplicável)."
+              }
+            }
+          },
+          "description": "Dores do ICP, ordenadas da mais intensa para a menos."
+        },
+        "gains": {
+          "type": "array",
+          "minItems": 3,
+          "maxItems": 5,
+          "items": {
+            "type": "object",
+            "required": [
+              "gain",
+              "type"
+            ],
+            "properties": {
+              "gain": {
+                "type": "string",
+                "description": "Ganho desejado pelo cliente."
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "tangible",
+                  "intangible"
+                ],
+                "description": "Se o ganho é tangível (mensurável) ou intangível (sentimento/percepção)."
+              }
+            }
+          },
+          "description": "Ganhos que o ICP deseja alcançar."
+        }
+      }
+    },
+    "persona": {
+      "type": "object",
+      "required": [
+        "name",
+        "photo_description",
+        "story",
+        "quote"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Nome fictício da persona."
+        },
+        "photo_description": {
+          "type": "string",
+          "description": "Descrição detalhada para gerar foto da persona (idade, expressão, contexto, vestuário)."
+        },
+        "story": {
+          "type": "string",
+          "description": "História de 1 parágrafo: situação atual, desafios, e por que precisa da solução."
+        },
+        "quote": {
+          "type": "string",
+          "description": "Frase que a persona diria sobre o problema. Deve soar como transcrição real."
+        }
+      }
+    },
+    "where_to_find": {
+      "type": "object",
+      "required": [
+        "digital_channels",
+        "keywords",
+        "influencers",
+        "communities"
+      ],
+      "properties": {
+        "digital_channels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Canais digitais específicos onde o ICP está (não genéricos)."
+        },
+        "keywords": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Palavras-chave que o ICP busca no Google/YouTube."
+        },
+        "influencers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Perfis, podcasts, canais que o ICP acompanha."
+        },
+        "communities": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Grupos, fóruns, associações, eventos que o ICP frequenta."
+        }
+      }
+    },
+    "anti_persona": {
+      "type": "object",
+      "description": "Perfis que NÃO são cliente ideal. Define quando o time diz 'não'.",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "profiles": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 4,
+          "items": {
+            "type": "object",
+            "description": "Cada perfil tem um identificador (profile_name OU label), uma descrição (description OU who) e uma lista de sinais (signals OU red_flags). O renderer do portal aceita ambos os conjuntos.",
+            "properties": {
+              "profile_name": {
+                "type": "string",
+                "description": "Apelido descritivo (ex: 'Caçador de preço'). Alternativa: 'label'."
+              },
+              "label": {
+                "type": "string",
+                "description": "Alternativa a 'profile_name'."
+              },
+              "description": {
+                "type": "string",
+                "description": "Comportamento típico em 2-3 linhas. Alternativa: 'who'."
+              },
+              "who": {
+                "type": "string",
+                "description": "Alternativa a 'description'."
+              },
+              "why_not": {
+                "type": "string",
+                "description": "Por que não é cliente ideal."
+              },
+              "signals": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Sinais concretos que o time usa para identificar esse perfil (3-6 itens). Alternativa: 'red_flags'."
+              },
+              "red_flags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Alternativa a 'signals'."
+              },
+              "operational_rule": {
+                "type": "string",
+                "description": "Como o time identifica e o que faz."
+              }
+            }
+          }
+        },
+        "operational_rule": {
+          "type": "string",
+          "description": "Regra-mãe que alinha o time."
+        }
+      }
+    },
+    "buyer_journey": {
+      "type": "object",
+      "description": "Jornada de decisão da persona do gatilho ao pós-compra.",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "stages": {
+          "type": "array",
+          "minItems": 4,
+          "maxItems": 7,
+          "items": {
+            "type": "object",
+            "required": [
+              "stage",
+              "mental_state",
+              "dominant_question"
+            ],
+            "properties": {
+              "stage": {
+                "type": "string"
+              },
+              "trigger": {
+                "type": "string",
+                "description": "O que inicia esse estágio."
+              },
+              "mental_state": {
+                "type": "string",
+                "description": "Estado mental dominante."
+              },
+              "primary_channel": {
+                "type": "string",
+                "description": "Onde a persona busca informação."
+              },
+              "dominant_question": {
+                "type": "string",
+                "description": "A pergunta que ela tenta responder."
+              },
+              "client_intervention": {
+                "type": "string",
+                "description": "Como o cliente intervém nesse estágio."
+              },
+              "friction_today": {
+                "type": "string",
+                "description": "Atrito/problema atual nesse estágio."
+              },
+              "duration_estimate": {
+                "type": "string",
+                "description": "Tempo típico (horas/dias/semanas)."
+              }
+            }
+          }
+        },
+        "critical_leakage_point": {
+          "description": "Estágio onde o cliente mais perde leads hoje. Aceita duas formas: (a) string livre com diagnóstico textual, ou (b) objeto estruturado com stage/evidence/estimated_loss_pct. A string é mais natural quando o vazamento é qualitativo; o objeto quando há número de perda.",
+          "oneOf": [
+            {
+              "type": "string",
+              "description": "Diagnóstico livre do ponto de vazamento (1-3 frases)."
+            },
+            {
+              "type": "object",
+              "properties": {
+                "stage": {
+                  "type": "string"
+                },
+                "evidence": {
+                  "type": "string"
+                },
+                "estimated_loss_pct": {
+                  "type": "number"
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "willingness_to_pay": {
+      "type": "object",
+      "description": "Faixas de preço que a persona aceita por serviço/produto principal.",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "services": {
+          "type": "array",
+          "description": "Cada serviço tem faixa atual, faixa justa percebida e teto premium. Shape preferido: 'current_ticket_range' + 'perceived_fair_range' + 'premium_ceiling' (strings como 'R$180-250' ou 'R$400'). O shape legado (current_price/fair_range/premium_range) ainda é aceito pelo renderer.",
+          "items": {
+            "type": "object",
+            "required": [
+              "service"
+            ],
+            "properties": {
+              "service": {
+                "type": "string",
+                "description": "Nome do serviço precificado."
+              },
+              "current_ticket_range": {
+                "type": "string",
+                "description": "PREFERIDO. Faixa de ticket atual praticada (ex: 'R$180-250')."
+              },
+              "perceived_fair_range": {
+                "type": "string",
+                "description": "PREFERIDO. Faixa que a persona percebe como justa (ex: 'R$180-300')."
+              },
+              "premium_ceiling": {
+                "type": "string",
+                "description": "PREFERIDO. Teto premium que a persona aceita pagar com justificativa (ex: 'R$400 com exame incluso')."
+              },
+              "current_price": {
+                "type": [
+                  "number",
+                  "string"
+                ],
+                "description": "LEGADO. Alternativa a current_ticket_range."
+              },
+              "fair_range": {
+                "type": "string",
+                "description": "LEGADO. Alternativa a perceived_fair_range."
+              },
+              "premium_range": {
+                "type": "string",
+                "description": "LEGADO. Alternativa a premium_ceiling."
+              },
+              "elasticity": {
+                "type": "string",
+                "description": "Elasticidade de preço. Pode ser palavra única (alta/média/baixa) ou frase com nuance separada por '—' ou ':' (ex: 'baixa — aceita pagar mais se entender o porquê'). O portal usa a primeira palavra como tag e o restante como nota explicativa."
+              },
+              "pricing_lever": {
+                "type": "string",
+                "description": "O que justifica cobrar mais (especialização, garantia, bundle, experiência)."
+              }
+            }
+          }
+        }
+      }
+    },
+    "objection_library": {
+      "type": "object",
+      "description": "Catálogo de objeções reais da persona com respostas testadas.",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "objections": {
+          "type": "array",
+          "minItems": 4,
+          "maxItems": 8,
+          "items": {
+            "type": "object",
+            "required": [
+              "objection",
+              "subtext",
+              "good_response"
+            ],
+            "properties": {
+              "objection": {
+                "type": "string",
+                "description": "Como ela diz, na linguagem do cliente."
+              },
+              "subtext": {
+                "type": "string",
+                "description": "O que ela realmente está dizendo."
+              },
+              "bad_response": {
+                "type": "string",
+                "description": "Resposta automática que NÃO funciona."
+              },
+              "good_response": {
+                "type": "string",
+                "description": "Resposta que funciona."
+              },
+              "when_to_use": {
+                "type": "string",
+                "description": "Canal/momento de uso."
+              }
+            }
+          }
+        }
+      }
+    },
+    "key_message": {
+      "type": "object",
+      "required": [
+        "chosen_message",
+        "approach",
+        "alternatives"
+      ],
+      "properties": {
+        "chosen_message": {
+          "type": "string",
+          "description": "Mensagem-chave final aprovada pelo operador (máx 15 palavras)."
+        },
+        "approach": {
+          "type": "string",
+          "enum": [
+            "functional",
+            "emotional",
+            "social",
+            "combined"
+          ],
+          "description": "Abordagem da mensagem escolhida."
+        },
+        "usage_context": {
+          "type": "string",
+          "description": "Onde usar esta mensagem (anúncios, bio, headline, etc.)."
+        },
+        "alternatives": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "message": {
+                "type": "string"
+              },
+              "approach": {
+                "type": "string"
+              },
+              "rationale": {
+                "type": "string"
+              }
+            }
+          },
+          "description": "As 3 opções apresentadas ao operador (incluindo a escolhida)."
+        }
+      }
+    },
+    "key_insight": {
+      "type": "object",
+      "description": "Ponto de alavancagem desta skill — o bloco que merece destaque visual para conversa com o stakeholder. Ver PADRAO-OUTPUT.md.",
+      "properties": {
+        "headline": {
+          "type": "string",
+          "description": "Frase-manchete do ponto (pode virar quote destacada no renderer)"
+        },
+        "context": {
+          "type": "string",
+          "description": "Contexto em 2-3 linhas explicando o cenário"
+        },
+        "numbered_reasons": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Razões numeradas (o renderer vira 3 cards numerados)"
+        },
+        "discussion_anchor": {
+          "type": "string",
+          "description": "Por que este é o ponto para stakeholder decidir/validar"
+        }
+      }
+    },
+    "honesty_alert": {
+      "type": "string",
+      "description": "Alerta se a análise revelou fragilidade real do cliente (não há diferencial claro, premissa contraditória, etc.). Nunca omitir se justificado."
+    }
+  }
+}

--- a/.claude/skills/geral-pesquisa-mercado/SKILL.md
+++ b/.claude/skills/geral-pesquisa-mercado/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: geral-pesquisa-mercado
+description: "Pesquisa de mercado completa: TAM/SAM/SOM, analise de concorrentes, tendencias, JTBD e diferenciais reais. Use quando o operador disser /geral-pesquisa-mercado ou 'pesquisa de mercado' ou 'analise de concorrentes' ou 'sizing de mercado'."
+area: geral
+author: luizfreitasv4
+version: 1.0.0
+dependencies:
+  - geral-persona-icp
+tools:
+  - WebSearch
+week: 1
+estimated_time: "3h"
+output_file: "geral-pesquisa-mercado.json"
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta versao foi portada do sistema de Estruturacao Estrategica. As regras abaixo tem precedencia sobre caminhos e persistencia citados no fluxo original:
+
+- Trabalhe somente em `squads/{squad}/clientes/{cliente}/`, nunca em um diretorio `clientes/` solto na raiz.
+- Leia primeiro o `CLAUDE.md` ou `AGENTS.md` da KB, `mission-control/`, `calls/`, `docs/` e `campanhas/`.
+- Se `client.json` existir, use-o como fonte complementar. Se nao existir, derive o contexto da KB e do Mission Control; nao exija nem invente esse arquivo.
+- Salve entregaveis em `squads/{squad}/clientes/{cliente}/outputs/`, em JSON e Markdown quando o fluxo pedir ambos.
+- Registre decisoes e progresso no `mission-control/historico-checkins.md` ou no arquivo de historico equivalente encontrado na KB.
+- Resolva recursos empacotados a partir do proprio diretorio desta skill. Se uma integracao externa nao estiver configurada, declare o gap e continue apenas com os dados reais disponiveis.
+
+
+# Pesquisa de Mercado (POP 1.9)
+
+Voce e um analista de mercado especializado em PMEs brasileiras. Vai conduzir uma pesquisa de mercado completa para embasar o posicionamento estrategico do cliente. Esta pesquisa e a base factual que valida (ou invalida) todo o posicionamento que sera definido na skill seguinte.
+
+> **Posição no fluxo:** Semana 1 (POP 1.9) — comum a todos os modelos. Divisão de trabalho com a `geral-analise-swot`: o **scorecard digital 0-10** dos concorrentes é gerado lá (POP 1.5); aqui o foco é **TAM/SAM/SOM + market share + posicionamento competitivo profundo + tendências**. Não duplique o scorecard; aprofunde o sizing e a leitura estratégica.
+
+## Dados necessários
+
+1. Leia `client.json` (seção `briefing`) do cliente — extraia: NOME_CLIENTE, SEGMENTO, REGIAO, PRODUTO_SERVICO, CONCORRENTES
+2. Leia `outputs/geral-persona-icp.json` — extraia: RESUMO_ICP, dores principais, Jobs-to-be-Done
+3. Se houver `client.json` (seção `connectors`), verifique se ha dados de mercado ja coletados
+
+Se faltar a lista de concorrentes no briefing, pergunte ao operador:
+
+> Preciso de 3 a 5 concorrentes diretos de {NOME_CLIENTE}. Podem ser empresas da mesma regiao ou concorrentes online. Quem sao?
+
+Se o operador nao souber, use WebSearch para identificar os principais players do segmento na regiao e sugira uma lista para validacao.
+
+---
+
+## Geração
+
+Gere o output COMPLETO de uma vez usando os dados de `client.json` (briefing, connectors) e outputs de skills dependentes em `outputs/`.
+
+Use WebSearch extensivamente para pesquisar dados reais.
+
+### TAM/SAM/SOM com fontes
+
+Consulte o framework em `references/framework-tam-sam-som.md` para a metodologia completa. Busque dados reais de mercado: relatórios SEBRAE, IBGE, ABComm, Statista, etc.
+
+Para cada nível (TAM, SAM, SOM):
+- Valor em R$ (anual)
+- Descrição
+- Fonte com link
+- Premissas (para SOM)
+
+Valores marcados com [E] sao estimativas. Demais tem fonte publica.
+
+**⚠️ Regras criticas para o SOM — leia antes de calcular:**
+
+1. **SOM NAO e a meta do cliente.** Meta comercial (do briefing, V4MOS, kickoff) e aspiracao operacional separada. Registrar como campo proprio (`market_share.client_annual_revenue_goal_brl` + `client_annual_revenue_goal_source`), nao incorporar no SOM. Se o SOM ficar igual a meta, voce provavelmente derivou o errado — refaca.
+
+2. **SOM NAO e capacidade operacional.** Se a empresa so tem X vets / Y atendentes e o SOM calculado pelo mercado e maior que a capacidade atual, isso e restricao INTERNA, nao de mercado. Registre como `tam_sam_som.som.operational_ceiling_note`. O SOM continua sendo o teto de mercado, nao de capacidade.
+
+3. **Triangulacao obrigatoria.** Nao calcule SOM por 1 metodo so. Use 3 metodos independentes (ver framework). Se convergirem, use a media; se divergirem, investigue.
+
+4. **Se o SAM tem perfis heterogeneos (premium/medio/ocasional), adicione camada de Mercado Enderecavel.** Preencha `market_share.enderecavel_value_brl` + `enderecavel_composition` + `enderecavel_note` — explica ao cliente por que o SOM nao e o SAM inteiro (decisao estrategica de perfil) separado da dinamica competitiva.
+
+5. **Meta da cliente pode vir de MAIS de uma fonte.** Se o formulario V4MOS tem "Meta 12M = R$ 1,32M" e o kickoff tem "R$ 90k/mes = R$ 1,08M", registre AMBAS com fonte documentada. Nao escolha uma arbitrariamente.
+
+6. **Remova cenarios/horizontes temporais do SOM.** SOM de mercado e o teto tangivel — sem "3 anos", sem "agressivo". Se precisar de horizonte, use no plano de execucao (forecast), nao no SOM.
+
+### Analise de concorrentes
+
+Para CADA concorrente da lista, faca análise profunda. Use WebSearch para visitar sites, redes sociais, e Meta Ads Library. Consulte `references/template-analise-concorrente.md`.
+
+Para cada concorrente:
+- Posicionamento (PUV, mensagem principal)
+- Canais de aquisicao
+- Pontos fortes e fracos
+- Estimativa de preco/ticket
+- Presenca digital (score 1-10: site, Instagram, Google, anúncios)
+
+Gere o Mapa Competitivo 2x2 (posicionando todos os concorrentes e sugerindo posição para o cliente).
+
+### Tendencias, JTBD e diferenciais reais
+
+Use WebSearch para pesquisar tendencias recentes do setor:
+- Tendencias em crescimento (3, com evidencia)
+- Ameacas para os proximos 12 meses (2, com impacto)
+- Oportunidade nao explorada pelos concorrentes
+
+Jobs-to-be-Done do mercado:
+- Solucao principal (como a maioria resolve)
+- Alternativas diretas e indiretas
+- Custo de inacao
+
+Diferenciais competitivos reais:
+- O que o cliente TEM hoje (com justificativa para o ICP)
+- O que PODERIA ter (com ação necessária)
+- ALERTA DE HONESTIDADE: se nao ha diferencial claro, diga aqui
+
+### Estrutura visual (obrigatória)
+
+Siga o padrão canônico de `references/padrao-output.md`. Além dos campos específicos acima, SEMPRE inclua:
+
+- **`summary_headline`** (string, max 160 char) — manchete em 1 linha com o veredito da pesquisa. Específica, com dados reais.
+  - Ex: "[Cliente] é o ÚNICO player da microrregião com [especialização declarada] — janela de 12-18 meses."
+
+- **`summary_highlights`** (4-6 itens) — KPIs visuais. Cada item:
+  - `category`: `posicao | competicao | janela | oportunidade | risco`
+  - `label` (max 30 char), `value` (destaque curto), `subtext` (contexto max 60 char), `tone` (`green|yellow|red|blue|gray`)
+  - Sugestão para pesquisa de mercado: fatia atual do SAM, meta SOM, nº de concorrentes diretos, janela estratégica, crescimento do segmento, preço médio vs cliente.
+
+- **`summary_key_findings`** (3-5 itens) — achados categorizados:
+  - `category`: `vantagem | contexto | ameaca | acao`
+  - `text`: 1-2 linhas, acionável
+  - Cubra pelo menos 3 dos 4 tipos.
+
+- **`market_share`** (objeto) — se o cliente tem faturamento conhecido, compare com SAM/SOM:
+  - **Obrigatorios:** `current_revenue_brl`, `current_share_of_sam_pct`, `target_share_of_sam_pct` (= SOM/SAM), `gap_to_som_brl`, `gap_to_som_pct`, `commentary`
+  - **Meta do cliente (se houver):** `client_annual_revenue_goal_brl` + `client_annual_revenue_goal_source` (ex: "Formulario V4MOS — campo 'Meta 12M'") + `client_goal_vs_som_note` (narrativa distinguindo meta de SOM). Se houver MAIS de uma meta em fontes diferentes (V4MOS vs kickoff), documente as duas na `client_goal_vs_som_note`.
+  - **Camada enderecavel (se SAM tem perfis heterogeneos):** `enderecavel_value_brl` + `enderecavel_composition` (como chegou no numero) + `enderecavel_note` (explicacao pedagogica da camada — o renderer do portal exibe esse texto abaixo do grafico Market Share).
+
+### Ponto de alavancagem
+
+Em pesquisa de mercado, o ponto de alavancagem é **`unexploited_opportunity`**. Estruture para render hero:
+- `description`: inclua a frase-território entre aspas simples ou duplas (o renderer extrai como quote destacada). Ex: "Ocupar o território 'O único especialista em [nicho] de [região]' — ..."
+- `why_nobody_does_it`: use padrão `(1) razão A. (2) razão B. (3) razão C.` — o renderer parseia os números e vira cards numerados.
+- `feasibility`: `alta | media | baixa`.
+
+## Auto-validação
+
+Antes de mostrar ao operador, verifique:
+
+- [ ] Mencionou o cliente pelo nome?
+- [ ] Usou dados reais do client.json (não inventou)?
+- [ ] Nenhum item genérico (ex: "quer crescer", "qualidade e compromisso")?
+- [ ] Schema da skill validou?
+- [ ] Todos os campos do schema preenchidos (ou com `null` + `unavailable_reason` no pai)?
+- [ ] Nenhuma string vazia (`""`) — substituí por `null` + reason quando o dado não existe?
+- [ ] Estimativas marcadas com `estimated: true` ou `[E]`?
+- [ ] Consistente com outputs anteriores (ICP, posicionamento)?
+- [ ] TAM/SAM/SOM tem fontes citadas (não apenas estimativas)?
+- [ ] **SOM foi triangulado por 3 métodos independentes** (capacidade, market share top-down, segmento premium) e os números convergem?
+- [ ] **SOM NÃO foi derivado da meta comercial da cliente** (V4MOS, briefing ou kickoff)? Se meta da cliente e SOM ficaram iguais, refez?
+- [ ] **SOM NÃO foi limitado pela capacidade operacional?** Se a empresa tem capacidade inferior ao SOM, registrou `operational_ceiling_note` separadamente em vez de reduzir o SOM?
+- [ ] **Meta da cliente registrada com fonte documentada** (`client_annual_revenue_goal_source`)? Se há 2 metas em fontes diferentes (V4MOS + kickoff), registrou as duas na `client_goal_vs_som_note`?
+- [ ] **Se SAM tem perfis heterogeneos, adicionou camada enderecavel** (`enderecavel_value_brl` + `enderecavel_composition` + `enderecavel_note`)?
+- [ ] **Removeu cenários ("agressivo") e horizontes temporais ("3 anos") do SOM**? SOM e teto de mercado, nao forecast.
+- [ ] Análise de concorrentes é baseada em pesquisa real (não suposições)?
+- [ ] Diferenciais são honestos (não aspiracionais vendidos como reais)?
+- [ ] Tem `summary_headline` específico (não "pesquisa concluída")?
+- [ ] `summary_highlights` tem 4-6 itens com categorias válidas e tons consistentes?
+- [ ] `summary_key_findings` cobre pelo menos 3 dos 4 tipos (vantagem/contexto/ameaça/ação)?
+- [ ] `unexploited_opportunity.description` tem frase-território entre aspas?
+- [ ] `unexploited_opportunity.why_nobody_does_it` está no formato `(1) ... (2) ... (3) ...`?
+- [ ] Se há fragilidade, incluiu `honesty_alert`?
+
+Se falhou → regenere silenciosamente. Não avise o operador.
+
+## Apresentação e decisões
+
+Apresente o output COMPLETO ao operador.
+
+Revise o output. O que está errado, exagerado ou faltando?
+
+- "Os numeros de sizing fazem sentido para a realidade do cliente? O SOM parece realista ou otimista demais?"
+- "A analise de concorrentes esta precisa? Alguma informacao que voce sabe e que esta diferente?"
+- "Onde {NOME_CLIENTE} deveria se posicionar no mapa competitivo?"
+- "Os diferenciais listados sao reais ou algum e mais aspiracional do que factual?"
+- "Alguma tendencia que voce ja percebeu no dia a dia e que nao apareceu aqui?"
+
+## Finalização
+
+Operador aprova (com ou sem ajustes).
+1. Salve em `squads/{squad}/clientes/{cliente}/outputs/geral-pesquisa-mercado.json` (com campo `summary` no topo)
+2. Atualize `client.json`: progress.skills → completed, version++, append em history[]
+3. Salve também uma versão Markdown do entregável na mesma pasta de outputs.
+4. Sugira próxima skill do dependency_graph
+   - "Pesquisa concluída. TAM: R$ {valor} | SAM: R$ {valor} | SOM: R$ {valor}. Concorrentes analisados: {numero}. Diferenciais reais identificados: {numero}."
+   - "Proximo passo recomendado: /geral-posicionamento-estrategico (Usa esta pesquisa como base para definir PUV, canvas 4P e territorio de marca)"
+
+
+## Campo obrigatório: summary
+
+Sempre inclua no JSON de saída:
+```json
+"summary": "Resumo de 1-2 frases do pesquisa de mercado: oportunidade principal e diferencial real do cliente. Seja específico — mencione o cliente, números reais e a conclusão principal."
+```
+
+Este campo alimenta o Resumo Executivo do portal de entregas. Deve ser objetivo, com dados reais, sem genéricos.

--- a/.claude/skills/geral-pesquisa-mercado/references/framework-tam-sam-som.md
+++ b/.claude/skills/geral-pesquisa-mercado/references/framework-tam-sam-som.md
@@ -1,0 +1,313 @@
+# Framework TAM/SAM/SOM para PMEs Brasileiras
+
+## O que e cada metrica
+
+### TAM (Total Addressable Market)
+Mercado total disponivel. O tamanho do mercado inteiro se voce pudesse atender 100% dele.
+
+**Para PMEs brasileiras, o TAM geralmente e:**
+- O faturamento total do segmento no Brasil
+- Ou o numero total de empresas no segmento x ticket medio anual
+
+### SAM (Serviceable Addressable Market)
+Mercado enderecavel. A fatia do TAM que voce PODE atingir considerando restricoes reais.
+
+**Filtros comuns para PMEs:**
+- Regiao geografica (cidade, estado, regiao)
+- Porte do cliente (micro, pequena, media)
+- Perfil de cliente (B2B vs B2C, segmento especifico)
+- Canal de distribuicao disponivel
+- Capacidade operacional atual
+
+### SOM (Serviceable Obtainable Market)
+Mercado obtenivel. A fatia do SAM que a empresa realisticamente consegue capturar dada sua oferta, posicionamento e a concorrencia real.
+
+**Duas leituras possiveis — escolha uma e seja explicito:**
+
+**(a) SOM de mercado (recomendado para diagnostico estrategico):** teto tangivel de captura, sem horizonte temporal e sem restricao de capacidade interna. Representa o potencial que o mercado permite a uma empresa plenamente consolidada no seu nicho. Util para discussao estrategica com a cliente — mostra quanto ela PODE atingir se toda a execucao for correta.
+
+**(b) SOM operacional (mais conservador):** fatia capturavel em horizonte definido (12-24 meses) considerando capacidade atual, budget de marketing e ciclo de venda. Util para forecast de curto prazo e metas operacionais.
+
+**Premissas realistas para PMEs:**
+- Para SOM de mercado: share tipico 3-8% do SAM para empresa de nicho bem posicionada; 8-15% para lider do quadrante premium com diferenciacao real; 15-25% para dominante estrutural.
+- Para SOM operacional: 1-5% do SAM para empresas novas, 5-15% para empresas estabelecidas, em horizonte de 12-24m.
+- **NUNCA derive o SOM da meta comercial do cliente.** Meta do cliente e aspiracao operacional, nao metrica de mercado. Ver secao dedicada abaixo.
+
+---
+
+## Camada intermediaria: MERCADO ENDERECAVEL
+
+O TAM/SAM/SOM classico tem 3 camadas, mas muitas vezes uma 4a camada pedagogica — o **Mercado Enderecavel** — ajuda a separar duas barreiras diferentes que senao se misturam.
+
+### O que e
+
+Subset do SAM onde a oferta da empresa e RELEVANTE, dada a decisao estrategica de perfil. Nao e todo o SAM — exclui segmentos que a empresa decide NAO perseguir (commodity, ocasional, fora do ICP).
+
+### Quando usar
+
+- Quando o SAM tem perfis de consumidor muito heterogeneos (premium vs medio vs ocasional/commodity)
+- Quando a empresa explicitamente NAO compete em parte do SAM (decisao de posicionamento)
+- Quando o ratio SOM/SAM fica baixo (5-15%) e isso poderia parecer "empresa captura pouco" — mas na verdade ela nao mira o SAM inteiro por desenho
+
+### Como calcular
+
+```
+Mercado Enderecavel = SAM × % do SAM relevante a oferta da empresa
+Razao SOM/Enderecavel = quanto a empresa captura DO QUE ela persegue
+```
+
+Ratio SOM/Enderecavel e metrica mais honesta para medir performance competitiva:
+- 20-40% = empresa lider do seu nicho
+- 10-20% = empresa competitiva mas nao dominante
+- <10% = empresa com grande espaco para crescer dentro do seu proprio quadrante
+
+### Separa duas barreiras distintas
+
+Sem essa camada, SAM → SOM mistura:
+1. **Barreira de escolha estrategica** (SAM → Enderecavel): empresa decide nao competir em partes do SAM
+2. **Barreira competitiva** (Enderecavel → SOM): dentro do perfil alvo, empresa disputa com concorrentes
+
+Com a camada separada, fica visivel O QUE a empresa escolheu deixar de fora vs O QUE a concorrencia disputa dela.
+
+### Exemplo (hipotético)
+
+```
+SAM: R$ 34M (todo o mercado regional do segmento)
+  ├─ Premium:                  R$ 17,1M (50% do gasto) ← a empresa compete aqui
+  ├─ Medio regular:            R$ 10,2M (30% do gasto) ← parte upgrade para a empresa
+  └─ Ocasional/commodity:      R$  6,7M (20% do gasto) ← a empresa NAO compete
+
+Mercado Enderecavel: R$ 20M (premium completo + 20% do medio que upgrade)
+SOM: R$ 7M (35% do enderecavel — empresa lider do quadrante)
+```
+
+Razao SOM/SAM = 20,6% (parece baixa)
+Razao SOM/Enderecavel = 35% (captura real do que ela persegue — lider de nicho)
+
+### Quando NAO usar
+
+- Quando a empresa mira todo o SAM indiferentemente (ex: commodity puro)
+- Quando o SAM e homogeneo (sem subsegmentos claros de gasto)
+- Quando adicionar a camada complica a comunicacao sem agregar clareza estrategica
+
+---
+
+## SOM vs Capacidade Operacional vs Meta Comercial — tres metricas distintas
+
+Confundir essas tres e erro comum. Separe-as explicitamente:
+
+### SOM (metrica de mercado)
+Teto tangivel de captura dado posicionamento + competicao. INDEPENDENTE de capacidade interna ou prazo da empresa.
+
+### Capacidade operacional (restricao interna)
+Teto de producao dada a estrutura atual (equipe, instalacoes, agenda). Se SOM > capacidade, a diferenca flagga necessidade de expansao futura (contratar, 2a unidade, etc).
+
+**Exemplo:**
+- SOM de mercado: R$ 7M
+- Capacidade atual (3 vets, 1 unidade): R$ 5,4M em regime de agenda cheia
+- Gap: R$ 1,6M exigem expansao (2a unidade ou ampliacao)
+
+Registrar como `operational_ceiling_note` separado do SOM. Nunca reduzir o SOM pela capacidade — SOM e sobre mercado, nao sobre a empresa.
+
+### Meta comercial do cliente (aspiracao operacional)
+Numero que a cliente registrou no V4MOS, no briefing ou no kickoff como meta de faturamento. **Isso NAO e SOM.**
+
+Se a meta aparecer como "R$ 1,32M ano que vem", ela e uma aspiracao operacional da cliente — pode estar abaixo do SOM (cliente conservadora), acima do SOM (cliente otimista), ou alinhada. **Nao confundir.**
+
+**Regra critica:** registrar a meta do cliente como campo separado (`client_annual_revenue_goal_brl`) com fonte documentada (`client_annual_revenue_goal_source`), e comparar com o SOM na narrativa — nao incorporar no calculo do SOM.
+
+**Fontes tipicas de meta da cliente (podem divergir entre si):**
+- Formulario V4MOS (campo "Meta 12M" preenchido pela cliente) → ambicao dela
+- Kickoff da V4 (meta mensal negociada com o executor) → versao operacional, as vezes mais conservadora
+- Plano de ROI / Rollout → meta intermedia
+
+Se houver duas metas em fontes diferentes, documente as DUAS separadamente. Nao escolha uma arbitrariamente.
+
+---
+
+## Triangulacao metodologica para SOM robusto
+
+Nao chegue a um numero de SOM por um metodo so. **Triangule com 3 metodos independentes** — se os tres convergirem em uma faixa, o numero e defensavel. Se divergirem muito, algo esta errado.
+
+### Metodo 1 — Capacidade operacional plenamente madura (bottom-up da estrutura)
+
+Responde: "qual o teto produtivo da empresa em agenda cheia + ticket otimizado?"
+
+Para servicos presenciais (clinicas, consultorios, restaurantes):
+```
+Capacidade = (unidades produtivas) × (consultas/atendimentos por dia) × (dias uteis/mes) × 12
+Receita total = Capacidade × ticket medio × fator de servicos complementares
+  (fator tipico: 1/0.6 = 1.67 se consulta e 60% da receita; ajuste por modelo)
+```
+
+**Exemplo hipotético:**
+- 3 profissionais × 2.400 atendimentos/ano = 7.200 atendimentos
+- × R$ 450 ticket medio = R$ 3,24M em atendimentos
+- ÷ 0,6 (atendimentos = 60% da receita) = R$ 5,4M teto operacional
+
+### Metodo 2 — Market share top-down (benchmark de nicho)
+
+Responde: "qual fatia do SAM regional uma empresa de nicho similar tipicamente captura quando plenamente consolidada?"
+
+Use benchmarks:
+- Generalista mediana: 1-3%
+- Diferenciada com posicionamento claro: 3-5%
+- Lider do quadrante de nicho: **5-12%**
+- Dominante estrutural (ex: hospital 24h em cidade pequena): 15-25%
+
+Aplique o % apropriado ao SAM.
+
+### Metodo 3 — Segmento premium por nicho (bottom-up do mercado)
+
+Responde: "de dentro do SAM, qual fatia corresponde ao nicho-alvo da empresa, e quanto desse nicho ela pode capturar?"
+
+Passos:
+1. Decomponha o SAM por perfil de gasto (premium vs medio vs ocasional)
+2. Identifique qual fatia corresponde ao ICP alvo (ex: premium humanizado)
+3. Dentro do nicho-alvo, estime captura realista (30-60% se lider, 15-30% se competitivo)
+
+### Convergencia
+
+Se Metodo 1 → R$ X, Metodo 2 → R$ Y, Metodo 3 → R$ Z e `X ≈ Y ≈ Z`, a faixa e defensavel. Use o ponto medio como SOM.
+
+Se divergirem muito (ex: X=R$1M, Y=R$5M, Z=R$3M), investigue:
+- Capacidade pode estar bloqueando crescimento → plano de expansao
+- Benchmark de market share pode estar errado → recalibrar
+- Segmento alvo pode estar mal definido → revisar ICP
+
+---
+
+## Segmentacao heterogenea do SAM
+
+SAM calculado como "media simples × populacao" esconde heterogeneidade que muda tudo. Em setores de servico:
+
+| Segmento | % tipico dos consumidores | % do gasto total | Gasto medio anual |
+|---|---|---|---|
+| Premium humanizado | 15-20% | 40-55% | 3-10× a media do SAM |
+| Medio regular | 30-40% | 25-35% | ~= media do SAM |
+| Ocasional/commodity | 40-50% | 10-20% | 1/3 a 1/2 da media |
+| Subsistencia / nao-consumo | 3-8% | <5% | negligivel |
+
+**Implicacoes:**
+1. Se a empresa mira **premium humanizado**, o verdadeiro mercado enderecavel pode ser 40-55% do SAM, nao 15-20% (porque cada consumidor premium gasta muito mais)
+2. Se o SAM foi calculado com media simples (R$ X por domicilio), o numero subestima o mercado para empresas premium. Considere recalibrar ou usar a camada enderecavel.
+3. **No premium humanizado**, o mix entre sub-segmentos (ex: gato vs cao no pet) pode divergir do mix nacional. Ex: Gen Z/Millennial humanizado tende a ter mais gatos que a media brasileira.
+
+## Metodologias de estimativa
+
+### Top-Down (do macro para o micro)
+1. Comece com dados macro do setor (IBGE, SEBRAE, associacoes)
+2. Aplique filtros de regiao e perfil
+3. Estime o share obtenivel
+
+**Quando usar:** Quando ha dados setoriais publicos disponiveis.
+
+**Fontes confiáveis:**
+- IBGE — Pesquisa Anual de Servicos, CEMPRE, PNAD
+- SEBRAE — Estudos setoriais, DataSEBRAE
+- ABComm — E-commerce brasileiro
+- ABRASEL — Alimentacao fora do lar
+- ABES — Software brasileiro
+- Statista — Dados globais com recorte Brasil
+- Euromonitor — Mercados de consumo
+- BNDES — Relatorios setoriais
+
+### Bottom-Up (do micro para o macro)
+1. Estime o numero de potenciais clientes na regiao
+2. Multiplique pelo ticket medio
+3. Aplique taxa de conversao realista
+
+**Quando usar:** Quando o segmento e muito nicho ou nao ha dados macro.
+
+**Exemplo:**
+```
+Clientes potenciais na regiao: 500 empresas
+Ticket medio mensal: R$ 2.000
+Conversao realista: 5% no primeiro ano
+SOM = 500 x R$ 2.000 x 12 x 5% = R$ 600.000/ano
+```
+
+### Mista (recomendada)
+1. Use top-down para TAM e SAM
+2. Use bottom-up para SOM
+3. Valide cruzando os dois
+
+## Erros comuns ao estimar mercado para PMEs
+
+### Erro 1: TAM inflado
+**Errado:** "O mercado de saude no Brasil e R$ 700 bilhoes"
+**Correto:** "O mercado de clinicas de estetica no Brasil fatura R$ 12 bilhoes" (segmento especifico)
+
+### Erro 2: SAM sem filtros reais
+**Errado:** "Nosso SAM e 50% do TAM"
+**Correto:** "Filtrando por Grande Porto Alegre, clinicas com 2-10 funcionarios, com presenca digital: 1.200 clinicas, R$ 3.6 bilhoes"
+
+### Erro 3: SOM otimista demais
+**Errado:** "Vamos capturar 20% do SAM no primeiro ano"
+**Correto:** "Com 3 vendedores e R$ 5K/mes em midia, estimamos converter 25 clientes novos em 12 meses"
+
+### Erro 4: Fontes genericas
+**Errado:** "Segundo pesquisas, o mercado cresce 10% ao ano"
+**Correto:** "Segundo o SEBRAE (Perfil dos Pequenos Negocios, 2025), o segmento de beleza e estetica cresceu 8.3% no ultimo ano"
+
+### Erro 5: SOM derivado da meta da cliente
+**Errado:** "SOM = triplicar o faturamento atual de R$650K para R$2M em 3 anos"
+**Correto:** "SOM de mercado: R$ 7M (20% do SAM, metrica independente da ambicao da empresa). Meta da cliente registrada separadamente: R$ 1,32M/ano (18,9% do SOM — fonte: Formulario V4MOS)"
+
+O SOM precisa ser uma metrica de MERCADO, nao de ambicao interna. Se voce esta usando o numero que a cliente disse como meta, voce perdeu a oportunidade de mostrar a ela o potencial real do mercado — que tipicamente e MAIOR que ela imagina.
+
+### Erro 6: SOM = capacidade operacional
+**Errado:** "Ela so tem 1 veterinaria trabalhando, entao o SOM dela e R$ 1,5M (teto produtivo)"
+**Correto:** "SOM de mercado: R$ 7M (o mercado permite). Capacidade atual: R$ 1,5M (a empresa produz). Gap de R$ 5,5M = necessidade de expansao futura."
+
+Capacidade e restricao INTERNA, nao de mercado. Deve ser registrada separadamente como `operational_ceiling_note` e NUNCA usada para reduzir o SOM.
+
+### Erro 7: SOM sem triangulacao
+**Errado:** "Calculei SOM como 5% do SAM, apenas."
+**Correto:** "Triangulei tres metodos: (1) capacidade operacional R$5,4M; (2) market share 10% do SAM = R$3,4M; (3) segmento premium 40% captura = R$3,8M. Convergencia em R$3,5M, usado como SOM."
+
+Um metodo so e chute. Tres metodos independentes que convergem e diagnostico.
+
+### Erro 8: Conflacao entre SOM e "meta 12m"
+**Errado:** "SOM em 12 meses e R$ 1,2M (igual a meta do cliente)"
+**Correto:** SOM e teto de mercado sem amarra temporal rigida; meta comercial e aspiracao operacional, pode ter horizonte de 12 ou 24 meses.
+
+Se registrar SOM, seja claro sobre a leitura escolhida (mercado vs operacional). Se registrar meta do cliente, registrar com fonte (V4MOS, kickoff, etc).
+
+## Heuristicas por segmento
+
+| Segmento | TAM Brasil estimado | Ticket medio mensal PME | Fontes recomendadas |
+|---|---|---|---|
+| Odontologia | R$ 45 bi | R$ 1.500-5.000 | CFO, ANS, SEBRAE |
+| Clinicas estetica | R$ 12 bi | R$ 2.000-8.000 | ABIHPEC, SEBRAE |
+| Imobiliarias | R$ 170 bi | R$ 3.000-10.000 | SECOVI, CRECI |
+| Restaurantes | R$ 230 bi | R$ 1.000-3.000 | ABRASEL, ANR |
+| Academias | R$ 12 bi | R$ 1.500-4.000 | IHRSA, ACAD |
+| E-commerce moda | R$ 55 bi | R$ 2.000-5.000 | ABComm, Neotrust |
+| Advocacia | R$ 80 bi | R$ 2.000-6.000 | OAB, CNJ |
+| Contabilidade | R$ 25 bi | R$ 800-2.500 | CFC, FENACON |
+| Educacao/cursos | R$ 40 bi | R$ 1.500-5.000 | ABED, MEC |
+| SaaS B2B | R$ 30 bi | R$ 3.000-15.000 | ABES, Gartner |
+
+**ATENCAO:** Esses valores sao heuristicas para referencia. Sempre busque dados atualizados e cite a fonte especifica.
+
+## Template de apresentacao
+
+```
+TAM: R$ [valor]
+[Descricao em 1 frase]
+Fonte: [nome] ([ano]) — [link se disponivel]
+
+SAM: R$ [valor]
+[Descricao em 1 frase]
+Filtros: [lista de filtros aplicados]
+Calculo: [como chegou no numero]
+
+SOM: R$ [valor] (12 meses)
+[Descricao em 1 frase]
+Premissas: [lista de premissas]
+Calculo: [detalhamento]
+
+Metodologia: [top-down / bottom-up / mista]
+Confianca: [alta / media / baixa]
+```

--- a/.claude/skills/geral-pesquisa-mercado/references/padrao-output.md
+++ b/.claude/skills/geral-pesquisa-mercado/references/padrao-output.md
@@ -1,0 +1,202 @@
+# Padrão de Output das Skills — V4 Estruturação IA
+
+Este documento define a **estrutura canônica** que todos os outputs de skill devem seguir para renderizar no portal com hierarquia visual consistente. O objetivo é que o operador e o stakeholder final abram qualquer entregável e encontrem o mesmo ritmo: manchete → KPIs → achados categorizados → ponto de alavancagem destacado → detalhes expansíveis.
+
+---
+
+## Princípios
+
+1. **Manchete antes de texto.** Toda skill abre com uma frase única e específica que resume a conclusão. Não é parágrafo, é headline.
+2. **Números em destaque, não escondidos no corpo do texto.** KPIs que importam viram cards. Texto corrido é para contexto, não para fato quantitativo.
+3. **Achados categorizados por intenção.** Cada insight é classificado como `vantagem | contexto | ameaca | acao` — o leitor identifica o tom antes de ler.
+4. **Ponto de alavancagem visualmente isolado.** Toda skill tem UM ponto onde a conversa com o stakeholder precisa acontecer. Esse ponto ganha hero visual (border, gradient, quote destacada).
+5. **Detalhe denso → colapsável.** Listas longas (concorrentes, itens de checklist, fontes) ficam em `<details>` para não afogar a leitura.
+
+---
+
+## Campos obrigatórios no JSON
+
+Todo output de skill DEVE ter estes campos no topo (antes dos campos específicos da skill):
+
+```json
+{
+  "client_name": "Nome do Cliente",
+  "summary": "Resumo em 1-2 frases. Específico, com dados reais. Alimenta o resumo executivo do portal.",
+
+  "summary_headline": "Manchete em 1 linha (max 120 caracteres). A frase que o stakeholder lê primeiro.",
+
+  "summary_highlights": [
+    {
+      "category": "posicao | competicao | janela | maturidade | oportunidade | risco",
+      "label": "Rótulo curto (max 30 char)",
+      "value": "Valor em destaque (número, %, status)",
+      "subtext": "Contexto em 1 linha (max 60 char)",
+      "tone": "green | yellow | red | blue | gray"
+    }
+  ],
+
+  "summary_key_findings": [
+    {
+      "category": "vantagem | contexto | ameaca | acao",
+      "text": "Achado em 1-2 linhas. Específico, acionável."
+    }
+  ]
+}
+```
+
+### Regras dos campos de summary
+
+**`summary_headline`**: É a ÚNICA frase que o stakeholder precisa ler se só tiver 5 segundos. Deve conter o veredito da skill. Exemplos bons:
+- ✓ "[Cliente] é o ÚNICO player premium da microrregião com [diferencial declarado] — janela competitiva de 12-18 meses."
+- ✗ "Análise de mercado concluída com sucesso."
+
+**`summary_highlights`** (4-6 itens): KPIs visuais. Categorias sugeridas:
+- `posicao` — onde o cliente está hoje vs potencial
+- `competicao` — quem disputa o mesmo espaço
+- `janela` — tempo/urgência
+- `maturidade` — estágio atual em algum eixo
+- `oportunidade` — tamanho do ganho possível
+- `risco` — tamanho da ameaça
+
+Agrupar de 2 em 2 por categoria no renderer (dá layout balanceado 3x2 ou 2x2).
+
+**`summary_key_findings`** (3-5 itens): Achados que embasam a manchete. Categorias:
+- `vantagem` (✓ verde) — o que o cliente tem a favor
+- `contexto` (i azul) — o que é fato do mercado, neutro
+- `ameaca` (! vermelho) — o que pode dar errado
+- `acao` (▸ laranja) — o que precisa ser feito
+
+---
+
+## Ponto de Alavancagem (hero block)
+
+Toda skill deve identificar **UM bloco que merece destaque visual especial** — o ponto onde a conversa estratégica precisa acontecer. O nome do campo varia por skill, mas a estrutura é consistente:
+
+```json
+{
+  "key_leverage_point": {
+    "headline": "Frase-manchete do ponto (pode ir como quote)",
+    "context": "Contexto em 2-3 linhas explicando o cenário",
+    "numbered_reasons": [
+      "Razão 1 (parse-friendly, pode começar com texto direto)",
+      "Razão 2",
+      "Razão 3"
+    ],
+    "discussion_anchor": "Frase curta sobre POR QUE este é o ponto de conversa com o stakeholder"
+  }
+}
+```
+
+Exemplos por skill:
+- `pesquisa-mercado` → `unexploited_opportunity` (whitespace estratégico)
+- `persona-icp` → persona principal + dor mais ignorada
+- `swot` → combinação força × oportunidade mais assimétrica
+- `posicionamento` → PUV vs alternativas descartadas
+- `diagnostico-midia` → canal mais subotimizado + upside estimado
+- `diagnostico-maturidade` → pilar mais fraco com maior impacto
+
+O renderer aplica:
+- Border verde 2px + gradient sutil
+- Selo "Whitespace Estratégico · Discussão com Stakeholder" no topo
+- Pill de viabilidade/urgência à direita
+- Quote/headline em card branco isolado
+- Razões numeradas em 3 círculos
+- Footer "💬 Momento de validar com a stakeholder"
+
+---
+
+## Alerta de honestidade
+
+Se a pesquisa/análise revelou fragilidade do cliente (não há diferencial real, ICP mal definido, mercado saturado, etc.), inclua:
+
+```json
+{
+  "honesty_alert": "Texto explicando a fragilidade encontrada e o que precisa ser feito antes de seguir."
+}
+```
+
+Esse campo renderiza em box amarelo/vermelho após os achados. **Nunca omita** se a realidade justifica. O valor do sistema depende de não vender aspiracional como real.
+
+---
+
+## Instrução para a IA da skill
+
+Em cada `SKILL.md`, incluir esta seção na geração:
+
+> ### Estrutura visual (obrigatória)
+>
+> Além dos campos específicos desta skill, gere SEMPRE:
+>
+> - `summary_headline` — manchete em 1 linha com o veredito
+> - `summary_highlights` — 4-6 KPIs categorizados (`posicao|competicao|janela|maturidade|oportunidade|risco`) com `{label, value, subtext, tone}`
+> - `summary_key_findings` — 3-5 achados categorizados (`vantagem|contexto|ameaca|acao`)
+> - `honesty_alert` se houver fragilidade
+>
+> Identifique o **ponto de alavancagem** desta skill (o bloco que merece hero visual) e estruture-o com headline + contexto + razões numeradas + discussion anchor.
+>
+> Consulte `references/padrao-output.md` para especificação completa.
+
+E na auto-validação:
+
+> - [ ] Tem `summary_headline` específico (não "análise concluída")?
+> - [ ] `summary_highlights` tem 4-6 itens com categorias válidas?
+> - [ ] `summary_key_findings` cobre pelo menos 3 dos 4 tipos (vantagem/contexto/ameaça/ação)?
+> - [ ] Identificou o ponto de alavancagem para discussão com stakeholder?
+> - [ ] Se há fragilidade, incluiu `honesty_alert`?
+
+---
+
+## Completude (regra crítica)
+
+**Todo campo definido no schema da skill é obrigatório no output.** Não omitir campos — o renderer assume que os campos do schema existem e quebra/fica vazio silenciosamente quando faltam.
+
+Se um dado **não pode ser obtido** (GA4 não instalado, conector não conectado, cliente não sabe, etc.), preencher com `null` E adicionar `unavailable_reason` no objeto pai:
+
+```json
+{
+  "current_conversion_rate": null,
+  "current_bounce_rate": null,
+  "avg_time_on_page": null,
+  "unavailable_reason": "GA4 não instalado no site — métricas de analytics não coletadas nesta auditoria"
+}
+```
+
+Para arrays vazios legitimamente (ex: nenhum competidor identificado), preencher com `[]` e adicionar uma nota no campo irmão `{campo}_note`:
+
+```json
+{
+  "competitors": [],
+  "competitors_note": "Nenhum concorrente direto identificado na microrregião após busca em Google Maps + Instagram."
+}
+```
+
+Para valores **estimados** (sem fonte pública), adicionar flag `[E]` no texto OU campo `estimated: true` no objeto:
+
+```json
+{ "tam_brl": 450000000, "estimated": true, "estimation_basis": "IBGE população × SEBRAE ticket médio" }
+```
+
+**Nunca** deixar string vazia (`""`), zero falso (`0` quando não é zero real), ou omitir o campo. Essas três formas são invisíveis para o renderer e geram o bug "coluna vazia".
+
+Valide o JSON contra o `schema.json` empacotado na skill e corrija campos ausentes ou `null` sem `unavailable_reason`.
+
+### Checklist adicional de auto-validação
+
+> - [ ] Todos os campos do schema estão presentes (preenchidos ou com `null` + `unavailable_reason`)?
+> - [ ] Nenhuma string vazia (`""`) — substituí por `null` + reason quando o dado não existe?
+> - [ ] Arrays vazios legítimos têm `{campo}_note` explicando por quê?
+> - [ ] Estimativas marcadas com `estimated: true` ou `[E]`?
+
+---
+
+## Tons de voz
+
+- `green` — oportunidade/vantagem/confirmado
+- `yellow` — atenção/potencial/médio
+- `red` — risco/ameaça/fraco
+- `blue` — contexto/informativo/neutro
+- `gray` — desativado/aspiracional/ausente
+
+Usar tons consistentemente: nunca pintar ameaça de verde ou vantagem de vermelho para "chamar atenção". O tom é semântico.
+
+---

--- a/.claude/skills/geral-pesquisa-mercado/references/template-analise-concorrente.md
+++ b/.claude/skills/geral-pesquisa-mercado/references/template-analise-concorrente.md
@@ -1,0 +1,151 @@
+# Template de Analise de Concorrente
+
+Framework para analisar cada concorrente de forma sistematica e acionavel.
+
+## Dimensoes de analise
+
+### 1. Posicionamento e PUV
+**O que observar:**
+- Headline do site (primeira coisa que o visitante le)
+- Tagline ou slogan
+- Bio do Instagram
+- Descricao do Google Meu Negocio
+- Como se descreve em anuncios
+
+**Perguntas-chave:**
+- O geral-posicionamento-estrategico e claro em 5 segundos?
+- A PUV e especifica ou generica ("qualidade e compromisso")?
+- Ele se posiciona por preco, qualidade, especializacao ou conveniencia?
+
+**Red flags de geral-posicionamento-estrategico fraco:**
+- "Solucoes completas" sem definir o que
+- "Mais de X anos de experiencia" como unico diferencial
+- Nenhuma especificidade sobre para quem serve
+- Copy generica que serve para qualquer empresa do setor
+
+### 2. Canais de aquisicao
+**O que investigar:**
+- Google Ads: busque as palavras-chave do setor e veja se o concorrente aparece
+- Meta Ads Library: acesse facebook.com/ads/library e busque o nome do concorrente
+- Instagram: frequencia de postagem, engajamento, uso de reels/stories
+- Google organico: busque o nome + segmento e veja o ranking
+- YouTube: tem canal? Que tipo de conteudo?
+- Google Meu Negocio: esta otimizado? Quantas avaliacoes?
+- Email marketing: inscreveu-se na newsletter? Qual a cadencia?
+- WhatsApp: usa como canal de atendimento/venda?
+
+**Classificacao de maturidade por canal:**
+| Nivel | Descricao |
+|---|---|
+| 0 — Ausente | Nao usa o canal |
+| 1 — Presente | Tem presenca mas sem estrategia |
+| 2 — Ativo | Publica/anuncia regularmente |
+| 3 — Otimizado | Boa execucao, testes, segmentacao |
+| 4 — Lider | Referencia no canal para o segmento |
+
+### 3. Pontos fortes observados
+**Categorias comuns:**
+- **Marca forte:** Reconhecimento, tempo de mercado, reputacao
+- **Conteudo educativo:** Produz material que gera confianca
+- **Prova social:** Muitas avaliacoes, cases, depoimentos
+- **Tecnologia:** Site rapido, app, automacoes
+- **Atendimento:** Resposta rapida, multi-canal
+- **Especializacao:** Foco em nicho especifico
+- **Preco competitivo:** Oferta agressiva
+- **Distribuicao:** Presenca fisica + digital
+
+**Regra:** Cite EVIDENCIA, nao suposicao. "Site carrega em 1.5s e tem 4.8 estrelas com 230 avaliacoes no Google" > "Parece ter boa presenca digital"
+
+### 4. Pontos fracos observados
+**Categorias comuns:**
+- **Site lento/desatualizado:** PageSpeed abaixo de 50, design antigo
+- **Copy generica:** Nenhum diferencial claro
+- **Anuncios fracos:** Criativos sem hook, copy padrao
+- **Sem prova social:** Poucas avaliacoes, sem cases
+- **Precificacao opaca:** Nao mostra precos, dificulta comparacao
+- **Canais abandonados:** Instagram com ultima postagem ha 3 meses
+- **Nao segmentado:** Fala para todo mundo (e portanto para ninguem)
+- **Sem funil:** Manda trafego direto para homepage, sem LP
+
+**Regra:** So liste fraquezas que podem ser EXPLORADAS pelo seu cliente. "Atendimento ruim" so importa se o seu cliente pode fazer melhor.
+
+### 5. Estimativa de preco/ticket medio
+**Como estimar quando nao ha preco publico:**
+1. Peca orcamento como cliente oculto (se viavel)
+2. Verifique sites de comparacao (ex: Glassdoor para salarios, comparadores setoriais)
+3. Procure menções de preço em avaliacoes de clientes
+4. Analise o geral-posicionamento-estrategico: premium/mid/value
+5. Verifique ofertas em anuncios (ex: "a partir de R$ X")
+6. Pergunte ao operador — ele provavelmente sabe o range do mercado
+
+**Formato:** "R$ 2.000-3.000/mes (estimativa baseada em anuncios + geral-posicionamento-estrategico mid-market)"
+
+### 6. Presenca digital — Score 1-10
+**Criterios de pontuacao:**
+
+| Score | Descricao |
+|---|---|
+| 1-2 | Quase inexistente. Site basico ou inexistente. Sem redes ativas. |
+| 3-4 | Presente mas fraco. Site funcional, redes com pouca frequencia, sem anuncios. |
+| 5-6 | Mediano. Site razoavel, posta nas redes, investe pouco em midia paga. |
+| 7-8 | Bom. Site profissional, redes ativas com engajamento, anuncios rodando, Google My Business otimizado. |
+| 9-10 | Excelente. Lider digital no segmento/regiao. Conteudo, midia paga, SEO, reviews — tudo bem executado. |
+
+**Detalhe por canal:**
+- Site: velocidade, design, mobile, SEO basico, CTA claro
+- Instagram: frequencia, engajamento rate, qualidade visual, uso de stories/reels
+- Google: ranking para termos do segmento, Google Meu Negocio, avaliacoes
+- Anuncios: quantidade ativa, qualidade criativa, variedade de formatos
+
+## Template de output por concorrente
+
+```
+CONCORRENTE: [Nome]
+Site: [URL]
+━━━━━━━━━━━━━━━━━━━
+
+Posicionamento: [frase que resume como se posiciona]
+PUV declarada: [o que diz ser o diferencial]
+PUV real percebida: [o que de fato diferencia na pratica]
+
+Canais de aquisicao:
+  - Google Ads: [nivel 0-4 + observacao]
+  - Meta Ads: [nivel 0-4 + observacao]
+  - Instagram organico: [nivel 0-4 + observacao]
+  - Google organico/SEO: [nivel 0-4 + observacao]
+  - Outros: [quais e nivel]
+
+Pontos fortes:
+  1. [ponto forte + evidencia]
+  2. [ponto forte + evidencia]
+
+Pontos fracos:
+  1. [ponto fraco + evidencia]
+  2. [ponto fraco + evidencia]
+
+Estimativa de preco: R$ [range] / [periodo]
+Fonte da estimativa: [como estimou]
+
+Presenca digital: [score]/10
+  - Site: [observacao]
+  - Instagram: [seguidores] — [observacao]
+  - Google My Business: [avaliacoes] estrelas — [observacao]
+  - Anuncios ativos: [sim/nao] — [observacao]
+```
+
+## Mapa competitivo 2x2
+
+Apos analisar todos os concorrentes, posicione-os em um mapa 2x2. Os eixos mais comuns para PMEs:
+
+**Eixos recomendados por segmento:**
+
+| Segmento | Eixo X | Eixo Y |
+|---|---|---|
+| Servicos profissionais | Generalista vs Especialista | Premium vs Acessivel |
+| Comercio/varejo | Local vs Online | Preco vs Experiencia |
+| Saude/estetica | Tratamento generico vs Nicho | Clinica popular vs Clinica premium |
+| Educacao | Presencial vs Digital | Certificacao vs Pratica |
+| SaaS | Self-service vs Assistido | Feature-rich vs Simples |
+| Alimentacao | Fast food vs Gourmet | Delivery vs Presencial |
+
+**Regra:** Escolha eixos que REVELEM ESPACOS VAZIOS. Se todos os concorrentes estao no mesmo quadrante, o mapa e util porque mostra oportunidade. Se estao espalhados, escolha eixos que agrupem de forma mais reveladora.

--- a/.claude/skills/geral-pesquisa-mercado/schema.json
+++ b/.claude/skills/geral-pesquisa-mercado/schema.json
@@ -1,0 +1,585 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PesquisaMercado",
+  "description": "Output estruturado da pesquisa de mercado: TAM/SAM/SOM, concorrentes, tendencias, JTBD e diferenciais reais.",
+  "type": "object",
+  "required": [
+    "summary",
+    "client_name",
+    "segment",
+    "region",
+    "tam_sam_som",
+    "competitors",
+    "trends",
+    "threats",
+    "unexploited_opportunity",
+    "market_jtbd",
+    "real_differentials",
+    "summary_headline",
+    "summary_highlights",
+    "summary_key_findings"
+  ],
+  "properties": {
+    "client_name": {
+      "type": "string",
+      "description": "Nome do cliente"
+    },
+    "summary": {
+      "type": "string",
+      "description": "Resumo de 1-2 frases da pesquisa de mercado. Inclui oportunidade principal e diferencial real do cliente."
+    },
+    "summary_headline": {
+      "type": "string",
+      "maxLength": 200,
+      "description": "Manchete em 1 linha com o veredito da pesquisa (para hero do resumo executivo no portal)"
+    },
+    "summary_highlights": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 8,
+      "description": "KPIs visuais categorizados para o resumo executivo",
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "label",
+          "value"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "posicao",
+              "competicao",
+              "janela",
+              "maturidade",
+              "oportunidade",
+              "risco"
+            ]
+          },
+          "label": {
+            "type": "string",
+            "maxLength": 40
+          },
+          "value": {
+            "type": "string"
+          },
+          "subtext": {
+            "type": "string",
+            "maxLength": 80
+          },
+          "tone": {
+            "type": "string",
+            "enum": [
+              "green",
+              "yellow",
+              "red",
+              "blue",
+              "gray"
+            ]
+          }
+        }
+      }
+    },
+    "summary_key_findings": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 6,
+      "description": "Achados categorizados por intenção (vantagem/contexto/ameaça/ação)",
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "text"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "vantagem",
+              "contexto",
+              "ameaca",
+              "acao"
+            ]
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "segment": {
+      "type": "string",
+      "description": "Segmento de atuacao"
+    },
+    "region": {
+      "type": "string",
+      "description": "Regiao de atuacao"
+    },
+    "tam_sam_som": {
+      "type": "object",
+      "description": "Sizing de mercado com metodologia e fontes",
+      "required": [
+        "tam",
+        "sam",
+        "som",
+        "methodology",
+        "sources"
+      ],
+      "properties": {
+        "tam": {
+          "type": "object",
+          "required": [
+            "value_brl",
+            "description"
+          ],
+          "properties": {
+            "value_brl": {
+              "type": "number",
+              "description": "Valor do TAM em reais"
+            },
+            "description": {
+              "type": "string",
+              "description": "Descricao do que o TAM representa"
+            }
+          }
+        },
+        "sam": {
+          "type": "object",
+          "required": [
+            "value_brl",
+            "description",
+            "filters"
+          ],
+          "properties": {
+            "value_brl": {
+              "type": "number",
+              "description": "Valor do SAM em reais"
+            },
+            "description": {
+              "type": "string",
+              "description": "Descricao do que o SAM representa"
+            },
+            "filters": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Filtros aplicados para chegar ao SAM (regiao, perfil, etc.)"
+            }
+          }
+        },
+        "som": {
+          "type": "object",
+          "required": [
+            "value_brl",
+            "description",
+            "assumptions"
+          ],
+          "properties": {
+            "value_brl": {
+              "type": "number",
+              "description": "Valor do SOM em reais (anual). Teto de mercado capturavel — NAO derivar da meta do cliente, NAO limitar pela capacidade interna."
+            },
+            "description": {
+              "type": "string",
+              "description": "Descricao do que o SOM representa. Inclua a triangulacao metodologica (capacidade + market share + segmento) e explicite: (1) que nao e derivado da meta do cliente; (2) que e metrica de mercado, nao de capacidade."
+            },
+            "assumptions": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Premissas usadas para estimar o SOM (posicionamento, competicao, dinamica de nicho, nao premissas operacionais de capacidade)."
+            },
+            "operational_ceiling_note": {
+              "type": "string",
+              "description": "Nota opcional descrevendo o teto de capacidade operacional atual (ex: 'estrutura atual de 3 vets topa em R$ 5,4M — R$ 1,6M entre capacidade e SOM exigem expansao futura'). Separa restricao INTERNA (capacidade) do SOM (mercado)."
+            },
+            "related_but_separate": {
+              "type": "object",
+              "description": "Metricas relacionadas mas SEPARADAS do SOM: meta comercial do cliente de fontes diversas. Ajuda a comparar aspiracao da cliente vs potencial de mercado sem conflatar.",
+              "properties": {
+                "client_annual_revenue_goal_brl_v4mos": {
+                  "type": "number",
+                  "description": "Meta anual registrada no Formulario V4MOS (campo 'Meta 12M')"
+                },
+                "client_annual_revenue_goal_source_v4mos": {
+                  "type": "string",
+                  "description": "Fonte exata (ex: 'Formulario V4MOS - campo Meta 12M preenchido pela cliente')"
+                },
+                "client_monthly_revenue_goal_kickoff": {
+                  "type": "string",
+                  "description": "Meta mensal negociada no kickoff (se houver), em formato livre (ex: 'R$ 90.000 = R$ 1,08M/ano')"
+                },
+                "note": {
+                  "type": "string",
+                  "description": "Narrativa explicando relacao entre metas e SOM — enfatizando que metas sao aspiracao operacional, nao metrica de mercado."
+                }
+              }
+            }
+          }
+        },
+        "methodology": {
+          "type": "string",
+          "enum": [
+            "top-down",
+            "bottom-up",
+            "mixed"
+          ],
+          "description": "Metodologia usada para estimar o mercado"
+        },
+        "sources": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "name",
+              "url"
+            ],
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Nome da fonte (ex: SEBRAE, IBGE, Statista)"
+              },
+              "url": {
+                "type": "string",
+                "description": "URL da fonte ou referencia"
+              },
+              "year": {
+                "type": "integer",
+                "description": "Ano dos dados"
+              }
+            }
+          },
+          "description": "Fontes usadas para os dados de mercado"
+        }
+      }
+    },
+    "competitors": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 7,
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "positioning",
+          "channels",
+          "strengths",
+          "weaknesses",
+          "estimated_pricing",
+          "digital_score"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Nome do concorrente"
+          },
+          "positioning": {
+            "type": "string",
+            "description": "Como o concorrente se posiciona (PUV, mensagem principal)"
+          },
+          "channels": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Canais de aquisicao usados (Google Ads, Meta, organico, etc.)"
+          },
+          "strengths": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Pontos fortes observados"
+          },
+          "weaknesses": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Pontos fracos observados"
+          },
+          "estimated_pricing": {
+            "type": "string",
+            "description": "Estimativa de preco/ticket medio (ex: R$ 2.000/mes)"
+          },
+          "digital_score": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 10,
+            "description": "Score de presenca digital (1-10)"
+          },
+          "digital_details": {
+            "type": "object",
+            "properties": {
+              "website": {
+                "type": "string"
+              },
+              "instagram": {
+                "type": "string"
+              },
+              "google": {
+                "type": "string"
+              },
+              "active_ads": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "description": "Analise de cada concorrente"
+    },
+    "competitive_map": {
+      "type": "object",
+      "description": "Mapa competitivo 2x2",
+      "properties": {
+        "axis_x": {
+          "type": "string",
+          "description": "Eixo horizontal (ex: Generalista vs Especialista)"
+        },
+        "axis_y": {
+          "type": "string",
+          "description": "Eixo vertical (ex: Premium vs Acessivel)"
+        },
+        "positions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "quadrant": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "empty_spaces": {
+          "type": "string",
+          "description": "Espacos nao ocupados no mapa"
+        },
+        "crowded_spaces": {
+          "type": "string",
+          "description": "Espacos mais disputados"
+        }
+      }
+    },
+    "trends": {
+      "type": "array",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "trend",
+          "evidence"
+        ],
+        "properties": {
+          "trend": {
+            "type": "string",
+            "description": "Descricao da tendencia"
+          },
+          "evidence": {
+            "type": "string",
+            "description": "Evidencia ou fonte que comprova a tendencia"
+          }
+        }
+      },
+      "description": "Tendencias em crescimento no setor"
+    },
+    "threats": {
+      "type": "array",
+      "minItems": 2,
+      "items": {
+        "type": "object",
+        "required": [
+          "threat",
+          "potential_impact"
+        ],
+        "properties": {
+          "threat": {
+            "type": "string",
+            "description": "Descricao da ameaca"
+          },
+          "potential_impact": {
+            "type": "string",
+            "description": "Impacto potencial nos proximos 12 meses"
+          }
+        }
+      },
+      "description": "Ameacas que podem impactar o mercado"
+    },
+    "unexploited_opportunity": {
+      "type": "object",
+      "required": [
+        "description",
+        "why_nobody_does_it",
+        "feasibility"
+      ],
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Oportunidade nao explorada pelos concorrentes"
+        },
+        "why_nobody_does_it": {
+          "type": "string",
+          "description": "Motivo pelo qual ninguem explora essa oportunidade"
+        },
+        "feasibility": {
+          "type": "string",
+          "enum": [
+            "alta",
+            "media",
+            "baixa"
+          ],
+          "description": "Viabilidade para o cliente"
+        }
+      }
+    },
+    "market_jtbd": {
+      "type": "object",
+      "required": [
+        "current_solutions",
+        "alternatives"
+      ],
+      "properties": {
+        "current_solutions": {
+          "type": "string",
+          "description": "Como o mercado resolve hoje o problema do cliente"
+        },
+        "alternatives": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "type",
+              "description"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "direct",
+                  "indirect",
+                  "diy",
+                  "inaction"
+                ],
+                "description": "Tipo de alternativa"
+              },
+              "description": {
+                "type": "string",
+                "description": "Descricao da alternativa"
+              }
+            }
+          },
+          "description": "Alternativas que o mercado considera"
+        },
+        "cost_of_inaction": {
+          "type": "string",
+          "description": "O que acontece se o cliente nao resolver o problema"
+        }
+      }
+    },
+    "real_differentials": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "differential",
+          "status",
+          "icp_relevance"
+        ],
+        "properties": {
+          "differential": {
+            "type": "string",
+            "description": "Descricao do diferencial"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "confirmed",
+              "potential",
+              "aspirational"
+            ],
+            "description": "Se o diferencial ja existe, e potencial, ou aspiracional"
+          },
+          "icp_relevance": {
+            "type": "string",
+            "description": "Por que este diferencial importa para o ICP"
+          },
+          "action_needed": {
+            "type": "string",
+            "description": "Acao necessaria para ativar o diferencial (se potencial/aspiracional)"
+          }
+        }
+      },
+      "description": "Diferenciais competitivos reais e potenciais"
+    },
+    "honesty_alert": {
+      "type": "string",
+      "description": "Alerta se nao ha diferencial claro ou se a pesquisa revelou fragilidades"
+    },
+    "completed_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Data/hora de conclusao"
+    },
+    "market_share": {
+      "type": "object",
+      "description": "Comparação do faturamento atual do cliente vs SAM/SOM + meta da cliente separada + camada enderecavel opcional.",
+      "properties": {
+        "current_revenue_brl": {
+          "type": "number",
+          "description": "Faturamento atual anual (12 meses) em reais."
+        },
+        "current_share_of_sam_pct": {
+          "type": "number",
+          "description": "% do SAM que o cliente captura hoje."
+        },
+        "target_share_of_sam_pct": {
+          "type": "number",
+          "description": "% do SAM que o SOM representa. Sem 'target_scenario' — SOM e metrica unica, nao cenarios."
+        },
+        "gap_to_som_brl": {
+          "type": "number",
+          "description": "Diferenca absoluta entre SOM e faturamento atual."
+        },
+        "gap_to_som_pct": {
+          "type": "number",
+          "description": "% de crescimento sobre atual necessario para atingir SOM."
+        },
+        "commentary": {
+          "type": "string",
+          "description": "Narrativa do market share: onde esta, onde pode chegar, porque."
+        },
+        "client_annual_revenue_goal_brl": {
+          "type": "number",
+          "description": "Meta comercial anual registrada pela cliente — SEPARADA do SOM. Use a meta oficial (V4MOS se houver). NAO usar como SOM."
+        },
+        "client_annual_revenue_goal_source": {
+          "type": "string",
+          "description": "Fonte documentada da meta do cliente (ex: 'Formulario V4MOS - campo Meta 12M', 'Kickoff V4', 'Briefing inicial'). Obrigatorio quando client_annual_revenue_goal_brl esta presente."
+        },
+        "client_goal_vs_som_note": {
+          "type": "string",
+          "description": "Narrativa explicando a relacao entre a meta da cliente e o SOM. Se houver MAIS de uma meta em fontes diferentes (V4MOS + kickoff), registrar ambas aqui com suas fontes respectivas."
+        },
+        "enderecavel_value_brl": {
+          "type": "number",
+          "description": "Tamanho do Mercado Enderecavel (subset do SAM onde a oferta do cliente e relevante). Usar quando SAM tem perfis heterogeneos e o cliente escolhe competir apenas em um subsegmento (tipicamente premium humanizado + upgrading medium)."
+        },
+        "enderecavel_composition": {
+          "type": "string",
+          "description": "Como chegou ao valor do enderecavel — composicao dos subsegmentos somados (ex: 'Premium humanizado R$17M + 20% do medio R$2,9M = R$20M')."
+        },
+        "enderecavel_note": {
+          "type": "string",
+          "description": "Explicacao pedagogica da camada enderecavel — renderizada no portal abaixo do grafico Market Share. Tipicamente explica: (1) que o SAM tem perfis diversos; (2) quais perfis o cliente NAO persegue por decisao estrategica; (3) separa barreira de escolha (SAM->Enderecavel) de barreira competitiva (Enderecavel->SOM)."
+        }
+      }
+    }
+  }
+}

--- a/.claude/skills/geral-posicionamento-estrategico/SKILL.md
+++ b/.claude/skills/geral-posicionamento-estrategico/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: geral-posicionamento-estrategico
+description: "Canvas de posicionamento estrategico completo: PUV, 4Ps, territorio de marca e taglines. A skill mais importante da Semana 2 — tudo que sera produzido na Semana 3 nasce daqui. Use quando o operador disser /geral-posicionamento-estrategico ou 'definir posicionamento' ou 'PUV' ou 'proposta de valor' ou 'canvas de posicionamento'."
+area: geral
+author: luizfreitasv4
+version: 1.0.0
+dependencies:
+  - geral-pesquisa-mercado
+  - geral-persona-icp
+  - geral-analise-swot
+tools: []
+week: 2
+estimated_time: "2.5h"
+output_file: "geral-posicionamento-estrategico.json"
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta versao foi portada do sistema de Estruturacao Estrategica. As regras abaixo tem precedencia sobre caminhos e persistencia citados no fluxo original:
+
+- Trabalhe somente em `squads/{squad}/clientes/{cliente}/`, nunca em um diretorio `clientes/` solto na raiz.
+- Leia primeiro o `CLAUDE.md` ou `AGENTS.md` da KB, `mission-control/`, `calls/`, `docs/` e `campanhas/`.
+- Se `client.json` existir, use-o como fonte complementar. Se nao existir, derive o contexto da KB e do Mission Control; nao exija nem invente esse arquivo.
+- Salve entregaveis em `squads/{squad}/clientes/{cliente}/outputs/`, em JSON e Markdown quando o fluxo pedir ambos.
+- Registre decisoes e progresso no `mission-control/historico-checkins.md` ou no arquivo de historico equivalente encontrado na KB.
+- Resolva recursos empacotados a partir do proprio diretorio desta skill. Se uma integracao externa nao estiver configurada, declare o gap e continue apenas com os dados reais disponiveis.
+
+
+# Canvas de Posicionamento Estrategico (POP 2.5)
+
+> **Posição no fluxo:** Semana 2 — síntese final, comum a todos os modelos. Consome todos os diagnósticos da S1/S2 e é a raiz da Semana 3 inteira (cabeça por modelo + cauda comum).
+
+Voce e um brand strategist senior especializado em posicionamento para PMEs brasileiras. Vai definir o posicionamento estrategico completo do cliente — o DNA de toda a producao da Semana 3 (brandbook, landing page, criativos, copy).
+
+**IMPORTANCIA:** Esta e a skill mais critica do processo. Se o posicionamento for generico, TUDO que vier depois sera generico. Se for afiado e verdadeiro, toda a producao ganha forca.
+
+## Dados necessários
+
+1. Leia `client.json` (seção `briefing`) — extraia: NOME_CLIENTE, SEGMENTO, PRODUTO_SERVICO, marca_valores
+2. Leia `outputs/geral-persona-icp.json` — extraia: RESUMO_ICP, dores, desejos, linguagem, Jobs-to-be-Done
+3. Leia `outputs/geral-pesquisa-mercado.json` — extraia: DIFERENCIAIS_REAIS, POSICIONAMENTOS_CONCORRENTES, mapa_competitivo, oportunidade_inexplorada
+4. Leia `outputs/geral-analise-swot.json` — extraia: RESUMO_SWOT (forcas + oportunidades prioritarias)
+
+Se algum input critico estiver faltando, alerte o operador e sugira completar a dependencia primeiro.
+
+Antes de gerar, confirme com o operador a direcao estrategica (se não encontrar estas informações no client.json):
+- "Diferencial mais forte que voce sente no dia a dia — dos que mapeamos, qual o cliente elogia mais?"
+- "Onde quer estar no mapa competitivo? O espaco vazio identificado faz sentido?"
+- "Restricao de posicionamento — algo que o cliente NAO quer ser associado?"
+- "Tom de comunicacao — mais tecnico/profissional, mais proximo/informal, ou mais aspiracional/premium?"
+
+---
+
+## Geração
+
+Gere o output COMPLETO de uma vez usando os dados de `client.json` (briefing, connectors) e outputs de skills dependentes em `outputs/`.
+
+### Mapa de posicionamento 2x2
+
+Posicione concorrentes e a posição recomendada para o cliente num mapa com eixos estratégicos (ex: Generalista → Especialista × Acessível → Premium). Justifique a posição recomendada.
+
+### 3 Declarações de posicionamento
+
+Gere 3 opções com direções diferentes usando o formato clássico:
+> "Para **[ICP]**, **{NOME_CLIENTE}** e o **[categoria]** que **[beneficio principal]** porque **[razao para acreditar]**."
+
+Para cada opção: aposta (o que prioriza) + risco (onde pode falhar).
+
+### PUV (Proposta Unica de Valor)
+
+Baseada na direção escolhida pelo operador (ou na recomendada). Inclua teste de qualidade:
+- É verdadeira? (diferencial real, não aspiracional)
+- É específica? (não serve para nenhum concorrente)
+- É relevante? (resolve a dor principal do ICP)
+- É memorável? (o ICP consegue repetir)
+- É diferente? (nenhum concorrente diz isso)
+
+### Canvas de Posicionamento (4Ps Estrategico)
+
+Consulte `references/exemplos-puv.md` e `references/canvas-4p-guide.md`.
+
+**PRODUTO:** Transformação entregue + antes/depois concreto + limitações honestas
+**PREÇO:** Posicionamento (premium/mid/value) + justificativa na comunicação + ancoragem
+**PRAÇA (CANAIS):** Canal principal + justificativa + canal secundário + canais a evitar (com motivo)
+**PROMOÇÃO:** Tom e estilo + mensagem topo de funil + mensagem fundo de funil
+
+### Territorio de marca
+
+Consulte `references/territorio-de-marca.md`.
+- Em 3 palavras: o que a marca representa
+- O que significa na prática
+- Territórios dos concorrentes (para diferenciação)
+- Por que o território escolhido está disponível
+
+### 3 opções de tagline
+
+Para cada: tom + justificativa + melhor uso (site, assinatura, anúncios).
+
+### Estrutura visual (obrigatória)
+
+Siga o padrão canônico de `references/padrao-output.md`. Além dos campos acima, SEMPRE inclua:
+
+- **`summary_headline`** (max 200 char) — manchete com o veredito do posicionamento. Ex: "[Cliente] ocupa '[Território Premium do nicho]' — território único na microrregião com janela de 12-18 meses".
+- **`summary_highlights`** (4-6 itens, `{category, label, value, subtext, tone}`) — sugestões:
+  - `posicao`: território de 3 palavras escolhido
+  - `competicao`: território ocupado pelo concorrente #1 (contraste)
+  - `janela`: tempo até concorrência relevante chegar
+  - `oportunidade`: ICP principal + ticket esperado
+  - `risco`: pior cenário de posicionamento forçado
+- **`summary_key_findings`** (3-5 itens, `{category, text}`) — `vantagem|contexto|ameaca|acao`.
+
+### Ponto de alavancagem
+
+Em posicionamento, o ponto de alavancagem é o **território × janela de oportunidade** — o espaço competitivo disponível combinado com o tempo que o cliente tem para ocupá-lo antes da concorrência chegar. Estruture em `key_insight`:
+```json
+"key_insight": {
+  "headline": "Frase sobre território + janela (ex: 'Território [Especialista do nicho] está vago por 12-18 meses')",
+  "context": "2-3 linhas sobre por que ninguém ocupou ainda e por que a janela é finita",
+  "numbered_reasons": ["(1) evidência de que está vago", "(2) o que fecha a janela", "(3) o que o cliente ganha ao ocupar primeiro"],
+  "discussion_anchor": "Por que o stakeholder precisa agir AGORA e não esperar validação"
+}
+```
+
+Se o território escolhido é aspiracional (diferencial ainda não construído), ou a janela é curtíssima e exige decisão imediata, inclua `honesty_alert`.
+
+## Auto-validação
+
+Antes de mostrar ao operador, verifique:
+
+- [ ] Mencionou o cliente pelo nome?
+- [ ] Usou dados reais do client.json (não inventou)?
+- [ ] Nenhum item genérico (ex: "quer crescer", "qualidade e compromisso")?
+- [ ] Schema da skill validou?
+- [ ] Todos os campos do schema preenchidos (ou com `null` + `unavailable_reason` no pai)?
+- [ ] Nenhuma string vazia (`""`) — substituí por `null` + reason quando o dado não existe?
+- [ ] Estimativas marcadas com `estimated: true` ou `[E]`?
+- [ ] Consistente com outputs anteriores (ICP, pesquisa de mercado, SWOT)?
+- [ ] PUV passa nos 5 testes de qualidade?
+- [ ] Cada declaração de posicionamento é diferente das outras (não variações do mesmo)?
+- [ ] Território de marca não está ocupado por concorrente?
+- [ ] Tem `summary_headline` específico?
+- [ ] `summary_highlights` tem 4-6 itens com categorias e tons válidos?
+- [ ] `summary_key_findings` cobre pelo menos 3 dos 4 tipos?
+- [ ] Identificou `key_insight` (território × janela)?
+- [ ] Se território é aspiracional ou janela curtíssima, incluiu `honesty_alert`?
+
+Se falhou → regenere silenciosamente. Não avise o operador.
+
+## Apresentação e decisões
+
+Apresente o output COMPLETO ao operador.
+
+**DECISÃO 1:** Direção de posicionamento — qual das 3 declarações?
+- Opção A: "[nome da direção]" — "[declaração]"
+- Opção B: "[nome da direção]" — "[declaração]"
+- Opção C: "[nome da direção]" — "[declaração]"
+
+**RECOMENDAÇÃO:** Opção [X]. [Justificativa baseada nos dados da pesquisa de mercado e SWOT, não opinião genérica.]
+
+**PROVOCAÇÃO:** [Ex: "Essa direção implica abandonar o público Y. O cliente está pronto pra essa escolha?"]
+
+**DECISÃO 2:** Tagline — qual direção?
+- Opção A: "[tagline]"
+- Opção B: "[tagline]"
+- Opção C: "[tagline]"
+
+**RECOMENDAÇÃO:** Opção [X]. [Justificativa baseada no território de marca e tom de voz.]
+
+**PROVOCAÇÃO:** [Ex: "Essa tagline funciona em outdoor ou só em contexto digital?"]
+
+Valide também:
+- O canvas 4P está alinhado com a realidade do cliente?
+- O que "não entregamos" está honesto?
+- O tom de comunicação soa como o cliente falaria?
+- As 3 palavras do território representam como o cliente quer ser percebido?
+
+## Finalização
+
+Operador aprova (com ou sem ajustes).
+1. Salve em `squads/{squad}/clientes/{cliente}/outputs/geral-posicionamento-estrategico.json` (com campo `summary` no topo)
+2. Atualize `client.json`: progress.skills → completed, version++, append em history[]
+3. Salve também uma versão Markdown do entregável na mesma pasta de outputs.
+4. Sugira próxima skill do dependency_graph
+   - "Posicionamento concluído. PUV: '{puv}'. Tagline: '{tagline}'. Território: {3 palavras}."
+   - "Este posicionamento é a raiz da Semana 3 inteira: a cabeça do modelo de venda + a cauda comum (/designer-manual-marca, /designer-landing-page, /copy-anuncios, /designer-criativos-anuncios, forecast)."
+   - "Proximo passo recomendado: /gt-diagnostico-midia-paga ou /gt-diagnostico-criativos"
+
+
+## Campo obrigatório: summary
+
+Sempre inclua no JSON de saída:
+```json
+"summary": "Resumo de 1-2 frases do posicionamento: PUV definida e território de marca escolhido. Seja específico — mencione o cliente, números reais e a conclusão principal."
+```
+
+Este campo alimenta o Resumo Executivo do portal de entregas. Deve ser objetivo, com dados reais, sem genéricos.

--- a/.claude/skills/geral-posicionamento-estrategico/references/canvas-4p-guide.md
+++ b/.claude/skills/geral-posicionamento-estrategico/references/canvas-4p-guide.md
@@ -1,0 +1,153 @@
+# Guia do Canvas 4P Estrategico
+
+O Canvas 4P nao e o mix de marketing academico. E uma ferramenta de POSICIONAMENTO que traduz a estrategia em decisoes operacionais de comunicacao e canal.
+
+## PRODUTO — O que entregamos de verdade
+
+### Perguntas-chave
+- O que o cliente COMPRA vs o que ele QUER? (ninguem compra "broca de 6mm" — compra "buraco na parede")
+- Qual e a transformacao? Descreva o ANTES e o DEPOIS do cliente
+- O que NAO entregamos? (isso e tao importante quanto o que entregamos)
+
+### Como preencher
+
+**"O que entregamos de verdade"**
+Nao liste features. Descreva o resultado que o cliente experimenta.
+
+Ruim: "Gestao de midias sociais com 20 posts por mes"
+Bom: "Presenca digital profissional que gera leads quentes — o cliente para de depender de indicacao"
+
+**"Qual transformacao o cliente vive"**
+Formato antes/depois:
+
+```
+ANTES: [situacao real que o ICP vive hoje]
+DEPOIS: [situacao apos usar o produto/servico]
+```
+
+Exemplo:
+```
+ANTES: Dona de clinica que posta no Instagram quando lembra, nao sabe se funciona, e depende 100% de indicacao
+DEPOIS: Recebe 30+ leads por mes do digital, sabe exatamente quanto custa cada lead, e tem previsibilidade de faturamento
+```
+
+**"O que NAO entregamos"**
+Isso cria confianca e evita expectativa errada. Exemplos:
+- "Nao fazemos milagre em 7 dias — resultados consistentes aparecem a partir do mes 2"
+- "Nao atendemos empresas que querem ser as mais baratas do mercado"
+- "Nao criamos conteudo para TikTok — nosso foco e performance no Meta e Google"
+
+### Armadilhas
+- Listar features em vez de beneficios
+- Prometer transformacao irreal ("6 digitos em 30 dias")
+- Nao delimitar o que nao faz (gera frustração)
+
+---
+
+## PRECO — Posicionamento, nao tabela
+
+### Posicionamentos possiveis
+
+| Posicionamento | Descricao | Quando usar |
+|---|---|---|
+| **Premium** | Mais caro que a media, justificado por resultado/exclusividade | Diferencial claro e comprovado, ICP valoriza resultado acima de preco |
+| **Mid-market** | Faixa media do mercado, custo-beneficio | Mercado com opcoes baratas ruins e premium inacessiveis |
+| **Value** | Mais acessivel, volume alto | Escala e eficiencia operacional, ICP sensivel a preco |
+
+### Justificativa do preco na comunicacao
+
+O preco nunca deve ser comunicado isolado. Sempre com contexto:
+
+**Para premium:**
+- Ancoragem pelo custo da inacao: "Quanto voce perde por mes sem isso?"
+- Ancoragem pelo resultado: "Se gera R$ 50K em vendas, R$ 5K de investimento e 10x de retorno"
+- Exclusividade: "Atendemos no maximo 15 clientes por consultor"
+
+**Para mid-market:**
+- Comparacao explicita: "Resultado de agencia premium, investimento justo"
+- Transparencia: "Sem taxa de setup, sem contrato de fidelidade, sem surpresas"
+- ROI claro: "CPL medio dos nossos clientes no segmento: R$ X"
+
+**Para value:**
+- Acessibilidade sem parecer barato: "Democratizamos o acesso a [beneficio]"
+- Volume como prova: "Mais de X clientes atendidos"
+- Simplicidade: "Um plano, um preco, tudo incluso"
+
+### Estrategia de ancoragem
+
+Tecnicas comuns para PMEs:
+1. **Ancora pelo concorrente:** "Agencias cobram R$ 5K+. Nos entregamos o mesmo por R$ 2.5K"
+2. **Ancora pelo custo interno:** "Um social media CLT custa R$ 4K+/mes. Voce tem um time inteiro por R$ 2K"
+3. **Ancora pelo resultado:** "Se cada lead vale R$ 500, 30 leads = R$ 15K. Investimento: R$ 3K"
+4. **Ancora pelo prejuizo:** "Cada dia sem LP otimizada sao X leads perdidos"
+
+---
+
+## PRACA (CANAIS) — Onde encontrar o ICP
+
+### Como escolher o canal principal
+
+| Se o ICP... | Canal principal recomendado |
+|---|---|
+| Busca ativamente a solucao | Google Ads (Search) |
+| Nao sabe que precisa, mas tem a dor | Meta Ads (Instagram/Facebook) |
+| E decisor B2B em empresas medias | LinkedIn Ads + conteudo |
+| E local e busca servico proximo | Google Meu Negocio + Google Ads Local |
+| E jovem (18-30) e visual | Instagram + TikTok organico |
+| Ja comprou algo similar | Retargeting + Email marketing |
+| Confia em indicacao | Programa de referral + parcerias |
+
+### Canais a evitar (e quando)
+
+| Canal | Evitar quando... |
+|---|---|
+| TikTok Ads | ICP e 40+, produto e B2B, ou nao ha capacidade de produzir video |
+| LinkedIn Ads | Budget < R$ 5K/mes (CPL altissimo), produto B2C |
+| Google Display | Sem retargeting configurado (display frio tem CTR minimo) |
+| Pinterest | Segmento sem apelo visual, ICP masculino 50+ |
+| Twitter/X Ads | Quase qualquer caso de PME (inventory pequeno no Brasil) |
+| Programatica | Budget < R$ 10K/mes, sem equipe para otimizar |
+
+### Canal de suporte
+
+O canal de suporte complementa o principal:
+- Principal = Google Ads → Suporte = Retargeting Meta Ads
+- Principal = Meta Ads → Suporte = Email nurturing
+- Principal = Organico Instagram → Suporte = Stories + WhatsApp
+- Principal = Indicacao → Suporte = Google Meu Negocio (prova social)
+
+---
+
+## PROMOCAO — Como comunicar
+
+### Tom e estilo de comunicacao
+
+| Tom | Descricao | Quando usar | Exemplo |
+|---|---|---|---|
+| **Tecnico/profissional** | Dados, metodologia, credibilidade | B2B, saude, financeiro | "Reduzimos o CAC medio em 40% com otimizacao de funil" |
+| **Proximo/informal** | Conversa, humor leve, empatia | Varejo, servicos locais, wellness | "A gente sabe como e dificil — por isso simplificamos tudo" |
+| **Aspiracional/premium** | Exclusividade, resultado, status | Luxo, estetica, coaching | "Para quem nao aceita o comum" |
+| **Didatico/educativo** | Ensina, gera autoridade, conquista confianca | SaaS, consultoria, educacao | "Antes de contratar qualquer agencia, entenda isso..." |
+| **Direto/performance** | CTA forte, urgencia, oferta clara | E-commerce, lancamentos, promocoes | "50 vagas. Comeca segunda. Inscricao aberta." |
+
+### Mensagem de topo de funil
+
+O objetivo no topo e PARAR o scroll e gerar curiosidade. Nao vender.
+
+**Formulas que funcionam:**
+1. **Dor direta:** "Voce posta todo dia e nao gera um lead sequer?"
+2. **Dado chocante:** "83% das clinicas de estetica perdem dinheiro com anuncios mal feitos"
+3. **Pergunta provocativa:** "Quanto custa cada lead que voce perde por nao ter uma LP?"
+4. **Resultado concreto:** "Como a [tipo de empresa] saiu de 5 para 50 leads/mes em 90 dias"
+5. **Contra-intuitivo:** "O problema nao e seu anuncio — e o que acontece DEPOIS do clique"
+
+### Mensagem de fundo de funil
+
+O objetivo no fundo e CONVERTER. O lead ja sabe quem voce e.
+
+**Formulas que funcionam:**
+1. **Prova + CTA:** "97% dos nossos clientes renovam. Agenda uma conversa."
+2. **Garantia:** "Se nao gerar X em 90 dias, devolvemos o fee"
+3. **Escassez real:** "Atendemos 15 clientes por cidade. 3 vagas restantes em [cidade]."
+4. **Simplicidade:** "Sem contrato. Sem setup. Comeca em 48h."
+5. **Resultado especifico:** "Em 90 dias: LP no ar, 30+ leads/mes, CPL abaixo de R$ X"

--- a/.claude/skills/geral-posicionamento-estrategico/references/exemplos-puv.md
+++ b/.claude/skills/geral-posicionamento-estrategico/references/exemplos-puv.md
@@ -1,0 +1,117 @@
+# Exemplos de PUV: Boas vs Ruins
+
+A PUV (Proposta Unica de Valor) e a resposta a pergunta: "Por que eu deveria escolher voce e nao o concorrente?"
+
+## Criterios de uma boa PUV
+
+1. **Verdadeira** — Baseada em algo que a empresa realmente faz/tem, nao em aspiracao
+2. **Especifica** — Nao serve para nenhum concorrente copiar sem mentir
+3. **Relevante** — Resolve uma dor real do ICP (nao e um diferencial que ninguem pediu)
+4. **Memoravel** — O ICP consegue repetir para outra pessoa
+5. **Diferente** — Nenhum concorrente esta dizendo isso
+
+## 10 exemplos por segmento: PUV boa vs PUV ruim
+
+### 1. Clinica odontologica
+
+**RUIM:** "Tratamento odontologico de qualidade com tecnologia de ponta"
+- Por que falha: Generica. Toda clinica diz isso. Nao e especifica nem memoravel.
+
+**BOA:** "Implante dental em 1 dia com sedacao — voce entra com medo e sai com o sorriso pronto"
+- Por que funciona: Especifica (1 dia + sedacao), resolve a dor real (medo + demora), memoravel.
+
+### 2. Escritorio de contabilidade
+
+**RUIM:** "Solucoes contabeis completas para sua empresa crescer"
+- Por que falha: "Solucoes completas" nao diz nada. Qualquer contador pode dizer isso.
+
+**BOA:** "Contabilidade para e-commerces que faturam de R$ 50K a R$ 2M/mes — voce vende, a gente cuida do regime tributario que mais economiza"
+- Por que funciona: Nicho claro (e-commerce), faixa de faturamento (qualificacao), beneficio concreto (economia tributaria).
+
+### 3. Academia/studio fitness
+
+**RUIM:** "Transforme seu corpo e sua vida com nossos profissionais qualificados"
+- Por que falha: Aspiracional demais, generica, nao diferencia de nenhuma academia.
+
+**BOA:** "Treino personalizado de 45 minutos com turmas de no maximo 6 pessoas — resultado de personal, preco de academia"
+- Por que funciona: Formato especifico (45min, max 6), resolve o trade-off percebido (personal caro vs academia lotada).
+
+### 4. Restaurante delivery
+
+**RUIM:** "Comida feita com amor e ingredientes frescos"
+- Por que falha: Todos dizem isso. "Feita com amor" e irrelevante para a decisao de compra.
+
+**BOA:** "Marmita fitness que chega em 30 minutos com as macros calculadas no rotulo — para quem treina e nao tem tempo de cozinhar"
+- Por que funciona: Produto especifico (marmita fitness), prazo (30min), diferencial unico (macros no rotulo), ICP claro (quem treina).
+
+### 5. Agencia de marketing digital
+
+**RUIM:** "Estrategias de marketing digital personalizadas para o seu negocio"
+- Por que falha: Toda agencia diz exatamente isso. Zero especificidade.
+
+**BOA:** "Marketing digital para clinicas de estetica — geramos 30+ leads qualificados por mes ou voce nao paga a gestao"
+- Por que funciona: Nicho (clinicas estetica), metrica concreta (30+ leads), garantia (nao paga se nao entregar).
+
+### 6. Imobiliaria
+
+**RUIM:** "Encontre o imovel dos seus sonhos com atendimento personalizado"
+- Por que falha: Frase de corretor desde 1990. Nao diferencia nada.
+
+**BOA:** "Apartamentos de 1-2 quartos para investidores no centro de Curitiba — analise de rentabilidade inclusa antes de fechar"
+- Por que funciona: Produto nicho (1-2q, centro CWB), ICP claro (investidores), diferencial de servico (analise de rentabilidade).
+
+### 7. Software/SaaS B2B
+
+**RUIM:** "A plataforma completa para gestao do seu negocio"
+- Por que falha: "Plataforma completa" e o que todo SaaS diz. Nao define para quem ou para que.
+
+**BOA:** "ERP para oficinas mecanicas que controla estoque de pecas, ordem de servico e cobranca em um lugar so — sem planilha, sem papel"
+- Por que funciona: Vertical clara (oficinas), funcionalidades relevantes, dor concreta que resolve (planilha + papel).
+
+### 8. Clinica de estetica
+
+**RUIM:** "Realce sua beleza natural com tratamentos de ultima geracao"
+- Por que falha: Frases bonitas mas vazias. Nao diferencia de nenhuma clinica.
+
+**BOA:** "Harmonizacao facial com resultado natural em sessao unica — antes e depois publicado so com sua autorizacao"
+- Por que funciona: Procedimento especifico, promessa real (resultado natural, sessao unica), diferencial de confianca (fotos com autorizacao).
+
+### 9. Escola de idiomas
+
+**RUIM:** "Aprenda ingles com a melhor metodologia do mercado"
+- Por que falha: "Melhor metodologia" e uma afirmacao generica e nao verificavel.
+
+**BOA:** "Ingles para profissionais de TI — conversacao focada em daily standups, code review e entrevistas tecnicas em 6 meses"
+- Por que funciona: ICP claro (TI), situacoes reais (standup, review, entrevistas), prazo concreto (6 meses).
+
+### 10. Pet shop/veterinaria
+
+**RUIM:** "Cuidamos do seu pet com carinho e profissionalismo"
+- Por que falha: Qualquer pet shop pode dizer isso. "Carinho" nao e diferencial comercial.
+
+**BOA:** "Banho e tosa com hora marcada e entrega em domicilio — seu cachorro volta limpo sem voce sair de casa"
+- Por que funciona: Formato especifico (hora marcada + delivery), resolve dor real (deslocamento + espera), promessa clara.
+
+## Padroes das PUVs ruins
+
+1. **Adjetivos vazios:** "qualidade", "excelencia", "compromisso", "inovacao"
+2. **Frases de efeito:** "transforme sua vida", "realce sua beleza", "solucoes completas"
+3. **Sem ICP:** Nao diz para quem e — fala para todo mundo (e portanto para ninguem)
+4. **Sem especificidade:** Nenhum numero, prazo, formato ou garantia
+5. **Aspiracional vs factual:** Descreve o que gostariam de ser, nao o que sao
+
+## Padroes das PUVs boas
+
+1. **ICP explicito:** Menciona para quem e, direto na PUV
+2. **Metrica ou promessa concreta:** "30 leads", "45 minutos", "sessao unica", "6 meses"
+3. **Dor real resolvida:** Conecta com algo que o ICP sofre hoje
+4. **Formato ou mecanismo unico:** Como funciona, nao apenas o que faz
+5. **Trade-off resolvido:** Entrega algo que antes parecia incompativel (qualidade + preco, resultado + velocidade)
+
+## Como refinar uma PUV fraca
+
+1. Substitua adjetivos por numeros: "rapido" → "em 30 minutos"
+2. Adicione o ICP: "para todos" → "para clinicas que faturam R$ 50-200K/mes"
+3. Adicione a dor: "solucoes de marketing" → "para quem ja gastou com agencia e nao viu resultado"
+4. Adicione prova: "resultado garantido" → "ou devolvemos o fee de gestao"
+5. Teste: "meu concorrente poderia dizer isso sem mentir?" Se sim, refine mais.

--- a/.claude/skills/geral-posicionamento-estrategico/references/padrao-output.md
+++ b/.claude/skills/geral-posicionamento-estrategico/references/padrao-output.md
@@ -1,0 +1,202 @@
+# Padrão de Output das Skills — V4 Estruturação IA
+
+Este documento define a **estrutura canônica** que todos os outputs de skill devem seguir para renderizar no portal com hierarquia visual consistente. O objetivo é que o operador e o stakeholder final abram qualquer entregável e encontrem o mesmo ritmo: manchete → KPIs → achados categorizados → ponto de alavancagem destacado → detalhes expansíveis.
+
+---
+
+## Princípios
+
+1. **Manchete antes de texto.** Toda skill abre com uma frase única e específica que resume a conclusão. Não é parágrafo, é headline.
+2. **Números em destaque, não escondidos no corpo do texto.** KPIs que importam viram cards. Texto corrido é para contexto, não para fato quantitativo.
+3. **Achados categorizados por intenção.** Cada insight é classificado como `vantagem | contexto | ameaca | acao` — o leitor identifica o tom antes de ler.
+4. **Ponto de alavancagem visualmente isolado.** Toda skill tem UM ponto onde a conversa com o stakeholder precisa acontecer. Esse ponto ganha hero visual (border, gradient, quote destacada).
+5. **Detalhe denso → colapsável.** Listas longas (concorrentes, itens de checklist, fontes) ficam em `<details>` para não afogar a leitura.
+
+---
+
+## Campos obrigatórios no JSON
+
+Todo output de skill DEVE ter estes campos no topo (antes dos campos específicos da skill):
+
+```json
+{
+  "client_name": "Nome do Cliente",
+  "summary": "Resumo em 1-2 frases. Específico, com dados reais. Alimenta o resumo executivo do portal.",
+
+  "summary_headline": "Manchete em 1 linha (max 120 caracteres). A frase que o stakeholder lê primeiro.",
+
+  "summary_highlights": [
+    {
+      "category": "posicao | competicao | janela | maturidade | oportunidade | risco",
+      "label": "Rótulo curto (max 30 char)",
+      "value": "Valor em destaque (número, %, status)",
+      "subtext": "Contexto em 1 linha (max 60 char)",
+      "tone": "green | yellow | red | blue | gray"
+    }
+  ],
+
+  "summary_key_findings": [
+    {
+      "category": "vantagem | contexto | ameaca | acao",
+      "text": "Achado em 1-2 linhas. Específico, acionável."
+    }
+  ]
+}
+```
+
+### Regras dos campos de summary
+
+**`summary_headline`**: É a ÚNICA frase que o stakeholder precisa ler se só tiver 5 segundos. Deve conter o veredito da skill. Exemplos bons:
+- ✓ "[Cliente] é o ÚNICO player premium da microrregião com [diferencial declarado] — janela competitiva de 12-18 meses."
+- ✗ "Análise de mercado concluída com sucesso."
+
+**`summary_highlights`** (4-6 itens): KPIs visuais. Categorias sugeridas:
+- `posicao` — onde o cliente está hoje vs potencial
+- `competicao` — quem disputa o mesmo espaço
+- `janela` — tempo/urgência
+- `maturidade` — estágio atual em algum eixo
+- `oportunidade` — tamanho do ganho possível
+- `risco` — tamanho da ameaça
+
+Agrupar de 2 em 2 por categoria no renderer (dá layout balanceado 3x2 ou 2x2).
+
+**`summary_key_findings`** (3-5 itens): Achados que embasam a manchete. Categorias:
+- `vantagem` (✓ verde) — o que o cliente tem a favor
+- `contexto` (i azul) — o que é fato do mercado, neutro
+- `ameaca` (! vermelho) — o que pode dar errado
+- `acao` (▸ laranja) — o que precisa ser feito
+
+---
+
+## Ponto de Alavancagem (hero block)
+
+Toda skill deve identificar **UM bloco que merece destaque visual especial** — o ponto onde a conversa estratégica precisa acontecer. O nome do campo varia por skill, mas a estrutura é consistente:
+
+```json
+{
+  "key_leverage_point": {
+    "headline": "Frase-manchete do ponto (pode ir como quote)",
+    "context": "Contexto em 2-3 linhas explicando o cenário",
+    "numbered_reasons": [
+      "Razão 1 (parse-friendly, pode começar com texto direto)",
+      "Razão 2",
+      "Razão 3"
+    ],
+    "discussion_anchor": "Frase curta sobre POR QUE este é o ponto de conversa com o stakeholder"
+  }
+}
+```
+
+Exemplos por skill:
+- `pesquisa-mercado` → `unexploited_opportunity` (whitespace estratégico)
+- `persona-icp` → persona principal + dor mais ignorada
+- `swot` → combinação força × oportunidade mais assimétrica
+- `posicionamento` → PUV vs alternativas descartadas
+- `diagnostico-midia` → canal mais subotimizado + upside estimado
+- `diagnostico-maturidade` → pilar mais fraco com maior impacto
+
+O renderer aplica:
+- Border verde 2px + gradient sutil
+- Selo "Whitespace Estratégico · Discussão com Stakeholder" no topo
+- Pill de viabilidade/urgência à direita
+- Quote/headline em card branco isolado
+- Razões numeradas em 3 círculos
+- Footer "💬 Momento de validar com a stakeholder"
+
+---
+
+## Alerta de honestidade
+
+Se a pesquisa/análise revelou fragilidade do cliente (não há diferencial real, ICP mal definido, mercado saturado, etc.), inclua:
+
+```json
+{
+  "honesty_alert": "Texto explicando a fragilidade encontrada e o que precisa ser feito antes de seguir."
+}
+```
+
+Esse campo renderiza em box amarelo/vermelho após os achados. **Nunca omita** se a realidade justifica. O valor do sistema depende de não vender aspiracional como real.
+
+---
+
+## Instrução para a IA da skill
+
+Em cada `SKILL.md`, incluir esta seção na geração:
+
+> ### Estrutura visual (obrigatória)
+>
+> Além dos campos específicos desta skill, gere SEMPRE:
+>
+> - `summary_headline` — manchete em 1 linha com o veredito
+> - `summary_highlights` — 4-6 KPIs categorizados (`posicao|competicao|janela|maturidade|oportunidade|risco`) com `{label, value, subtext, tone}`
+> - `summary_key_findings` — 3-5 achados categorizados (`vantagem|contexto|ameaca|acao`)
+> - `honesty_alert` se houver fragilidade
+>
+> Identifique o **ponto de alavancagem** desta skill (o bloco que merece hero visual) e estruture-o com headline + contexto + razões numeradas + discussion anchor.
+>
+> Consulte `references/padrao-output.md` para especificação completa.
+
+E na auto-validação:
+
+> - [ ] Tem `summary_headline` específico (não "análise concluída")?
+> - [ ] `summary_highlights` tem 4-6 itens com categorias válidas?
+> - [ ] `summary_key_findings` cobre pelo menos 3 dos 4 tipos (vantagem/contexto/ameaça/ação)?
+> - [ ] Identificou o ponto de alavancagem para discussão com stakeholder?
+> - [ ] Se há fragilidade, incluiu `honesty_alert`?
+
+---
+
+## Completude (regra crítica)
+
+**Todo campo definido no schema da skill é obrigatório no output.** Não omitir campos — o renderer assume que os campos do schema existem e quebra/fica vazio silenciosamente quando faltam.
+
+Se um dado **não pode ser obtido** (GA4 não instalado, conector não conectado, cliente não sabe, etc.), preencher com `null` E adicionar `unavailable_reason` no objeto pai:
+
+```json
+{
+  "current_conversion_rate": null,
+  "current_bounce_rate": null,
+  "avg_time_on_page": null,
+  "unavailable_reason": "GA4 não instalado no site — métricas de analytics não coletadas nesta auditoria"
+}
+```
+
+Para arrays vazios legitimamente (ex: nenhum competidor identificado), preencher com `[]` e adicionar uma nota no campo irmão `{campo}_note`:
+
+```json
+{
+  "competitors": [],
+  "competitors_note": "Nenhum concorrente direto identificado na microrregião após busca em Google Maps + Instagram."
+}
+```
+
+Para valores **estimados** (sem fonte pública), adicionar flag `[E]` no texto OU campo `estimated: true` no objeto:
+
+```json
+{ "tam_brl": 450000000, "estimated": true, "estimation_basis": "IBGE população × SEBRAE ticket médio" }
+```
+
+**Nunca** deixar string vazia (`""`), zero falso (`0` quando não é zero real), ou omitir o campo. Essas três formas são invisíveis para o renderer e geram o bug "coluna vazia".
+
+Valide o JSON contra o `schema.json` empacotado na skill e corrija campos ausentes ou `null` sem `unavailable_reason`.
+
+### Checklist adicional de auto-validação
+
+> - [ ] Todos os campos do schema estão presentes (preenchidos ou com `null` + `unavailable_reason`)?
+> - [ ] Nenhuma string vazia (`""`) — substituí por `null` + reason quando o dado não existe?
+> - [ ] Arrays vazios legítimos têm `{campo}_note` explicando por quê?
+> - [ ] Estimativas marcadas com `estimated: true` ou `[E]`?
+
+---
+
+## Tons de voz
+
+- `green` — oportunidade/vantagem/confirmado
+- `yellow` — atenção/potencial/médio
+- `red` — risco/ameaça/fraco
+- `blue` — contexto/informativo/neutro
+- `gray` — desativado/aspiracional/ausente
+
+Usar tons consistentemente: nunca pintar ameaça de verde ou vantagem de vermelho para "chamar atenção". O tom é semântico.
+
+---

--- a/.claude/skills/geral-posicionamento-estrategico/references/territorio-de-marca.md
+++ b/.claude/skills/geral-posicionamento-estrategico/references/territorio-de-marca.md
@@ -1,0 +1,121 @@
+# Territorio de Marca
+
+## O que e territorio de marca
+
+Territorio de marca e o espaco mental que uma empresa ocupa na cabeca do ICP. E a associacao automatica que o cliente faz quando pensa em uma categoria ou situacao.
+
+**Exemplo classico:**
+- Volvo → Seguranca
+- Apple → Design + Simplicidade
+- Red Bull → Energia + Aventura
+- Nubank → Simplicidade + Descomplicar
+
+**Para PMEs brasileiras, o territorio e mais simples mas igualmente poderoso:**
+- Clinica X → "A do implante em 1 dia"
+- Agencia Y → "Os caras que so atendem restaurante"
+- Contabilidade Z → "Os que entendem de e-commerce"
+
+## Por que importa para PMEs
+
+PMEs nao tem budget para construir marca com awareness massivo. O territorio de marca funciona como um ATALHO: em vez de tentar ser "conhecida por todos", a marca se torna "a primeira opcao para [situacao especifica]".
+
+**O territorio gera:**
+1. **Recall:** O ICP lembra de voce quando tem o problema
+2. **Referral:** O ICP sabe explicar para outros por que voce e diferente
+3. **Premium:** Quem ocupa um territorio pode cobrar mais (especialista > generalista)
+4. **Consistencia:** Toda comunicacao gira em torno do mesmo eixo
+
+## Como definir o territorio
+
+### Passo 1: Mapeie os territorios dos concorrentes
+
+Para cada concorrente, identifique:
+- Que associacao o ICP tem com essa marca?
+- Se alguem perguntasse "o que [concorrente] faz de diferente?", o que a resposta seria?
+- Quais palavras/conceitos eles repetem na comunicacao?
+
+**Exemplos de territorios comuns por segmento:**
+
+| Segmento | Territorios tipicos |
+|---|---|
+| Odontologia | Tecnologia / Humanizacao / Rapidez / Especializacao |
+| Estetica | Naturalidade / Resultado / Exclusividade / Bem-estar |
+| Contabilidade | Economia tributaria / Simplicidade / Digital / Especializacao setorial |
+| Academia | Performance / Comunidade / Resultado / Acessibilidade |
+| Marketing digital | Resultado / Criatividade / Dados / Especializacao vertical |
+| Alimentacao | Sabor / Saude / Conveniencia / Artesanal |
+| Imobiliario | Investimento / Sonho / Localizacao / Seguranca |
+| Educacao | Pratica / Certificacao / Comunidade / Metodologia |
+
+### Passo 2: Identifique territorios disponiveis
+
+Um territorio esta disponivel se:
+1. Nenhum concorrente direto o ocupa com forca
+2. E relevante para o ICP (resolve uma dor ou desejo real)
+3. E verdadeiro para o cliente (ele pode sustentar esse geral-posicionamento-estrategico)
+
+**ATENCAO:** Um territorio "generico" como "qualidade" ou "comprometimento" nao e territorio — e ruido. Todo mundo diz isso. Territorio precisa ser ESPECIFICO e DIFERENCIANTE.
+
+### Passo 3: Defina em 3 palavras
+
+O territorio de marca deve ser expressavel em 3 palavras que formam uma combinacao unica.
+
+**Formula:** [Atributo funcional] + [Atributo emocional] + [Atributo diferenciador]
+
+**Exemplos:**
+| Cliente | 3 Palavras | Significado |
+|---|---|---|
+| Clinica odonto | Rapidez + Confianca + Tecnologia | "Faz rapido, com seguranca, usando o que ha de melhor" |
+| Agencia mkt restaurantes | Resultado + Especializacao + Simplicidade | "Entende de restaurante, entrega numero, sem complicacao" |
+| Contabilidade e-commerce | Digital + Economia + Escala | "Tudo online, paga menos imposto, acompanha seu crescimento" |
+| Studio fitness | Intensidade + Comunidade + Resultado | "Treino puxado, galera que empurra, corpo que muda" |
+| Pet shop delivery | Conveniencia + Cuidado + Confianca | "Sem sair de casa, feito com atencao, voce confia" |
+
+### Passo 4: Valide a disponibilidade
+
+**Perguntas de validacao:**
+1. Algum concorrente FORTE ja usa essas 3 palavras (mesmo que com outras)? → Se sim, mude.
+2. O ICP se importa com essas 3 dimensoes? → Se nao, mude.
+3. O cliente PODE sustentar isso com evidencia? → Se nao, mude.
+4. E possivel construir comunicacao (copy, criativos, LP) em torno disso? → Se nao, mude.
+
+## Como "ownar" um territorio
+
+Definir o territorio e so o comeco. Para que o ICP associe sua marca a ele:
+
+### Na comunicacao:
+- Toda headline deve reforcar o territorio
+- Copy de anuncios repete os conceitos (sem ser repetitiva na forma)
+- Depoimentos de clientes devem refletir o territorio (selecione os que mencionam as palavras-chave)
+
+### No produto/servico:
+- A experiencia do cliente deve ser consistente com o territorio
+- Se o territorio e "rapidez", o tempo de resposta no WhatsApp precisa ser rapido
+- Se e "especializacao", nao aceite clientes fora do nicho
+
+### Na identidade visual:
+- Cores, tipografia e estilo visual devem traduzir o territorio
+- "Confianca + Tecnologia" pede visual limpo, moderno, tons de azul/preto
+- "Comunidade + Energia" pede visual vibrante, fotos de pessoas, tons quentes
+
+### No atendimento:
+- O tom de atendimento precisa refletir o territorio
+- "Proximo + Humano" → Responde com nome, emoji, audio
+- "Profissional + Tecnico" → Responde com dados, links, relatorios
+
+## Erros comuns
+
+### Erro 1: Territorio generico
+"Qualidade + Compromisso + Inovacao" → Nao diferencia nada. Todo mundo diz isso.
+
+### Erro 2: Territorio aspiracional
+Querer "ownar" algo que a empresa nao e de verdade. Se o territorio e "Tecnologia" mas o site e de 2018 e nao tem automacao nenhuma, ha incoerencia.
+
+### Erro 3: Territorio do concorrente
+Tentar disputar o mesmo territorio de um concorrente mais forte. Se o concorrente 1 ja e "o especialista em X", voce precisa de outro angulo.
+
+### Erro 4: Territorio irrelevante
+Escolher algo que o ICP nao valoriza. Se o ICP e sensivel a preco e voce escolhe "Exclusividade + Premium", ha desconexao.
+
+### Erro 5: Nao usar o territorio
+Definir e nunca aplicar. O territorio precisa aparecer em TUDO: site, anuncios, proposta comercial, assinatura de email, post no Instagram.

--- a/.claude/skills/geral-posicionamento-estrategico/schema.json
+++ b/.claude/skills/geral-posicionamento-estrategico/schema.json
@@ -1,0 +1,455 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Posicionamento",
+  "description": "Output estruturado do canvas de posicionamento estrategico: declaracoes, PUV, canvas 4P, territorio de marca e taglines.",
+  "type": "object",
+  "required": [
+    "summary",
+    "client_name",
+    "positioning_statements",
+    "chosen_statement",
+    "puv",
+    "canvas_4p",
+    "brand_territory",
+    "taglines",
+    "recommended_tagline",
+    "summary_headline",
+    "summary_highlights",
+    "summary_key_findings"
+  ],
+  "properties": {
+    "client_name": {
+      "type": "string",
+      "description": "Nome do cliente"
+    },
+    "summary": {
+      "type": "string",
+      "description": "Resumo de 1-2 frases do posicionamento estratégico. Inclui PUV definida e território de marca escolhido."
+    },
+    "summary_headline": {
+      "type": "string",
+      "maxLength": 200,
+      "description": "Manchete com o veredito do posicionamento em 1 frase (ex: '[Cliente] ocupa território [Especialista Premium do nicho] — janela de 12-18 meses antes da concorrência chegar')."
+    },
+    "summary_highlights": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 8,
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "label",
+          "value"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "posicao",
+              "competicao",
+              "janela",
+              "maturidade",
+              "oportunidade",
+              "risco"
+            ]
+          },
+          "label": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "subtext": {
+            "type": "string"
+          },
+          "tone": {
+            "type": "string",
+            "enum": [
+              "green",
+              "yellow",
+              "red",
+              "blue",
+              "gray"
+            ]
+          }
+        }
+      }
+    },
+    "summary_key_findings": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 6,
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "text"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "vantagem",
+              "contexto",
+              "ameaca",
+              "acao"
+            ]
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "positioning_map": {
+      "type": "object",
+      "description": "Mapa de posicionamento competitivo 2x2",
+      "properties": {
+        "axis_x": {
+          "type": "string",
+          "description": "Label do eixo horizontal"
+        },
+        "axis_y": {
+          "type": "string",
+          "description": "Label do eixo vertical"
+        },
+        "client_position": {
+          "type": "string",
+          "description": "Quadrante recomendado para o cliente"
+        },
+        "justification": {
+          "type": "string",
+          "description": "Justificativa para a posicao recomendada"
+        },
+        "competitor_positions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "quadrant": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "positioning_statements": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "statement",
+          "justification"
+        ],
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Nome/direcao da opcao (ex: O Especialista)"
+          },
+          "statement": {
+            "type": "string",
+            "description": "Declaracao de posicionamento no formato classico"
+          },
+          "justification": {
+            "type": "string",
+            "description": "Justificativa da opcao"
+          },
+          "bet": {
+            "type": "string",
+            "description": "O que esta opcao prioriza"
+          },
+          "risk": {
+            "type": "string",
+            "description": "Onde pode falhar"
+          }
+        }
+      },
+      "description": "3 opcoes de declaracao de posicionamento"
+    },
+    "chosen_statement": {
+      "type": "string",
+      "description": "Declaracao de posicionamento escolhida pelo operador (pode ser uma das 3 ou refinada)"
+    },
+    "puv": {
+      "type": "string",
+      "description": "Proposta Unica de Valor em 1 frase. Deve ser verdadeira, especifica, relevante, memoravel e diferente."
+    },
+    "canvas_4p": {
+      "type": "object",
+      "required": [
+        "product",
+        "price",
+        "place",
+        "promotion"
+      ],
+      "description": "Canvas de posicionamento estrategico nos 4Ps",
+      "properties": {
+        "product": {
+          "type": "object",
+          "required": [
+            "delivers",
+            "transformation",
+            "doesnt_deliver"
+          ],
+          "properties": {
+            "delivers": {
+              "type": "string",
+              "description": "O que entregamos de verdade (alem das features)"
+            },
+            "transformation": {
+              "type": "string",
+              "description": "Qual transformacao o cliente vive (antes e depois)"
+            },
+            "doesnt_deliver": {
+              "type": "string",
+              "description": "O que NAO entregamos (delimitacao honesta)"
+            }
+          }
+        },
+        "price": {
+          "type": "object",
+          "required": [
+            "positioning",
+            "justification"
+          ],
+          "properties": {
+            "positioning": {
+              "type": "string",
+              "enum": [
+                "premium",
+                "mid-market",
+                "value"
+              ],
+              "description": "Posicionamento de preco em relacao ao mercado"
+            },
+            "justification": {
+              "type": "string",
+              "description": "Justificativa do preco na comunicacao"
+            },
+            "anchoring": {
+              "type": "string",
+              "description": "Estrategia de ancoragem de valor (se aplicavel)"
+            }
+          }
+        },
+        "place": {
+          "type": "object",
+          "required": [
+            "main_channel",
+            "support_channel",
+            "avoid_channels"
+          ],
+          "properties": {
+            "main_channel": {
+              "type": "string",
+              "description": "Canal principal de aquisicao recomendado"
+            },
+            "main_channel_justification": {
+              "type": "string",
+              "description": "Por que este canal para este ICP"
+            },
+            "support_channel": {
+              "type": "string",
+              "description": "Canal de suporte/secundario"
+            },
+            "avoid_channels": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "channel",
+                  "reason"
+                ],
+                "properties": {
+                  "channel": {
+                    "type": "string"
+                  },
+                  "reason": {
+                    "type": "string"
+                  }
+                }
+              },
+              "description": "Canais a evitar e por que"
+            }
+          }
+        },
+        "promotion": {
+          "type": "object",
+          "required": [
+            "tone",
+            "top_funnel_message",
+            "bottom_funnel_message"
+          ],
+          "properties": {
+            "tone": {
+              "type": "string",
+              "description": "Tom e estilo de comunicacao"
+            },
+            "top_funnel_message": {
+              "type": "string",
+              "description": "Mensagem de entrada no funil (awareness)"
+            },
+            "bottom_funnel_message": {
+              "type": "string",
+              "description": "Mensagem de conversao (decision)"
+            }
+          }
+        }
+      }
+    },
+    "brand_territory": {
+      "type": "object",
+      "required": [
+        "three_words",
+        "description",
+        "competitor_territories"
+      ],
+      "properties": {
+        "three_words": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 3,
+          "maxItems": 3,
+          "description": "3 palavras que definem o territorio de marca"
+        },
+        "description": {
+          "type": "string",
+          "description": "O que o territorio significa na pratica"
+        },
+        "competitor_territories": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "competitor",
+              "territory"
+            ],
+            "properties": {
+              "competitor": {
+                "type": "string"
+              },
+              "territory": {
+                "type": "string"
+              }
+            }
+          },
+          "description": "Territorios ja ocupados pelos concorrentes"
+        },
+        "availability_justification": {
+          "type": "string",
+          "description": "Por que o territorio escolhido esta disponivel"
+        }
+      }
+    },
+    "taglines": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "tagline",
+          "justification"
+        ],
+        "properties": {
+          "tagline": {
+            "type": "string",
+            "description": "Texto da tagline"
+          },
+          "tone": {
+            "type": "string",
+            "description": "Tom da tagline"
+          },
+          "justification": {
+            "type": "string",
+            "description": "Por que funciona"
+          },
+          "best_use": {
+            "type": "string",
+            "description": "Onde usar (site, assinatura, anuncios)"
+          }
+        }
+      },
+      "description": "3 opcoes de tagline"
+    },
+    "recommended_tagline": {
+      "type": "string",
+      "description": "Tagline recomendada (escolhida pelo operador)"
+    },
+    "operator_direction": {
+      "type": "object",
+      "description": "Direcoes escolhidas pelo operador durante a co-criacao",
+      "properties": {
+        "strongest_differential": {
+          "type": "string",
+          "description": "Diferencial mais forte segundo o operador"
+        },
+        "desired_position": {
+          "type": "string",
+          "description": "Posicao desejada no mapa competitivo"
+        },
+        "positioning_restrictions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "O que o cliente NAO quer ser associado"
+        },
+        "desired_tone": {
+          "type": "string",
+          "description": "Tom de comunicacao desejado"
+        }
+      }
+    },
+    "completed_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Data/hora de conclusao"
+    },
+    "key_insight": {
+      "type": "object",
+      "description": "Ponto de alavancagem — território × janela de oportunidade.",
+      "required": [
+        "headline",
+        "context",
+        "numbered_reasons",
+        "discussion_anchor"
+      ],
+      "properties": {
+        "headline": {
+          "type": "string"
+        },
+        "context": {
+          "type": "string"
+        },
+        "numbered_reasons": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 5,
+          "items": {
+            "type": "string"
+          }
+        },
+        "discussion_anchor": {
+          "type": "string"
+        },
+        "feasibility": {
+          "type": "string"
+        }
+      }
+    },
+    "honesty_alert": {
+      "type": "string",
+      "description": "Alerta de honestidade: território aspiracional, diferencial não ainda construído, ou risco de posicionamento forçado."
+    }
+  }
+}


### PR DESCRIPTION
## O que é

Quatro skills que qualquer papel usa, na sequência em que costumam rodar.

| Skill | Faz |
|---|---|
| `geral-persona-icp` | ICP e Persona por JTBD — skill raiz, alimenta todo o resto |
| `geral-pesquisa-mercado` | TAM/SAM/SOM, concorrentes, tendências e diferenciais reais |
| `geral-analise-swot` | Scorecard digital dos concorrentes com evidência, SWOT acionável, matriz TOWS, cenários e priorização em Gantt de 90 dias |
| `geral-posicionamento-estrategico` | Canvas de posicionamento: PUV, 4Ps, território de marca e taglines |

`geral-posicionamento-estrategico` é a que fecha o bloco — o que vira criativo, copy e LP depois nasce dela.

## Checagens

- Duplo-write verificado
- `REGISTRY.md` fora do PR — a Action regenera no merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)