### PR TITLE
feat(skills): 6 skills de gestao de trafego

### DIFF
--- a/.agents/skills/gt-diagnostico-criativos/SKILL.md
+++ b/.agents/skills/gt-diagnostico-criativos/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: gt-diagnostico-criativos
+description: "Diagnostico de criativos com analise multimodal: matriz de avaliacao, padroes, analise de concorrentes e briefing de producao. Use quando o operador disser /gt-diagnostico-criativos ou 'analisar criativos' ou 'avaliar anuncios' ou 'como estao os criativos'."
+area: gt
+author: luizfreitasv4
+version: 1.0.0
+dependencies:
+  - geral-persona-icp
+tools: []
+week: 2
+estimated_time: "2h"
+output_file: "gt-diagnostico-criativos.json"
+multimodal: true
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta versao foi portada do sistema de Estruturacao Estrategica. As regras abaixo tem precedencia sobre caminhos e persistencia citados no fluxo original:
+
+- Trabalhe somente em `squads/{squad}/clientes/{cliente}/`, nunca em um diretorio `clientes/` solto na raiz.
+- Leia primeiro o `CLAUDE.md` ou `AGENTS.md` da KB, `mission-control/`, `calls/`, `docs/` e `campanhas/`.
+- Se `client.json` existir, use-o como fonte complementar. Se nao existir, derive o contexto da KB e do Mission Control; nao exija nem invente esse arquivo.
+- Salve entregaveis em `squads/{squad}/clientes/{cliente}/outputs/`, em JSON e Markdown quando o fluxo pedir ambos.
+- Registre decisoes e progresso no `mission-control/historico-checkins.md` ou no arquivo de historico equivalente encontrado na KB.
+- Resolva recursos empacotados a partir do proprio diretorio desta skill. Se uma integracao externa nao estiver configurada, declare o gap e continue apenas com os dados reais disponiveis.
+
+
+# Diagnostico de Criativos (POP 2.3)
+
+> **Posição no fluxo:** Semana 2 — comum a todos os modelos. O briefing de produção gerado aqui alimenta `designer-criativos-anuncios` (POP 3.11) na cauda da Semana 3.
+
+Voce e um diretor criativo especializado em performance marketing para PMEs brasileiras. Vai analisar os criativos atuais do cliente — anuncios, posts, stories, banners — usando analise VISUAL (multimodal) e de copy para identificar por que nao estao performando e gerar um briefing para a producao da Semana 3.
+
+**CAPACIDADE MULTIMODAL:** Voce pode analisar imagens diretamente. O operador vai compartilhar screenshots/prints dos criativos e voce vai avaliar cada um visualmente.
+
+## Dados necessários
+
+1. Leia `client.json` (seção `briefing`) — extraia: NOME_CLIENTE, SEGMENTO, TOM_DE_VOZ, identidade visual atual
+2. Leia `outputs/geral-persona-icp.json` — extraia: RESUMO_ICP, linguagem do ICP, canais preferenciais, dores principais
+3. Se houver `outputs/geral-posicionamento-estrategico.json`, extraia: PUV, tagline, tom de voz aprovado
+4. Se houver `outputs/gt-diagnostico-midia-paga.json`, **automaticamente** cruze `campaigns[]` e `creatives[]` (se existir) para trazer CTR, CPL, impressions, spend por criativo — nao pergunte ao operador sobre performance se esse output ja tem os dados.
+5. Se houver `outputs/gt-diagnostico-organico-instagram.json`, extraia `top_posts` e `client_winning_patterns` do cliente — padroes que ja funcionam no organico devem ser considerados no briefing de producao pago.
+
+### Cross-reference automatico com diagnostico de midia
+
+Ao popular cada item de `creative_matrix[].performance_data`, prefira PUXAR de `gt-diagnostico-midia-paga.json` em vez de perguntar. O operador deve precisar fornecer apenas:
+- Os screenshots/criativos em si (visual)
+- Quais concorrentes analisar na Meta Ads Library
+
+### Pedido ao operador (unico)
+
+Peca os criativos ao operador de UMA vez:
+
+> Preciso dos criativos visuais para analisar. Pode enviar:
+> - **Screenshots/prints dos anuncios** ativos (10-15 idealmente, vertical + quadrado + video)
+> - **Links da Meta Ads Library** do {NOME_CLIENTE} (se souber quais campanhas estao ativas)
+> - **Posts boosteados** se forem parte da midia paga
+>
+> Performance (CTR, CPL, impressions) eu ja vou puxar automaticamente do gt-diagnostico-midia-paga.
+>
+> Tambem: quais concorrentes analisar na Meta Ads Library? Minha sugestao e pegar os 2-3 de maior `digital_score` em geral-pesquisa-mercado.json — posso validar uma lista antes.
+
+Aguarde o operador enviar os criativos antes de iniciar a analise.
+
+---
+
+## Geração
+
+Gere o output COMPLETO de uma vez após receber os criativos do operador. Use os dados de `client.json` (briefing) e outputs de skills dependentes em `outputs/`.
+
+Consulte `references/boas-praticas-criativos.md` para os criterios de avaliacao.
+
+### Catálogo de criativos recebidos
+
+Total, ICP target, tom de voz, objetivo, dados de performance disponíveis.
+
+### Matriz de avaliação
+
+Para CADA criativo, analise visual e de copy com score 1-5 em 5 dimensões:
+
+| # | Tipo | Hook | Clareza | ICP Coer. | CTA | Visual | Total | Veredicto |
+|---|------|------|---------|-----------|-----|--------|-------|-----------|
+| 1 | {tipo} | {1-5} | {1-5} | {1-5} | {1-5} | {1-5} | {/25} | {M/O/E} |
+
+Legenda: M = Manter | O = Otimizar | E = Eliminar
+Score: 20-25 = Manter | 13-19 = Otimizar | <13 = Eliminar
+
+Para cada criativo, inclua comentário específico por dimensão (não genérico).
+
+### Padrões identificados
+
+Problemas que se repetem na maioria dos criativos (com referência a quais criativos). Elementos que estão funcionando e devem ser preservados/replicados.
+
+### Análise de criativos de concorrentes
+
+Se o operador fornecer prints ou links, analise. Senão, instrua como acessar Meta Ads Library (`https://www.facebook.com/ads/library/?active_status=active&ad_type=all&country=BR&q={nome_concorrente}`).
+
+Para cada concorrente:
+- `active_ads_count` — nº de anúncios ativos na Library
+- `ads_library_url` — link direto para a página do concorrente na Library
+- `creative_pattern` — padrão observado (formato, hook recorrente, ângulo)
+- `what_works`, `what_to_avoid`
+- `gap_para_cliente: true/false` — se o padrão NÃO aparece nos criativos do cliente e deveria ser testado
+- `replication_idea` (se gap=true) — ideia concreta para o cliente replicar
+
+### Padrões de concorrentes NÃO usados pelo cliente (`competitor_patterns_missing`)
+
+Esta é a parte mais acionável — alinha com `gt-diagnostico-organico-instagram.competitor_patterns_missing`. Liste 3-6 padrões recorrentes que aparecem nos concorrentes e **não** aparecem nos criativos do cliente. Para cada:
+
+- `pattern` — descrição (ex: "vídeo vertical com caso real + depoimento em texto sobreposto")
+- `seen_in_competitors` — lista dos concorrentes
+- `ads_count` — quantos anúncios dos concorrentes usam o padrão
+- `why_it_works` — por que provavelmente funciona para o ICP do cliente
+- `how_client_could_implement` — ação concreta (não "melhorar conteúdo")
+- `priority` — alta/media/baixa
+
+### Briefing de produção para Semana 3
+
+**HOOK:** Direção recomendada + 3 exemplos
+**FORMATO PRIORITÁRIO:** formato + justificativa para o ICP
+**ELEMENTOS VISUAIS:** a incluir + a evitar (com exemplos)
+**COPY — Diretrizes:** comprimento, tom, estrutura recomendada (hook → dor → solução → prova → CTA), palavras-chave do ICP
+**QUANTIDADE:** criativos novos + variações sugeridas
+
+### Estrutura visual (obrigatória)
+
+Siga o padrão canônico de `references/padrao-output.md`. Além dos campos específicos da skill, SEMPRE inclua:
+
+- **`summary_headline`** (max 200 char) — manchete com o veredito. Ex: "[Cliente] tem 10 criativos mas 7 falham no hook — eliminar 3, redesenhar 4 antes de escalar mídia."
+- **`summary_highlights`** (4-6 itens, `{category, label, value, subtext, tone}`) — para criativos sugestões:
+  - `maturidade`: score médio (ex: "13,2/25")
+  - `posicao`: distribuição M/O/E (ex: "3M · 4O · 3E")
+  - `competicao`: volume de anúncios ativos dos concorrentes (ex: "18 ads ativos vs 0 do cliente")
+  - `oportunidade`: padrão missing mais impactante
+  - `risco`: problema criativo mais recorrente (ex: "Copy genérica em 7/10")
+- **`summary_key_findings`** (3-5 itens, `{category, text}`) — `vantagem|contexto|ameaca|acao` — cubra pelo menos 3 dos 4.
+
+### Ponto de alavancagem (`key_insight`)
+
+Para criativos, o ponto de alavancagem é o **padrão criativo recorrente mais impactante** — um problema sistêmico a corrigir OU um sucesso específico a amplificar. Estruture:
+
+```json
+"key_insight": {
+  "headline": "Frase-manchete em 1 linha (pode virar quote)",
+  "context": "2-3 linhas sobre por que este padrão está dominando",
+  "numbered_reasons": ["(1) padrão afeta X de Y criativos...", "(2) impacto em performance...", "(3) comparativo com concorrentes..."],
+  "discussion_anchor": "Por que o stakeholder precisa validar a direção de produção"
+}
+```
+
+Se o diagnóstico revelou fragilidade estrutural (cliente não tem criativos pagos ativos, base insuficiente, concorrentes com volume incomparável), inclua `honesty_alert`.
+
+## Auto-validação
+
+Antes de mostrar ao operador, verifique:
+
+- [ ] Mencionou o cliente pelo nome?
+- [ ] Usou dados reais do client.json (não inventou)?
+- [ ] Performance por criativo foi puxada de `gt-diagnostico-midia-paga.json` (não pedida ao operador se já existe)?
+- [ ] Nenhum item genérico (ex: "quer crescer", "qualidade e compromisso")?
+- [ ] Schema da skill validou?
+- [ ] Todos os campos do schema preenchidos (ou com `null` + `unavailable_reason` no pai)?
+- [ ] Nenhuma string vazia (`""`) — substituí por `null` + reason quando o dado não existe?
+- [ ] Estimativas marcadas com `estimated: true` ou `[E]`?
+- [ ] Consistente com outputs anteriores (ICP, posicionamento, orgânico IG)?
+- [ ] Cada criativo tem comentário específico (não "poderia melhorar")?
+- [ ] Padrões são baseados em evidência (referência a criativos específicos)?
+- [ ] `competitor_patterns_missing` tem ao menos 3 itens acionáveis (não "melhorar conteúdo")?
+- [ ] Cada item de `competitor_analysis` tem `gap_para_cliente` marcado corretamente?
+- [ ] Briefing de produção é acionável (um criativo conseguiria executar)?
+- [ ] Tem `summary_headline` específico (não "análise concluída")?
+- [ ] `summary_highlights` tem 4-6 itens com categorias e tons válidos?
+- [ ] `summary_key_findings` cobre pelo menos 3 dos 4 tipos?
+- [ ] Identificou `key_insight` (padrão recorrente ou gap mais impactante) para stakeholder?
+- [ ] Se há fragilidade, incluiu `honesty_alert`?
+
+Se falhou → regenere silenciosamente. Não avise o operador.
+
+## Apresentação e decisões
+
+Apresente o output COMPLETO ao operador.
+
+Revise o output. O que está errado, exagerado ou faltando?
+
+- "A avaliacao faz sentido? Algum criativo que voce acha que merece nota diferente?"
+- "Algum contexto que eu perdi? (ex: 'o #3 foi feito as pressas', 'o #7 teve o melhor CPL')"
+- "O briefing de produção está acionável? Alguma restrição de marca?"
+
+## Finalização
+
+Operador aprova (com ou sem ajustes).
+1. Salve em `squads/{squad}/clientes/{cliente}/outputs/gt-diagnostico-criativos.json` (com campo `summary` no topo)
+2. Atualize `client.json`: progress.skills → completed, version++, append em history[]
+3. Salve também uma versão Markdown do entregável na mesma pasta de outputs.
+4. Sugira próxima skill do dependency_graph
+   - "Diagnóstico concluído. Criativos analisados: {numero}. Manter: {n} | Otimizar: {n} | Eliminar: {n}."
+   - "Este diagnostico alimenta: /designer-criativos-anuncios, /copy-anuncios"
+   - "Proximo passo recomendado: /gt-diagnostico-cro"
+
+
+## Campo obrigatório: summary
+
+Sempre inclua no JSON de saída:
+```json
+"summary": "Resumo de 1-2 frases do diagnóstico de criativos: principais padrões encontrados e ação prioritária. Seja específico — mencione o cliente, números reais e a conclusão principal."
+```
+
+Este campo alimenta o Resumo Executivo do portal de entregas. Deve ser objetivo, com dados reais, sem genéricos.

--- a/.agents/skills/gt-diagnostico-criativos/references/boas-praticas-criativos.md
+++ b/.agents/skills/gt-diagnostico-criativos/references/boas-praticas-criativos.md
@@ -1,0 +1,174 @@
+# Boas Praticas para Criativos de Performance Marketing
+
+Guia para avaliar e produzir criativos de anuncios pagos para PMEs brasileiras, focado em Meta Ads (Instagram/Facebook) e Google Ads.
+
+## Principio #1: O criativo e o anuncio
+
+Em performance marketing, o criativo nao e "a arte". E o anuncio inteiro. Se o criativo nao funciona, nada funciona — segmentacao perfeita + budget alto + LP otimizada = zero resultado se o criativo nao para o scroll.
+
+## Anatomia de um criativo de performance
+
+### Hook (primeiros 1-3 segundos)
+
+O hook e o elemento mais importante. 80% da decisao de engajar ou pular acontece aqui.
+
+**Tipos de hook que funcionam:**
+
+| Tipo | Descricao | Exemplo | Melhor para |
+|---|---|---|---|
+| Pergunta-dor | Pergunta que ativa a dor do ICP | "Cansou de gastar com anuncio sem retorno?" | Servicos B2B |
+| Dado chocante | Numero que surpreende | "87% das clinicas perdem R$ 3K/mes em ads mal feitos" | Autoridade |
+| Antes/depois | Transformacao visual | Foto split antes → depois | Estetica, fitness, reformas |
+| Depoimento | Cliente real falando | "Eu gastava R$ 5K e nao via resultado..." | Prova social |
+| Demonstracao | Mostra o produto/servico em acao | Video mostrando o dashboard | SaaS, produto fisico |
+| Contra-intuitivo | Afirmacao que desafia crenca | "Nao poste todo dia. Poste menos, melhor." | Educacao, consultoria |
+| Resultado | Numero concreto de resultado | "De 5 para 47 leads/mes em 60 dias" | Performance, resultado |
+
+**Hooks que NAO funcionam:**
+- Logo da empresa (ninguem conhece sua marca)
+- "Ola, tudo bem?" (nao para o scroll)
+- Texto generico ("Descubra como...")
+- Musica sem contexto
+- Fundo colorido sem informacao
+
+### Clareza da mensagem
+
+Em 5 segundos, o espectador precisa entender:
+1. Para QUEM e isto
+2. O que RESOLVE
+3. O que FAZER (CTA)
+
+**Teste de clareza:** Mostre o criativo para alguem de fora por 5 segundos. Pergunte: "O que estao vendendo?" Se a resposta for vaga, a mensagem nao esta clara.
+
+**Erros comuns de clareza:**
+- Tentar comunicar 3 beneficios ao mesmo tempo (escolha 1)
+- Copy longa demais na imagem (regra Meta: <20% de texto)
+- Jargao tecnico que o ICP nao entende
+- Metaforas abstratas em vez de beneficio direto
+
+### Coerencia com ICP
+
+O criativo precisa parecer feito PARA aquele ICP especifico. Sinais de coerencia:
+
+- **Visual:** Pessoas que se parecem com o ICP (idade, contexto, estilo)
+- **Linguagem:** Palavras que o ICP usa no dia a dia
+- **Cenario:** Contexto real do ICP (escritorio, clinica, casa, academia)
+- **Dor:** A dor mencionada e a dor REAL do ICP, nao a que a empresa acha que e
+- **Formato:** O formato e o que o ICP consome (stories para jovens, feed para 40+)
+
+**Red flags de incoerencia:**
+- Foto de stock americana para ICP brasileiro
+- Linguagem formal para ICP jovem informal
+- Foco em features tecnicas para ICP que quer resultado
+- Video longo para ICP que consome reels de 15s
+
+### CTA (Call to Action)
+
+**Regras de CTA em criativos:**
+1. Um CTA por criativo (nao dois, nao tres)
+2. O CTA deve ser visivel sem esforco
+3. Deve dizer O QUE acontece ao clicar ("Agendar consulta gratis", nao "Saiba mais")
+4. Deve gerar baixo atrito ("Simulacao em 30 segundos" > "Preencha o formulario")
+
+**Hierarquia de CTAs por conversao (do mais forte ao mais fraco):**
+1. "Agendar [coisa] gratis" / "Teste gratis"
+2. "Receber orcamento em X minutos"
+3. "Ver precos" / "Ver planos"
+4. "Baixar [material]"
+5. "Falar com especialista"
+6. "Saiba mais" (o mais fraco — evite)
+
+### Qualidade visual
+
+**Criterios de avaliacao:**
+
+| Score | Descricao |
+|---|---|
+| 1 | Amador: foto borrada, design feio, sem identidade, parece spam |
+| 2 | Basico: foto ok mas sem tratamento, design generico de Canva template |
+| 3 | Aceitavel: foto boa, design limpo, mas nada que destaque |
+| 4 | Bom: foto profissional ou muito boa, design alinhado com marca, destaca no feed |
+| 5 | Excelente: foto/video de alta qualidade, design proprio, para o scroll, transmite profissionalismo |
+
+**O que melhora visual rapidamente:**
+- Fotos reais (mesmo de celular) > stock
+- Contraste alto (se destaca no feed)
+- Rostos humanos (geram mais conexao)
+- Menos texto na imagem (mais limpo + melhor entrega Meta)
+- Cores consistentes com a marca
+
+---
+
+## Formatos por plataforma
+
+### Meta Ads (Instagram/Facebook)
+
+| Formato | Dimensao | Quando usar | Performance tipica |
+|---|---|---|---|
+| Feed quadrado | 1:1 (1080x1080) | Imagem unica, oferta clara | CTR medio |
+| Stories/Reels | 9:16 (1080x1920) | Video, imersivo, urgencia | CTR alto (ocupa tela toda) |
+| Carrossel | 1:1 (multiplos) | Educativo, lista, antes/depois | Engajamento alto |
+| Video feed | 1:1 ou 4:5 | Demonstracao, depoimento | Melhor custo por view |
+| Collection | Mix | E-commerce, catalogo | ROAS alto |
+
+**Regras gerais Meta:**
+- Video: primeiros 3 segundos sao tudo. Nao use intro/logo
+- Imagem: texto <20% da area (senao entrega cai)
+- Carrossel: primeiro slide e o hook, ultimo e o CTA
+- Stories: use elementos nativos (stickers, polls) para parecer organico
+- Legenda: curta (1-2 linhas) para performance, longa para conteudo educativo
+
+### Google Ads
+
+| Formato | Quando usar |
+|---|---|
+| Search (texto) | Busca ativa, intencao alta |
+| Display (banner) | Retargeting, awareness |
+| YouTube (video) | Pre-roll, educacao, demonstracao |
+| Performance Max | Mix automatico, escala |
+
+**Regras gerais Google:**
+- Display: banner clean, CTA grande, pouco texto
+- YouTube: hook em 5 segundos (antes do "pular anuncio")
+- Search: headline com palavra-chave + beneficio + CTA
+
+---
+
+## Checklist de avaliacao rapida
+
+Para cada criativo, passe por este checklist:
+
+```
+[ ] HOOK: Para o scroll em 1-3 segundos?
+[ ] CLAREZA: Em 5 segundos, sabe o que e e para quem?
+[ ] ICP: Parece feito para o ICP (visual, linguagem, contexto)?
+[ ] CTA: Tem 1 CTA claro e visivel?
+[ ] VISUAL: Qualidade profissional? Destaca no feed?
+[ ] MOBILE-FIRST: Funciona em tela pequena? Texto legivel?
+[ ] TEXTO: <20% da area (regra Meta)?
+[ ] CONFIANCA: Transmite profissionalismo?
+[ ] DIFERENCIACAO: E diferente dos concorrentes?
+[ ] ACAO: Quem ve sabe o que fazer?
+```
+
+## Erros fatais (eliminam o criativo)
+
+1. **Logo como hook** — Ninguem para o scroll por um logo que nao conhece
+2. **Texto ilegivel em mobile** — Se nao da pra ler no celular, nao existe
+3. **Sem CTA** — Bonito mas nao converte
+4. **Foto de stock obvia** — Perde confianca instantaneamente
+5. **Informacao errada** — Preco, telefone, oferta expirada
+6. **Muito texto na imagem** — Meta penaliza a entrega
+7. **Audio ruim em video** — Melhor sem audio do que com audio estourado
+8. **Duracao longa sem hook** — Video >30s que so fica bom a partir dos 15s
+
+## Tendencias 2025-2026 em criativos de performance
+
+1. **UGC (User Generated Content)** — Conteudo que parece organico performa melhor que producao polida
+2. **Video vertical curto** — 15-30 segundos, formato reels/stories
+3. **Hooks de texto na tela** — Texto grande + imagem de fundo, estilo meme
+4. **Antes/depois** — Continua sendo o formato mais poderoso para transformacao
+5. **Depoimento em video** — Cliente real falando direto pra camera
+6. **Static creative revival** — Imagens estaticas com copy forte voltando a competir com video
+7. **AI-generated variations** — Multiplas variacoes de hook/copy para teste rapido
+8. **Dark post testing** — Testar criativos sem publicar no perfil

--- a/.agents/skills/gt-diagnostico-criativos/references/padrao-output.md
+++ b/.agents/skills/gt-diagnostico-criativos/references/padrao-output.md
@@ -1,0 +1,202 @@
+# Padrão de Output das Skills — V4 Estruturação IA
+
+Este documento define a **estrutura canônica** que todos os outputs de skill devem seguir para renderizar no portal com hierarquia visual consistente. O objetivo é que o operador e o stakeholder final abram qualquer entregável e encontrem o mesmo ritmo: manchete → KPIs → achados categorizados → ponto de alavancagem destacado → detalhes expansíveis.
+
+---
+
+## Princípios
+
+1. **Manchete antes de texto.** Toda skill abre com uma frase única e específica que resume a conclusão. Não é parágrafo, é headline.
+2. **Números em destaque, não escondidos no corpo do texto.** KPIs que importam viram cards. Texto corrido é para contexto, não para fato quantitativo.
+3. **Achados categorizados por intenção.** Cada insight é classificado como `vantagem | contexto | ameaca | acao` — o leitor identifica o tom antes de ler.
+4. **Ponto de alavancagem visualmente isolado.** Toda skill tem UM ponto onde a conversa com o stakeholder precisa acontecer. Esse ponto ganha hero visual (border, gradient, quote destacada).
+5. **Detalhe denso → colapsável.** Listas longas (concorrentes, itens de checklist, fontes) ficam em `<details>` para não afogar a leitura.
+
+---
+
+## Campos obrigatórios no JSON
+
+Todo output de skill DEVE ter estes campos no topo (antes dos campos específicos da skill):
+
+```json
+{
+  "client_name": "Nome do Cliente",
+  "summary": "Resumo em 1-2 frases. Específico, com dados reais. Alimenta o resumo executivo do portal.",
+
+  "summary_headline": "Manchete em 1 linha (max 120 caracteres). A frase que o stakeholder lê primeiro.",
+
+  "summary_highlights": [
+    {
+      "category": "posicao | competicao | janela | maturidade | oportunidade | risco",
+      "label": "Rótulo curto (max 30 char)",
+      "value": "Valor em destaque (número, %, status)",
+      "subtext": "Contexto em 1 linha (max 60 char)",
+      "tone": "green | yellow | red | blue | gray"
+    }
+  ],
+
+  "summary_key_findings": [
+    {
+      "category": "vantagem | contexto | ameaca | acao",
+      "text": "Achado em 1-2 linhas. Específico, acionável."
+    }
+  ]
+}
+```
+
+### Regras dos campos de summary
+
+**`summary_headline`**: É a ÚNICA frase que o stakeholder precisa ler se só tiver 5 segundos. Deve conter o veredito da skill. Exemplos bons:
+- ✓ "[Cliente] é o ÚNICO player premium da microrregião com [diferencial declarado] — janela competitiva de 12-18 meses."
+- ✗ "Análise de mercado concluída com sucesso."
+
+**`summary_highlights`** (4-6 itens): KPIs visuais. Categorias sugeridas:
+- `posicao` — onde o cliente está hoje vs potencial
+- `competicao` — quem disputa o mesmo espaço
+- `janela` — tempo/urgência
+- `maturidade` — estágio atual em algum eixo
+- `oportunidade` — tamanho do ganho possível
+- `risco` — tamanho da ameaça
+
+Agrupar de 2 em 2 por categoria no renderer (dá layout balanceado 3x2 ou 2x2).
+
+**`summary_key_findings`** (3-5 itens): Achados que embasam a manchete. Categorias:
+- `vantagem` (✓ verde) — o que o cliente tem a favor
+- `contexto` (i azul) — o que é fato do mercado, neutro
+- `ameaca` (! vermelho) — o que pode dar errado
+- `acao` (▸ laranja) — o que precisa ser feito
+
+---
+
+## Ponto de Alavancagem (hero block)
+
+Toda skill deve identificar **UM bloco que merece destaque visual especial** — o ponto onde a conversa estratégica precisa acontecer. O nome do campo varia por skill, mas a estrutura é consistente:
+
+```json
+{
+  "key_leverage_point": {
+    "headline": "Frase-manchete do ponto (pode ir como quote)",
+    "context": "Contexto em 2-3 linhas explicando o cenário",
+    "numbered_reasons": [
+      "Razão 1 (parse-friendly, pode começar com texto direto)",
+      "Razão 2",
+      "Razão 3"
+    ],
+    "discussion_anchor": "Frase curta sobre POR QUE este é o ponto de conversa com o stakeholder"
+  }
+}
+```
+
+Exemplos por skill:
+- `pesquisa-mercado` → `unexploited_opportunity` (whitespace estratégico)
+- `persona-icp` → persona principal + dor mais ignorada
+- `swot` → combinação força × oportunidade mais assimétrica
+- `posicionamento` → PUV vs alternativas descartadas
+- `diagnostico-midia` → canal mais subotimizado + upside estimado
+- `diagnostico-maturidade` → pilar mais fraco com maior impacto
+
+O renderer aplica:
+- Border verde 2px + gradient sutil
+- Selo "Whitespace Estratégico · Discussão com Stakeholder" no topo
+- Pill de viabilidade/urgência à direita
+- Quote/headline em card branco isolado
+- Razões numeradas em 3 círculos
+- Footer "💬 Momento de validar com a stakeholder"
+
+---
+
+## Alerta de honestidade
+
+Se a pesquisa/análise revelou fragilidade do cliente (não há diferencial real, ICP mal definido, mercado saturado, etc.), inclua:
+
+```json
+{
+  "honesty_alert": "Texto explicando a fragilidade encontrada e o que precisa ser feito antes de seguir."
+}
+```
+
+Esse campo renderiza em box amarelo/vermelho após os achados. **Nunca omita** se a realidade justifica. O valor do sistema depende de não vender aspiracional como real.
+
+---
+
+## Instrução para a IA da skill
+
+Em cada `SKILL.md`, incluir esta seção na geração:
+
+> ### Estrutura visual (obrigatória)
+>
+> Além dos campos específicos desta skill, gere SEMPRE:
+>
+> - `summary_headline` — manchete em 1 linha com o veredito
+> - `summary_highlights` — 4-6 KPIs categorizados (`posicao|competicao|janela|maturidade|oportunidade|risco`) com `{label, value, subtext, tone}`
+> - `summary_key_findings` — 3-5 achados categorizados (`vantagem|contexto|ameaca|acao`)
+> - `honesty_alert` se houver fragilidade
+>
+> Identifique o **ponto de alavancagem** desta skill (o bloco que merece hero visual) e estruture-o com headline + contexto + razões numeradas + discussion anchor.
+>
+> Consulte `references/padrao-output.md` para especificação completa.
+
+E na auto-validação:
+
+> - [ ] Tem `summary_headline` específico (não "análise concluída")?
+> - [ ] `summary_highlights` tem 4-6 itens com categorias válidas?
+> - [ ] `summary_key_findings` cobre pelo menos 3 dos 4 tipos (vantagem/contexto/ameaça/ação)?
+> - [ ] Identificou o ponto de alavancagem para discussão com stakeholder?
+> - [ ] Se há fragilidade, incluiu `honesty_alert`?
+
+---
+
+## Completude (regra crítica)
+
+**Todo campo definido no schema da skill é obrigatório no output.** Não omitir campos — o renderer assume que os campos do schema existem e quebra/fica vazio silenciosamente quando faltam.
+
+Se um dado **não pode ser obtido** (GA4 não instalado, conector não conectado, cliente não sabe, etc.), preencher com `null` E adicionar `unavailable_reason` no objeto pai:
+
+```json
+{
+  "current_conversion_rate": null,
+  "current_bounce_rate": null,
+  "avg_time_on_page": null,
+  "unavailable_reason": "GA4 não instalado no site — métricas de analytics não coletadas nesta auditoria"
+}
+```
+
+Para arrays vazios legitimamente (ex: nenhum competidor identificado), preencher com `[]` e adicionar uma nota no campo irmão `{campo}_note`:
+
+```json
+{
+  "competitors": [],
+  "competitors_note": "Nenhum concorrente direto identificado na microrregião após busca em Google Maps + Instagram."
+}
+```
+
+Para valores **estimados** (sem fonte pública), adicionar flag `[E]` no texto OU campo `estimated: true` no objeto:
+
+```json
+{ "tam_brl": 450000000, "estimated": true, "estimation_basis": "IBGE população × SEBRAE ticket médio" }
+```
+
+**Nunca** deixar string vazia (`""`), zero falso (`0` quando não é zero real), ou omitir o campo. Essas três formas são invisíveis para o renderer e geram o bug "coluna vazia".
+
+Valide o JSON contra o `schema.json` empacotado na skill e corrija campos ausentes ou `null` sem `unavailable_reason`.
+
+### Checklist adicional de auto-validação
+
+> - [ ] Todos os campos do schema estão presentes (preenchidos ou com `null` + `unavailable_reason`)?
+> - [ ] Nenhuma string vazia (`""`) — substituí por `null` + reason quando o dado não existe?
+> - [ ] Arrays vazios legítimos têm `{campo}_note` explicando por quê?
+> - [ ] Estimativas marcadas com `estimated: true` ou `[E]`?
+
+---
+
+## Tons de voz
+
+- `green` — oportunidade/vantagem/confirmado
+- `yellow` — atenção/potencial/médio
+- `red` — risco/ameaça/fraco
+- `blue` — contexto/informativo/neutro
+- `gray` — desativado/aspiracional/ausente
+
+Usar tons consistentemente: nunca pintar ameaça de verde ou vantagem de vermelho para "chamar atenção". O tom é semântico.
+
+---

--- a/.agents/skills/gt-diagnostico-criativos/schema.json
+++ b/.agents/skills/gt-diagnostico-criativos/schema.json
@@ -1,0 +1,608 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DiagnosticoCriativos",
+  "description": "Output estruturado do diagnostico de criativos: matriz de avaliacao, padroes, analise de concorrentes e briefing de producao.",
+  "type": "object",
+  "required": [
+    "summary",
+    "summary_headline",
+    "summary_highlights",
+    "summary_key_findings",
+    "client_name",
+    "segment",
+    "creative_matrix",
+    "patterns_identified",
+    "what_works",
+    "production_briefing"
+  ],
+  "properties": {
+    "client_name": {
+      "type": "string",
+      "description": "Nome do cliente"
+    },
+    "segment": {
+      "type": "string",
+      "description": "Segmento de atuacao"
+    },
+    "icp_summary": {
+      "type": "string",
+      "description": "Resumo do ICP para referencia"
+    },
+    "total_creatives_analyzed": {
+      "type": "integer",
+      "description": "Total de criativos analisados"
+    },
+    "average_score": {
+      "type": "number",
+      "description": "Score medio dos criativos (de 25)"
+    },
+    "creative_matrix": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "number",
+          "type",
+          "hook_score",
+          "clarity_score",
+          "icp_coherence_score",
+          "cta_score",
+          "visual_score",
+          "total_score",
+          "verdict"
+        ],
+        "properties": {
+          "number": {
+            "type": "integer",
+            "description": "Numero sequencial do criativo"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "feed",
+              "story",
+              "carrossel",
+              "video_curto",
+              "video_longo",
+              "banner",
+              "reels",
+              "outro"
+            ],
+            "description": "Tipo/formato do criativo"
+          },
+          "description": {
+            "type": "string",
+            "description": "Descricao curta do criativo"
+          },
+          "hook_score": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 5,
+            "description": "Score do hook — capacidade de parar o scroll (1-5)"
+          },
+          "hook_comment": {
+            "type": "string",
+            "description": "Comentario especifico sobre o hook"
+          },
+          "clarity_score": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 5,
+            "description": "Score de clareza da mensagem (1-5)"
+          },
+          "clarity_comment": {
+            "type": "string",
+            "description": "Comentario especifico sobre a clareza"
+          },
+          "icp_coherence_score": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 5,
+            "description": "Score de coerencia com o ICP (1-5)"
+          },
+          "icp_coherence_comment": {
+            "type": "string",
+            "description": "Comentario especifico sobre coerencia com ICP"
+          },
+          "cta_score": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 5,
+            "description": "Score do CTA — clareza e visibilidade (1-5)"
+          },
+          "cta_comment": {
+            "type": "string",
+            "description": "Comentario especifico sobre o CTA"
+          },
+          "visual_score": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 5,
+            "description": "Score de qualidade visual (1-5)"
+          },
+          "visual_comment": {
+            "type": "string",
+            "description": "Comentario especifico sobre a qualidade visual"
+          },
+          "total_score": {
+            "type": "integer",
+            "minimum": 5,
+            "maximum": 25,
+            "description": "Score total (soma dos 5 criterios)"
+          },
+          "verdict": {
+            "type": "string",
+            "enum": [
+              "manter",
+              "otimizar",
+              "eliminar"
+            ],
+            "description": "Veredicto: manter (20-25), otimizar (13-19), eliminar (<13)"
+          },
+          "verdict_reason": {
+            "type": "string",
+            "description": "Motivo do veredicto em 1 frase"
+          },
+          "performance_data": {
+            "type": "object",
+            "description": "Dados de performance se disponiveis",
+            "properties": {
+              "ctr": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "cpl": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "impressions": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "clicks": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              }
+            }
+          },
+          "preview": {
+            "type": "object",
+            "description": "Midia do criativo para embed no portal. Populado automaticamente pelo meta_ads_fetch.sh ou manualmente pelo operador.",
+            "properties": {
+              "image_url": {
+                "type": ["string", "null"],
+                "description": "Path relativo (ex: 'assets/creatives/meta/{slug}/{ad_id}/image.jpg') ou URL absoluta"
+              },
+              "thumbnail_url": {
+                "type": ["string", "null"],
+                "description": "Miniatura otimizada para grid"
+              },
+              "video_url": {
+                "type": ["string", "null"],
+                "description": "URL do CDN Meta (se for video) — renderer embeda direto via <video>"
+              },
+              "ads_library_id": {
+                "type": ["string", "null"],
+                "description": "ID do anuncio na Meta Ads Library"
+              },
+              "ads_library_url": {
+                "type": ["string", "null"],
+                "description": "Link direto para a pagina do anuncio no Meta Ads Library"
+              },
+              "start_date": {
+                "type": ["string", "null"],
+                "description": "Data de inicio da veiculacao (ISO)"
+              },
+              "platforms": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Plataformas onde o anuncio foi veiculado (facebook, instagram, messenger, audience_network)"
+              },
+              "cta_type": {
+                "type": ["string", "null"],
+                "description": "Tipo de CTA (LEARN_MORE, MESSAGE_PAGE, SHOP_NOW, etc.)"
+              },
+              "source": {
+                "type": "string",
+                "enum": ["meta_ads_library", "uploaded", "unavailable"],
+                "description": "De onde veio a midia"
+              },
+              "fetched_at": {
+                "type": ["string", "null"],
+                "format": "date-time"
+              }
+            }
+          }
+        }
+      },
+      "description": "Matriz de avaliacao de cada criativo"
+    },
+    "patterns_identified": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "pattern",
+          "affected_creatives",
+          "example"
+        ],
+        "properties": {
+          "pattern": {
+            "type": "string",
+            "description": "Descricao do padrao/problema"
+          },
+          "affected_creatives": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            },
+            "description": "Numeros dos criativos afetados"
+          },
+          "example": {
+            "type": "string",
+            "description": "Exemplo concreto do padrao"
+          }
+        }
+      },
+      "description": "Padroes de problema que se repetem"
+    },
+    "what_works": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "element",
+          "seen_in",
+          "reason"
+        ],
+        "properties": {
+          "element": {
+            "type": "string",
+            "description": "Elemento que funciona"
+          },
+          "seen_in": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            },
+            "description": "Numeros dos criativos onde aparece"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Por que funciona"
+          }
+        }
+      },
+      "description": "Elementos que devem ser preservados ou replicados"
+    },
+    "competitor_analysis": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "competitor",
+          "creative_pattern"
+        ],
+        "properties": {
+          "competitor": {
+            "type": "string",
+            "description": "Nome do concorrente"
+          },
+          "active_ads_count": {
+            "type": "integer",
+            "description": "Numero de anuncios ativos (Meta Ads Library)"
+          },
+          "ads_library_url": {
+            "type": "string",
+            "description": "Link direto para a Meta Ads Library do concorrente"
+          },
+          "creative_pattern": {
+            "type": "string",
+            "description": "Padrao criativo observado"
+          },
+          "what_works": {
+            "type": "string",
+            "description": "O que pode inspirar"
+          },
+          "what_to_avoid": {
+            "type": "string",
+            "description": "O que nao copiar"
+          },
+          "gap_para_cliente": {
+            "type": "boolean",
+            "description": "True se o concorrente usa um padrao que o cliente NAO usa e deveria testar."
+          },
+          "replication_idea": {
+            "type": ["string", "null"],
+            "description": "Se gap_para_cliente=true, ideia concreta para o cliente replicar (formato, hook, angulo). null quando gap=false."
+          },
+          "sample_ads": {
+            "type": "array",
+            "description": "Ate 6 anuncios de exemplo do concorrente para embed no portal. Populado pelo meta_ads_fetch.sh.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "ads_library_id": {"type": ["string", "null"]},
+                "ads_library_url": {"type": ["string", "null"]},
+                "image_url": {"type": ["string", "null"]},
+                "thumbnail_url": {"type": ["string", "null"]},
+                "video_url": {"type": ["string", "null"]},
+                "copy_excerpt": {"type": ["string", "null"], "description": "Primeiros 150 caracteres do copy"},
+                "start_date": {"type": ["string", "null"]},
+                "platforms": {"type": "array", "items": {"type": "string"}},
+                "cta_type": {"type": ["string", "null"]}
+              }
+            }
+          }
+        }
+      },
+      "description": "Analise de criativos de concorrentes na Meta Ads Library"
+    },
+    "competitor_patterns_missing": {
+      "type": "array",
+      "description": "Padroes recorrentes dos concorrentes que o cliente NAO usa — lista priorizada de gaps acionaveis. Mesma logica do gt-diagnostico-organico-instagram para coerencia cross-outputs.",
+      "items": {
+        "type": "object",
+        "required": [
+          "pattern",
+          "seen_in_competitors",
+          "why_it_works",
+          "how_client_could_implement"
+        ],
+        "properties": {
+          "pattern": {
+            "type": "string",
+            "description": "Descricao do padrao (ex: 'video vertical com case real + depoimento em texto sobreposto')"
+          },
+          "seen_in_competitors": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Nomes dos concorrentes que usam o padrao"
+          },
+          "ads_count": {
+            "type": "integer",
+            "description": "Quantos anuncios dos concorrentes usam esse padrao"
+          },
+          "why_it_works": {
+            "type": "string",
+            "description": "Por que provavelmente funciona para o ICP do cliente"
+          },
+          "how_client_could_implement": {
+            "type": "string",
+            "description": "Como o cliente poderia implementar (acionavel, nao generico)"
+          },
+          "priority": {
+            "type": "string",
+            "enum": ["alta", "media", "baixa"]
+          }
+        }
+      }
+    },
+    "production_briefing": {
+      "type": "object",
+      "required": [
+        "hook_direction",
+        "priority_format",
+        "visual_elements",
+        "avoid_elements",
+        "copy_guidelines"
+      ],
+      "properties": {
+        "hook_direction": {
+          "type": "string",
+          "description": "Direcao recomendada para hooks"
+        },
+        "hook_examples": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Exemplos de hooks recomendados"
+        },
+        "priority_format": {
+          "type": "string",
+          "enum": [
+            "stories_vertical",
+            "feed_quadrado",
+            "carrossel",
+            "video_curto",
+            "video_longo",
+            "reels"
+          ],
+          "description": "Formato prioritario para novos criativos"
+        },
+        "format_justification": {
+          "type": "string",
+          "description": "Por que este formato para este ICP"
+        },
+        "visual_elements": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Elementos visuais a incluir nos novos criativos"
+        },
+        "avoid_elements": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Elementos a evitar nos novos criativos"
+        },
+        "copy_guidelines": {
+          "type": "object",
+          "properties": {
+            "length": {
+              "type": "string",
+              "enum": [
+                "short_15_words",
+                "medium_30_words",
+                "long_50_plus"
+              ],
+              "description": "Comprimento recomendado"
+            },
+            "tone": {
+              "type": "string",
+              "description": "Tom recomendado"
+            },
+            "structure": {
+              "type": "string",
+              "description": "Estrutura recomendada (ex: hook-dor-solucao-prova-CTA)"
+            },
+            "icp_keywords": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Palavras-chave que o ICP usa"
+            }
+          },
+          "description": "Diretrizes de copy para novos criativos"
+        },
+        "recommended_quantity": {
+          "type": "integer",
+          "description": "Quantidade recomendada de novos criativos"
+        },
+        "variation_plan": {
+          "type": "string",
+          "description": "Plano de variacoes (ex: 3 hooks x 2 formatos x 2 CTAs)"
+        }
+      },
+      "description": "Briefing para producao de novos criativos na Semana 3"
+    },
+    "completed_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Data/hora de conclusao"
+    },
+    "counts": {
+      "type": "object",
+      "description": "Resumo da avaliacao",
+      "properties": {
+        "keep_count": {
+          "type": "integer",
+          "description": "Quantidade de criativos para manter"
+        },
+        "optimize_count": {
+          "type": "integer",
+          "description": "Quantidade de criativos para otimizar"
+        },
+        "eliminate_count": {
+          "type": "integer",
+          "description": "Quantidade de criativos para eliminar"
+        }
+      }
+    },
+    "summary": {
+      "type": "string",
+      "description": "Resumo de 1-2 frases do diagnóstico de criativos. Inclui principais padrões encontrados e ação prioritária."
+    },
+    "summary_headline": {
+      "type": "string",
+      "maxLength": 200,
+      "description": "Manchete em 1 linha com o veredito da analise. Ex: '[Cliente]: 7 de 10 criativos falham no hook — oportunidade de redesenho antes de escalar midia'. Ver PADRAO-OUTPUT.md."
+    },
+    "summary_highlights": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 8,
+      "description": "KPIs visuais categorizados para o resumo executivo. Ex: {category:'maturidade', label:'Score medio', value:'13,2/25', tone:'yellow'}.",
+      "items": {
+        "type": "object",
+        "required": ["category", "label", "value"],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": ["posicao", "competicao", "janela", "maturidade", "oportunidade", "risco"]
+          },
+          "label": {
+            "type": "string",
+            "maxLength": 40
+          },
+          "value": {
+            "type": "string"
+          },
+          "subtext": {
+            "type": "string",
+            "maxLength": 80
+          },
+          "tone": {
+            "type": "string",
+            "enum": ["green", "yellow", "red", "blue", "gray"]
+          }
+        }
+      }
+    },
+    "summary_key_findings": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 6,
+      "description": "Achados categorizados. Cobrir pelo menos 3 dos 4 tipos (vantagem/contexto/ameaca/acao).",
+      "items": {
+        "type": "object",
+        "required": ["category", "text"],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": ["vantagem", "contexto", "ameaca", "acao"]
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "key_insight": {
+      "type": "object",
+      "description": "Ponto de alavancagem desta skill — para diagnostico de criativos, e o padrao criativo mais impactante (problema recorrente ou sucesso a amplificar) OU o gap mais assimetrico vs concorrente. Ver PADRAO-OUTPUT.md.",
+      "properties": {
+        "headline": {
+          "type": "string",
+          "description": "Frase-manchete do ponto (pode virar quote destacada)"
+        },
+        "context": {
+          "type": "string",
+          "description": "Contexto em 2-3 linhas explicando o cenario"
+        },
+        "numbered_reasons": {
+          "type": "array",
+          "items": {"type": "string"},
+          "description": "Razoes numeradas (renderer vira 3 cards)"
+        },
+        "discussion_anchor": {
+          "type": "string",
+          "description": "Por que este e o ponto para stakeholder decidir/validar"
+        }
+      }
+    },
+    "honesty_alert": {
+      "type": "string",
+      "description": "Alerta se o diagnostico revelou fragilidade critica (ex: cliente nao tem criativos pagos ativos, base insuficiente para analise, concorrentes dominam com volume que o cliente nao consegue acompanhar). Nunca omitir se justificado."
+    },
+    "source_outputs": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Outputs consultados para cross-referencia (ex: 'gt-diagnostico-midia-paga.json' para performance por criativo, 'geral-persona-icp.json' para ICP)."
+    },
+    "period": {
+      "type": "object",
+      "description": "Periodo coberto pelos criativos analisados (se aplicavel).",
+      "properties": {
+        "start": {"type": "string", "format": "date"},
+        "end": {"type": "string", "format": "date"}
+      }
+    }
+  }
+}

--- a/.agents/skills/gt-diagnostico-cro/SKILL.md
+++ b/.agents/skills/gt-diagnostico-cro/SKILL.md
@@ -1,0 +1,283 @@
+---
+name: gt-diagnostico-cro
+description: "Diagnostico de CRO (Conversion Rate Optimization): analise tecnica, auditoria de copy, hipoteses de teste e wireframe de melhorias para a landing page. Use quando o operador disser /gt-diagnostico-cro ou 'analisar conversao' ou 'diagnostico da landing page' ou 'por que a LP nao converte' ou 'analise de CRO'."
+area: gt
+author: luizfreitasv4
+version: 1.0.0
+dependencies:
+  - geral-persona-icp
+  - geral-posicionamento-estrategico
+tools: []
+week: 3
+modelo_venda: inside-sales
+estimated_time: "2.5h"
+output_file: "gt-diagnostico-cro.json"
+multimodal: true
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta versao foi portada do sistema de Estruturacao Estrategica. As regras abaixo tem precedencia sobre caminhos e persistencia citados no fluxo original:
+
+- Trabalhe somente em `squads/{squad}/clientes/{cliente}/`, nunca em um diretorio `clientes/` solto na raiz.
+- Leia primeiro o `CLAUDE.md` ou `AGENTS.md` da KB, `mission-control/`, `calls/`, `docs/` e `campanhas/`.
+- Se `client.json` existir, use-o como fonte complementar. Se nao existir, derive o contexto da KB e do Mission Control; nao exija nem invente esse arquivo.
+- Salve entregaveis em `squads/{squad}/clientes/{cliente}/outputs/`, em JSON e Markdown quando o fluxo pedir ambos.
+- Registre decisoes e progresso no `mission-control/historico-checkins.md` ou no arquivo de historico equivalente encontrado na KB.
+- Resolva recursos empacotados a partir do proprio diretorio desta skill. Se uma integracao externa nao estiver configurada, declare o gap e continue apenas com os dados reais disponiveis.
+
+
+# Diagnóstico de CRO — Site/LP (POP 3.1 — Inside Sales)
+
+> **Posição no fluxo:** etapa de CRO para operações de Inside Sales. Cobre Core Web Vitals, SEO on-page, copy vs. PUV, sinais de confiança, tracking e LGPD, com hipóteses A/B priorizadas por ICE. Para e-commerce, adapte a análise para PDP, carrinho e checkout.
+
+Voce e um especialista em CRO com experiencia em PMEs brasileiras. Vai analisar o site ou landing page do cliente sob a otica de conversao: onde os visitantes saem, o que impede o clique no CTA, e quais mudancas tem maior impacto. O output final inclui um wireframe de melhorias que alimenta diretamente a skill de landing page da Semana 3.
+
+**CAPACIDADE MULTIMODAL:** Voce pode analisar screenshots da pagina visualmente. O operador vai compartilhar prints da pagina (mobile e desktop) e voce faz a auditoria visual.
+
+## Dados necessários
+
+1. Leia `client.json` (seção `briefing`) — extraia: NOME_CLIENTE, SEGMENTO, URL_SITE, OBJETIVO_PAGINA
+2. Leia `outputs/geral-persona-icp.json` — extraia: RESUMO_ICP, dores, linguagem, canal preferencial
+3. Leia `outputs/geral-posicionamento-estrategico.json` — extraia: PUV, mensagem topo/fundo de funil, tom de comunicacao
+4. Se houver `outputs/gt-diagnostico-midia-paga.json`, carregue taxa de conversao e bounce rate
+
+## Fluxo obrigatório (ordem fixa, sem pular etapas)
+
+Todo diagnóstico de CRO é composto por 3 etapas automatizadas + análise visual. **Nenhuma etapa é opcional** — o schema exige os blocos preenchidos.
+
+1. **Audit técnico PSI** (`page_audit.sh`) → preenche `technical_audit`, `onpage_seo`, `security_headers`
+2. **Audit profundo Playwright** (`page_audit_deep.sh`) → preenche `tracking_stack`, `events_fired`, `quality_flags`, `cro_elements_deep`, `compliance_lgpd`
+3. **Análise visual** (screenshots + copy audit + hipóteses + wireframe) → preenche `copy_audit`, `trust_analysis`, `test_hypotheses`, `wireframe_improvements`
+
+Cache: se `client.json.page_audit.fetched_at` e `client.json.page_audit_deep.fetched_at` forem ambos < 7 dias, reaproveitar. Senão rodar novamente.
+
+### Passo 1 — Audit técnico automatizado (PSI)
+
+Ele alimenta os blocos `technical_audit`, `onpage_seo` e `security_headers` do output com dados reais de PageSpeed Insights + parser HTML + headers de segurança.
+
+Verifique `client.json.page_audit.fetched_at`:
+- Se ausente OU mais de 7 dias → rode novo audit
+- Se dentro de 7 dias → reaproveite os dados do `client.json.page_audit`
+
+**Comando:**
+```bash
+bash .claude/skills/gt-diagnostico-cro/scripts/page_audit.sh squads/{squad}/clientes/{cliente} {URL}
+```
+
+O script:
+1. Lê `.credentials/google.json` (campo `pagespeed_api_key`)
+2. Roda em paralelo: PSI mobile + PSI desktop + on-page mobile UA + on-page desktop UA + headers
+3. Salva raw em `squads/{squad}/clientes/{cliente}/cache/page_audit-{timestamp}.json`
+4. Condensa summary em `client.json.page_audit`
+
+**Setup inicial (uma vez por ambiente):**
+- Criar projeto no Google Cloud Console → habilitar PageSpeed Insights API → gerar API Key
+- Copiar `.credentials/google.json.example` → `.credentials/google.json` → colar a key
+- 1 key serve para todos os clientes (cota 25k queries/dia, 2 queries por audit)
+- `pip3 install --user -r .claude/skills/gt-diagnostico-cro/scripts/requirements.txt` (requests, beautifulsoup4, lxml)
+
+### Passo 2 — Audit PROFUNDO (Playwright)
+
+**SEMPRE depois do Passo 1.** Rode o audit profundo com Playwright. Ele renderiza a página como um usuário real (Chromium headless), intercepta requests de rede, inspeciona `dataLayer`, simula interações e gera 5 blocos adicionais:
+
+1. `tracking_stack` — GTM/GA4/Meta Pixel/Clarity/Hotjar/Chat detectados (com IDs reais AW-XXX, GTM-XXX, G-XXX)
+2. `events_fired` — eventos GA4 (`page_view`, `scroll`, `generate_lead`) e Meta Pixel (`PageView`, `Lead`, `Purchase`) realmente disparados
+3. `quality_flags` — red flags: UA legacy, Pixel duplicado, GTM sem analytics, sem Consent Mode v2
+4. `cro_elements_deep` — CTAs visíveis, forms (campos, required, consent checkbox), WhatsApp, prova social, urgência, confiança
+5. `compliance_lgpd` — 2-pass (pre-consent) para detectar scripts que vazam dados antes do usuário aceitar cookies
+
+Verifique `client.json.page_audit_deep.fetched_at`:
+- Se ausente OU mais de 7 dias → rode novo deep audit
+- Se dentro de 7 dias → reaproveite
+
+**Comando:**
+```bash
+bash .claude/skills/gt-diagnostico-cro/scripts/page_audit_deep.sh squads/{squad}/clientes/{cliente} {URL}
+```
+
+O script:
+1. Lança Chromium headless (user-agent pt-BR, timezone SP)
+2. Faz 3 passes: desktop completo, mobile completo, compliance pre-consent
+3. Captura todo o network (GA4 `/collect`, Meta `/tr`, GTM, doubleclick, etc.)
+4. Dump do `window.dataLayer` e globals relevantes
+5. Screenshot full-page de desktop + mobile
+6. Salva raw em `squads/{squad}/clientes/{cliente}/cache/page_audit_deep-{timestamp}.json`
+7. Condensa summary em `client.json.page_audit_deep`
+
+**Setup inicial (uma vez por ambiente):**
+- `pip3 install --user -r .claude/skills/gt-diagnostico-cro/scripts/requirements-deep.txt` (playwright, pyyaml)
+- `python3 -m playwright install chromium` (~200MB, uma vez por máquina)
+- Tempo total: ~60-90s por URL
+
+### Pedido ao operador
+
+Peca ao operador de uma vez:
+
+> Para o diagnostico de CRO, preciso de:
+> 1. **URL do site/landing page** do cliente (vou rodar o audit tecnico automatico)
+> 2. **Screenshots da pagina** — mobile E desktop, scroll completo (para analise visual multimodal)
+> 3. **Taxa de conversao atual** (se tiver)
+> 4. **Bounce rate** (se tiver)
+> 5. **Tempo medio na pagina** (se tiver)
+
+Aguarde o operador fornecer os dados. Com a URL, rode `page_audit.sh` E `page_audit_deep.sh` em sequência ANTES de pedir os screenshots — os dados técnicos + tagueamento + compliance já orientam onde olhar na análise visual.
+
+### Passo 3 — Análise visual + geração do output
+
+Só depois dos Passos 1 e 2 concluídos (client.json populado com `page_audit` + `page_audit_deep`), proceda para a análise visual dos screenshots e geração do output JSON completo conforme schema.
+
+---
+
+## Geração
+
+Gere o output COMPLETO de uma vez usando os dados de `client.json` (briefing, connectors) e outputs de skills dependentes em `outputs/`.
+
+Consulte `references/checklist-cro.md` para os criterios de avaliacao.
+
+### Diagnóstico técnico (3 camadas automáticas)
+
+Com o audit já rodado (passo anterior), leia `client.json.page_audit` e preencha 3 blocos estruturados:
+
+**1. `technical_audit`** — Core Web Vitals + Lighthouse (copie exatamente do page_audit.pagespeed):
+- `mobile_scores` e `desktop_scores` (performance, accessibility, best_practices, seo)
+- `mobile_cwv_lab` e `desktop_cwv_lab` (LCP, FCP, TBT, CLS, Speed Index, TTI, TTFB)
+- `mobile_cwv_field` e `desktop_cwv_field` (CrUX, se disponível)
+- `mobile_top_opportunities` e `desktop_top_opportunities` (Top 10 por savings_ms)
+
+**2. `onpage_seo`** — parser HTML (copie de page_audit.onpage):
+- `mobile` e `desktop` com: title, meta_description, canonical, lang, viewport, favicon, og, twitter, schema_types, h1/h2/h3_count, images_total/images_without_alt, links_internal/external/nofollow, html_size_kb, response_time_ms
+- `divergences` — diferenças entre mobile e desktop (rendering inconsistente, cloaking acidental)
+
+**3. `security_headers`** — headers HTTP (copie de page_audit.security):
+- https, hsts, csp, x_frame_options, x_content_type_options, referrer_policy, permissions_policy
+- `score` 0-10 e `issues` (lista de headers ausentes ou fracos)
+
+### Diagnóstico profundo (5 blocos do page_audit_deep)
+
+Com o audit profundo rodado, leia `client.json.page_audit_deep` e preencha 5 novos blocos:
+
+**5. `tracking_stack`** — ferramentas detectadas (copie de page_audit_deep.tracking_stack):
+- `tools_detected`, `ids_found`, `categories_summary`, `total_tools`
+- `setup_diagnosis` — narrativa obrigatória. Exemplos de interpretação:
+  - "GTM presente (GTM-XXXXX) mas sem GA4 — cliente opera cego. Investimento em mídia não tem atribuição."
+  - "Google Ads tag presente (AW-XXXXX) mas sem Meta Pixel — perde possibilidade de remarketing no Facebook/Instagram."
+  - "Hotjar detectado — cliente já investe em UX research. Aproveitar para validar hipóteses de teste com gravações."
+  - "Plataforma: WordPress + Elementor + LiteSpeed — site estático. Qualquer mudança pode ser feita sem dev."
+
+**6. `events_fired`** — eventos reais (copie de page_audit_deep.events_fired):
+- `ga4_event_count`, `meta_event_count`, `ga4_event_names`, `meta_event_names`
+- `events_diagnosis` — cheque completude esperada: `page_view` (GA4) e `PageView` (Pixel) são obrigatórios. Formulários devem gerar `generate_lead` (GA4) e `Lead` (Pixel). Se faltarem, listar em `expected_events_missing`.
+
+**7. `quality_flags`** — copie de page_audit_deep.quality_flags (array de red flags com severity).
+
+**8. `cro_elements_deep`** — copie de page_audit_deep.cro_elements (mobile + desktop). Adicione narrativas:
+- `cta_diagnosis` — interprete `cta_count`, `cta_above_fold`, consistência de texto entre CTAs
+- `form_diagnosis` — regra: formulário com > 5 campos cai conversão >50% (baseline Hubspot). Sempre checar `has_consent_checkbox` para LGPD.
+- `social_proof_diagnosis` — baseado em `social_proof.*` (has_testimonials, has_ratings, has_numbers, has_certifications, has_logos_clients)
+- `trust_diagnosis` — baseado em `trust.*` (has_cnpj, has_phone, has_email, has_privacy_link, has_terms_link)
+
+**9. `compliance_lgpd`** — copie de page_audit_deep.compliance_lgpd. Sempre adicione `recommendation`:
+- Se `non_compliant` → "URGENTE: Instalar CMP (Cookiebot R$0/mês até 500k pageviews ou OneTrust). Configurar gtag consent default denied + Consent Mode v2. Risco de multa ANPD até R$50M."
+- Se `partial` (CMP mas trackers pré-consent) → "Ajustar CMP para bloquear tags até opt-in. Verificar GTM: triggers devem checar consent state."
+- Se `compliant` → "Manter. Checar anualmente se novas tags adicionadas respeitam consent."
+
+**4. `technical_diagnosis`** — narrativa sobre os números:
+- `pagespeed_mobile` e `pagespeed_desktop` (score de performance)
+- `lcp`, `cls`, `inp` (lab mobile, em segundos para LCP/INP)
+- `critical_issues` — **interprete** os top opportunities e o on-page: se `render-blocking-resources` > 1000ms, cite; se `images_without_alt` > 50% do total, cite; se falta HSTS/CSP e o site transaciona dados, cite
+- `estimated_conversion_loss` — correlacione com benchmarks: cada 100ms de LCP > 2500ms custa ~7% de conversão (estudo Google/Deloitte). Se LCP mobile > 4s, diga "queda estimada de 20-30%"
+- `tested: true`
+
+### Auditoria de copy (above the fold + seção a seção)
+
+**Above the fold (hero):**
+- Proposta de valor clara em < 5 segundos?
+- Headline responde "o que + para quem + qual benefício"?
+- Headline atual vs headline sugerida (baseada na PUV)
+- CTA visível sem rolar? CTA atual vs sugerido
+- O que um visitante do ICP pensa ao chegar
+
+**Estrutura da página (seção a seção):**
+
+| Secao | Existe? | Avaliacao | Problema principal |
+|-------|---------|-----------|-------------------|
+| Hero com PUV | {S/N} | {1-5} | {descricao} |
+| Problema/dor | {S/N} | {1-5} | {descricao} |
+| Solucao | {S/N} | {1-5} | {descricao} |
+| Como funciona | {S/N} | {1-5} | {descricao} |
+| Prova social | {S/N} | {1-5} | {descricao} |
+| FAQ | {S/N} | {1-5} | {descricao} |
+| CTA final | {S/N} | {1-5} | {descricao} |
+
+Seções faltando (críticas) + seções desnecessárias.
+
+**Análise de confiança:**
+Checklist de sinais de confiança (CNPJ, endereço, fotos reais, depoimentos, selos, SSL, etc.). Score de confiança X/10. Maior gap.
+
+### Hipóteses de teste priorizadas por impacto
+
+| # | Hipotese | Elemento | Impacto | Dificuldade | Prioridade |
+|---|----------|----------|---------|-------------|------------|
+
+Para cada hipótese P1, detalhe: versão atual, versão proposta, métrica de sucesso, impacto estimado.
+
+### Wireframe de melhorias
+
+Estrutura recomendada para a nova LP (seção por seção): Hero, Problema/Dor, Solução, Como Funciona, Prova Social, FAQ, CTA Final. Para cada: conteúdo, copy sugerida, formato. Elementos transversais: barra de confiança, WhatsApp flutuante, exit intent popup.
+
+## Auto-validação
+
+Antes de mostrar ao operador, verifique:
+
+- [ ] Mencionou o cliente pelo nome?
+- [ ] Usou dados reais do client.json (não inventou)?
+- [ ] Nenhum item genérico (ex: "quer crescer", "qualidade e compromisso")?
+- [ ] Schema da skill validou?
+- [ ] Todos os campos do schema preenchidos (ou com `null` + `unavailable_reason` no pai)?
+- [ ] Nenhuma string vazia (`""`) — substituí por `null` + reason quando o dado não existe?
+- [ ] Estimativas marcadas com `estimated: true` ou `[E]`?
+- [ ] Consistente com outputs anteriores (ICP, posicionamento)?
+- [ ] Headlines sugeridas são baseadas na PUV aprovada?
+- [ ] Hipóteses têm impacto estimado (não apenas "melhorar")?
+- [ ] Wireframe é suficiente para construir a LP na Semana 3?
+- [ ] `technical_audit`, `onpage_seo`, `security_headers` preenchidos com dados reais do page_audit (não zerados)?
+- [ ] `critical_issues` em `technical_diagnosis` cita opportunities específicas (não "otimizar velocidade" genérico)?
+- [ ] Hipóteses de teste incluem pelo menos 1 ligada a achado técnico (LCP alto → otimizar hero, imagens sem alt → adicionar alt, etc.)?
+- [ ] `tracking_stack`, `events_fired`, `quality_flags`, `cro_elements_deep`, `compliance_lgpd` preenchidos do page_audit_deep?
+- [ ] `setup_diagnosis` é específico (cita os IDs reais GTM-/AW-/G-, não genérico)?
+- [ ] Hipóteses P1 incluem pelo menos 1 ligada a tagueamento/compliance se houver red flags críticos (ex: "Instalar GA4", "Adicionar CMP")?
+
+Se falhou → regenere silenciosamente. Não avise o operador.
+
+## Apresentação e decisões
+
+Apresente o output COMPLETO ao operador.
+
+Revise o output. O que está errado, exagerado ou faltando?
+
+- "A auditoria reflete o que voce ve na pagina? Algum elemento que eu nao consegui ver nos screenshots?"
+- "As hipoteses de teste fazem sentido na prioridade? Alguma que voce ja testou?"
+- "O wireframe seria suficiente para construir a LP na Semana 3?"
+- "Alguma restricao tecnica? (ex: 'usamos WordPress e nao Vercel', 'formulario precisa integrar com Kommo')"
+
+## Finalização
+
+Operador aprova (com ou sem ajustes).
+1. Salve em `squads/{squad}/clientes/{cliente}/outputs/gt-diagnostico-cro.json` (com campo `summary` no topo)
+2. Atualize `client.json`: progress.skills → completed, version++, append em history[]
+3. Salve também uma versão Markdown do entregável na mesma pasta de outputs.
+4. Sugira próxima skill do dependency_graph
+   - "Diagnóstico CRO concluído. PageSpeed mobile: {score}/100. Score de confiança: {X}/10. Hipóteses: {numero}."
+   - "Este diagnostico (CRO Site/LP, POP 3.1) alimenta a Landing Page (POP 3.8) e o Pipeline consultivo."
+   - "Cabeça do Inside Sales: próximo passo é o Cliente Oculto (/account-cliente-oculto, POP 3.2)."
+
+
+## Campo obrigatório: summary
+
+Sempre inclua no JSON de saída:
+```json
+"summary": "Resumo de 1-2 frases do diagnóstico de CRO: principal gap de conversão identificado e ação prioritária. Seja específico — mencione o cliente, números reais e a conclusão principal."
+```
+
+Este campo alimenta o Resumo Executivo do portal de entregas. Deve ser objetivo, com dados reais, sem genéricos.

--- a/.agents/skills/gt-diagnostico-cro/references/checklist-cro.md
+++ b/.agents/skills/gt-diagnostico-cro/references/checklist-cro.md
@@ -1,0 +1,281 @@
+# Checklist Completo de CRO para Landing Pages de PMEs Brasileiras
+
+## Como usar este checklist
+
+Use este checklist como referencia ao auditar landing pages. Nem todos os itens se aplicam a todos os casos — priorize os que tem maior impacto para o segmento e ICP do cliente.
+
+A auditoria segue 5 dimensoes:
+1. Performance tecnica
+2. Above the fold (hero)
+3. Estrutura e conteudo
+4. Confianca e credibilidade
+5. Mobile e UX
+
+---
+
+## 1. Performance Tecnica
+
+### Core Web Vitals
+
+| Metrica | Bom | Medio | Ruim | Impacto |
+|---------|-----|-------|------|---------|
+| LCP (Largest Contentful Paint) | <2.5s | 2.5-4s | >4s | Cada segundo extra = -7% conversao |
+| CLS (Cumulative Layout Shift) | <0.1 | 0.1-0.25 | >0.25 | Layout pulando = visitante sai |
+| INP (Interaction to Next Paint) | <200ms | 200-500ms | >500ms | Clique sem resposta = frustracao |
+
+### PageSpeed Score
+
+| Score | Classificacao | Acao |
+|-------|--------------|------|
+| 90-100 | Excelente | Manter e monitorar |
+| 50-89 | Medio | Otimizar (imagens, JS, CSS) |
+| 0-49 | Ruim | Refazer ou otimizacao urgente |
+
+### Checklist tecnico
+
+```
+[ ] PageSpeed mobile >= 50 (idealmente >= 70)
+[ ] PageSpeed desktop >= 70 (idealmente >= 90)
+[ ] LCP < 2.5 segundos
+[ ] CLS < 0.1
+[ ] SSL (HTTPS) ativo
+[ ] Sem erros 404 ou redirects desnecessarios
+[ ] Imagens otimizadas (WebP, lazy loading)
+[ ] Sem JavaScript blocante na renderizacao
+[ ] Fonts carregando rapido (preload ou system fonts)
+[ ] Meta tags basicas (title, description, og:image)
+[ ] Mobile responsive (nao apenas "funciona" — "fica bom")
+[ ] Formulario funcional (testado — envia de verdade)
+[ ] Tracking instalado (GA4, Pixel Meta, Tag Manager)
+```
+
+### Causas comuns de lentidao em LPs de PMEs
+
+1. **Imagens nao otimizadas** — JPGs de 3MB direto da camera. Solucao: WebP, max 200KB, lazy load
+2. **Slider/carrossel pesado** — Plugins de carrossel com JS pesado. Solucao: imagem estatica ou CSS puro
+3. **Fonts externas** — Google Fonts sem preload. Solucao: preload ou hospedar localmente
+4. **WordPress com 30 plugins** — Cada plugin adiciona JS/CSS. Solucao: remover nao essenciais
+5. **Video autoplay** — Video pesado carregando no hero. Solucao: thumbnail + play on click
+6. **Hosting ruim** — Shared hosting lento. Solucao: Vercel, Netlify, ou VPS
+7. **Chat widgets** — Tawk.to, Intercom carregando JS pesado. Solucao: lazy load ou remover
+8. **Animations pesadas** — CSS/JS animations que causam repaints. Solucao: transform/opacity only
+
+---
+
+## 2. Above the Fold (Hero)
+
+O hero e responsavel por 80% da decisao de ficar ou sair. A regra e: em 5 segundos, o visitante precisa saber O QUE e, PARA QUEM e, e O QUE FAZER.
+
+### Checklist do hero
+
+```
+[ ] Headline clara (responde "o que + para quem + beneficio")
+[ ] Sub-headline que complementa (nao repete)
+[ ] CTA visivel sem rolar (botao, nao link)
+[ ] CTA com texto acionavel ("Agendar consulta gratis" > "Saiba mais")
+[ ] Elemento visual relevante (foto real, nao stock generico)
+[ ] Prova social rapida (estrelas, numero de clientes, selo)
+[ ] Sem excesso de informacao (max 3 elementos de texto)
+[ ] Contraste suficiente entre texto e fundo
+[ ] Mobile: tudo acima da dobra em tela de 375px
+```
+
+### Erros fatais no hero
+
+| Erro | Por que e fatal | Solucao |
+|------|----------------|---------|
+| Headline generica ("Bem-vindo") | Nao diz o que faz nem para quem | PUV como headline |
+| Slider/carrossel no hero | Ninguem le alem do primeiro slide | Imagem unica com mensagem clara |
+| Video autoplay com som | Irrita e faz o visitante fechar | Video mudo ou thumbnail |
+| CTA abaixo da dobra | Quem nao rola nunca ve | CTA no hero, sempre |
+| Formulario longo no hero | Gera atrito antes de gerar interesse | Formulario curto (nome + telefone) ou CTA para WhatsApp |
+
+### Headlines que convertem (formulas)
+
+1. **Resultado direto:** "[Resultado] para [ICP] em [prazo]"
+   Ex: "30+ leads qualificados por mes para clinicas de estetica"
+
+2. **Dor → Solucao:** "Cansou de [dor]? [Solucao] sem [objecao]"
+   Ex: "Cansou de gastar com anuncio sem retorno? Performance real sem contrato de fidelidade"
+
+3. **PUV direta:** "[O que faz] de um jeito [como ninguem faz]"
+   Ex: "Implante dental em sessao unica com sedacao — sem medo, sem espera"
+
+4. **Especializacao:** "[Servico] para [nicho especifico]"
+   Ex: "Contabilidade exclusiva para e-commerces que faturam R$ 50K-2M/mes"
+
+---
+
+## 3. Estrutura e Conteudo
+
+### Ordem recomendada de secoes
+
+A ordem importa. Cada secao leva o visitante um passo mais perto da conversao.
+
+| # | Secao | Objetivo | Se nao tiver |
+|---|-------|----------|--------------|
+| 1 | Hero (PUV + CTA) | Captar atencao, dizer o que e | Visitante sai em 5s |
+| 2 | Problema/dor | Gerar identificacao ("voce tambem?") | Visitante nao se conecta |
+| 3 | Solucao | Mostrar como resolve | Visitante nao entende o valor |
+| 4 | Como funciona | Reduzir incerteza (passo a passo) | Visitante tem medo de contratar |
+| 5 | Prova social | Gerar confianca (outros ja fizeram) | Visitante nao acredita |
+| 6 | Beneficios / diferenciais | Reforcar por que voce e diferente | Visitante compara com concorrente |
+| 7 | FAQ | Eliminar objecoes | Visitante sai com dúvida |
+| 8 | CTA final | Fechar a conversao | Visitante nao converte |
+
+### Checklist por secao
+
+**Secao Problema/Dor:**
+```
+[ ] Descreve a dor com palavras do ICP (nao jargao)
+[ ] Gera identificacao ("voce ja passou por isso?")
+[ ] Nao e exagerada (nao parece manipulacao)
+[ ] Conecta com a solucao que vem a seguir
+```
+
+**Secao Solucao:**
+```
+[ ] Mostra o "o que" e o "como" (nao so features)
+[ ] Foca em transformacao (antes → depois)
+[ ] Usa imagem/video do produto/servico real
+[ ] Conecta com a PUV
+```
+
+**Secao Como Funciona:**
+```
+[ ] 3-5 passos simples (nao 10)
+[ ] Cada passo cabe em 1 frase
+[ ] Mostra que e facil comecar
+[ ] Ultimo passo = resultado positivo
+```
+
+**Secao Prova Social:**
+```
+[ ] Depoimentos com nome + foto + cargo/empresa (nao anonimo)
+[ ] Depoimentos especificos (mencionam resultado, nao "otimo servico")
+[ ] Numero de clientes/projetos/avaliacoes
+[ ] Se possivel, video de depoimento
+[ ] Se tiver logos de clientes, sao reconheciveis pelo ICP
+```
+
+**FAQ:**
+```
+[ ] 3-5 perguntas (nao 20)
+[ ] Inclui objecoes de venda (preco, prazo, garantia)
+[ ] Respostas curtas e diretas
+[ ] Usa linguagem do ICP
+```
+
+---
+
+## 4. Confianca e Credibilidade
+
+Para PMEs, confianca e o maior obstaculo de conversao. O visitante nao conhece a marca e precisa de sinais de que e seguro.
+
+### Hierarquia de sinais de confianca (do mais forte ao mais fraco)
+
+1. **Depoimentos com video** — Mais dificil de falsificar
+2. **Avaliacoes Google (link para Google Meu Negocio)** — Verificavel
+3. **Depoimentos com nome + foto + empresa** — Crivel
+4. **Logos de clientes conhecidos** — Transferencia de confianca
+5. **Selos e certificacoes** (ISO, CRO, OAB, etc.) — Autoridade
+6. **Numero de clientes / projetos** — Prova de volume
+7. **CNPJ e endereco** — Empresa real
+8. **Politica de privacidade** — Profissionalismo
+9. **Garantia explicita** — Reduz risco percebido
+10. **SSL (cadeado)** — Basico, mas ausencia e fatal
+
+### Score de confianca
+
+| Score | Descricao | Conversao tipica |
+|-------|-----------|-----------------|
+| 1-3 | Sem sinais de confianca. Parece golpe. | <1% |
+| 4-5 | Sinais basicos (CNPJ, SSL). Pouco profissional. | 1-3% |
+| 6-7 | Profissional. Depoimentos e prova social. | 3-8% |
+| 8-9 | Forte confianca. Video, reviews, garantia. | 8-15% |
+| 10 | Confianca maxima. Marca conhecida, prova abundante. | 15%+ |
+
+---
+
+## 5. Mobile e UX
+
+### Estatisticas que importam
+- 75-85% do trafego de Meta Ads em PMEs brasileiras e mobile
+- Se a LP nao funciona em mobile, voce perde 3/4 do investimento
+- Visitante mobile tem menos paciencia (thumb scroll rapido)
+
+### Checklist mobile
+
+```
+[ ] Layout 100% responsivo (nao apenas "encolhido")
+[ ] Texto legivel sem zoom (min 16px)
+[ ] Botoes grandes o suficiente para polegar (min 44x44px)
+[ ] CTA fixo na tela (sticky button) ou facilmente acessivel
+[ ] Formulario simples (max 3 campos em mobile)
+[ ] Nao tem popup que bloqueia a tela inteira em mobile
+[ ] Imagens redimensionadas para mobile (nao carrega desktop-size)
+[ ] WhatsApp link funciona (abre o app diretamente)
+[ ] Telefone clicavel (tel: link)
+[ ] Scroll suave (sem travamentos)
+```
+
+### Erros de UX mais comuns em LPs de PMEs
+
+1. **Formulario longo** — Nome, email, telefone, cidade, como conheceu, mensagem. Solucao: nome + telefone (ou so WhatsApp)
+2. **CTA generico** — "Enviar" em vez de "Agendar minha consulta gratis"
+3. **Multiplos CTAs conflitantes** — "Agendar" + "Ver precos" + "Baixar e-book" + "Seguir no Instagram". Solucao: 1 CTA principal
+4. **Informacao demais** — Pagina com 10 secoes e 5000 palavras. Solucao: cortar pela metade
+5. **Pop-up agressivo** — Abre antes do visitante ler qualquer coisa. Solucao: exit intent ou scroll-trigger
+6. **Sem WhatsApp** — PME brasileira sem WhatsApp e como loja sem porta. Obrigatorio.
+7. **Fundo escuro com texto claro** — Cansa a leitura em scroll longo. Solucao: fundo claro, texto escuro
+8. **Auto-play de audio/video** — Irrita e faz fechar. Solucao: mudo ou click-to-play
+
+---
+
+## Priorizacao de melhorias (ICE Framework)
+
+Para priorizar hipoteses de teste, use o framework ICE:
+
+| Criterio | Descricao | Score 1-5 |
+|----------|-----------|-----------|
+| **Impact** | Quanto impacto na conversao se funcionar? | 1 (minimo) - 5 (enorme) |
+| **Confidence** | Quao confiante estou que vai funcionar? | 1 (chute) - 5 (certeza) |
+| **Ease** | Quao facil e implementar? | 1 (dificil) - 5 (trivial) |
+
+**Score ICE = (I + C + E) / 3**
+
+**Priorizacao:**
+- ICE >= 4.0 → P1 (fazer primeiro)
+- ICE 3.0-3.9 → P2 (fazer depois)
+- ICE < 3.0 → P3 (backlog)
+
+### Melhorias de alto impacto (quase sempre P1)
+
+1. **Reescrever headline do hero** (I:5, C:4, E:5 = 4.7)
+2. **Mudar texto do CTA** (I:4, C:4, E:5 = 4.3)
+3. **Adicionar prova social no hero** (I:4, C:4, E:4 = 4.0)
+4. **Reduzir campos do formulario** (I:4, C:5, E:5 = 4.7)
+5. **Adicionar WhatsApp flutuante** (I:4, C:4, E:5 = 4.3)
+
+### Melhorias de medio impacto (geralmente P2)
+
+1. **Otimizar PageSpeed** (I:3, C:4, E:3 = 3.3)
+2. **Adicionar secao FAQ** (I:3, C:3, E:4 = 3.3)
+3. **Melhorar depoimentos** (I:3, C:3, E:3 = 3.0)
+4. **Adicionar secao "como funciona"** (I:3, C:3, E:3 = 3.0)
+5. **Exit intent popup** (I:3, C:3, E:4 = 3.3)
+
+---
+
+## Benchmarks de conversao por tipo de LP
+
+| Tipo de LP | Conversao mediana | Boa | Excelente |
+|---|---|---|---|
+| Lead gen B2B (formulario) | 3-5% | 5-10% | 10-15% |
+| Lead gen B2C (formulario) | 5-10% | 10-20% | 20%+ |
+| Lead gen (WhatsApp CTA) | 8-15% | 15-25% | 25%+ |
+| E-commerce (produto) | 1-2% | 2-4% | 4%+ |
+| Agendamento online | 5-10% | 10-20% | 20%+ |
+| Download de material | 15-25% | 25-40% | 40%+ |
+
+**NOTA:** CTA de WhatsApp geralmente converte 2-3x mais que formulario para PMEs brasileiras. O atrito e muito menor (1 clique vs preencher campos).

--- a/.agents/skills/gt-diagnostico-cro/schema.json
+++ b/.agents/skills/gt-diagnostico-cro/schema.json
@@ -1,0 +1,1086 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DiagnosticoCRO",
+  "description": "Output estruturado do diagnostico de CRO: analise tecnica, auditoria de copy, hipoteses de teste e wireframe de melhorias.",
+  "type": "object",
+  "required": [
+    "summary",
+    "client_name",
+    "segment",
+    "url",
+    "technical_audit",
+    "onpage_seo",
+    "security_headers",
+    "technical_diagnosis",
+    "tracking_stack",
+    "events_fired",
+    "quality_flags",
+    "cro_elements_deep",
+    "compliance_lgpd",
+    "copy_audit",
+    "trust_analysis",
+    "test_hypotheses",
+    "wireframe_improvements",
+    "summary_headline",
+    "summary_highlights",
+    "summary_key_findings"
+  ],
+  "properties": {
+    "client_name": {
+      "type": "string",
+      "description": "Nome do cliente"
+    },
+    "summary": {
+      "type": "string",
+      "description": "Resumo de 1-2 frases do diagnóstico de CRO. Inclui principal gap de conversão e ação prioritária."
+    },
+    "summary_headline": {
+      "type": "string",
+      "description": "Manchete em 1 linha (~120 caracteres) com o veredito da skill."
+    },
+    "summary_highlights": {
+      "type": "array",
+      "description": "KPIs em destaque (4-6 itens). Categorias: posicao | competicao | janela | maturidade | oportunidade | risco.",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "label",
+          "value",
+          "tone"
+        ],
+        "properties": {
+          "category": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "subtext": {
+            "type": "string"
+          },
+          "tone": {
+            "type": "string",
+            "enum": [
+              "green",
+              "yellow",
+              "red",
+              "blue",
+              "gray"
+            ]
+          }
+        }
+      }
+    },
+    "summary_key_findings": {
+      "type": "array",
+      "description": "3-5 achados categorizados (vantagem | contexto | ameaca | acao).",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "text"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "vantagem",
+              "contexto",
+              "ameaca",
+              "acao"
+            ]
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "segment": {
+      "type": "string",
+      "description": "Segmento de atuacao"
+    },
+    "url": {
+      "type": "string",
+      "description": "URL do site/landing page analisada"
+    },
+    "current_conversion_rate": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "description": "Taxa de conversao atual em percentual (se disponivel)"
+    },
+    "current_bounce_rate": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "description": "Taxa de rejeicao atual em percentual (se disponivel)"
+    },
+    "avg_time_on_page": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Tempo medio na pagina (se disponivel)"
+    },
+    "technical_audit": {
+      "type": "object",
+      "description": "Dados brutos do audit tecnico automatizado (PageSpeed Insights + on-page). Preenchido a partir de client.json.page_audit.",
+      "required": [
+        "fetched_at",
+        "pagespeed"
+      ],
+      "properties": {
+        "fetched_at": {
+          "type": "string",
+          "description": "ISO timestamp do audit"
+        },
+        "cache_file": {
+          "type": "string",
+          "description": "Caminho relativo do cache raw"
+        },
+        "pagespeed": {
+          "type": "object",
+          "properties": {
+            "mobile_scores": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "performance": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "accessibility": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "best_practices": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "seo": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                }
+              }
+            },
+            "desktop_scores": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "performance": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "accessibility": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "best_practices": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "seo": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                }
+              }
+            },
+            "mobile_cwv_lab": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "description": "Core Web Vitals lab data (Lighthouse)",
+              "properties": {
+                "lcp_ms": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "fcp_ms": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "tbt_ms": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "cls": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "speed_index_ms": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "tti_ms": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "ttfb_ms": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                }
+              }
+            },
+            "desktop_cwv_lab": {
+              "type": [
+                "object",
+                "null"
+              ]
+            },
+            "mobile_cwv_field": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "description": "CrUX field data (usuarios reais), null se sem dados suficientes"
+            },
+            "desktop_cwv_field": {
+              "type": [
+                "object",
+                "null"
+              ]
+            },
+            "mobile_top_opportunities": {
+              "type": "array",
+              "description": "Top opportunities do Lighthouse mobile ordenadas por savings_ms"
+            },
+            "desktop_top_opportunities": {
+              "type": "array"
+            }
+          }
+        }
+      }
+    },
+    "onpage_seo": {
+      "type": "object",
+      "description": "Analise on-page SEO (mobile/desktop via parser HTML). Preenchido a partir de client.json.page_audit.onpage.",
+      "properties": {
+        "mobile": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "title": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "title_length": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "meta_description": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "meta_description_length": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "canonical": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "lang": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "viewport": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "favicon": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "og": {
+              "type": "object",
+              "description": "Open Graph tags"
+            },
+            "twitter": {
+              "type": "object",
+              "description": "Twitter card tags"
+            },
+            "schema_types": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "h1_count": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "h2_count": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "h3_count": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "images_total": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "images_without_alt": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "links_internal": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "links_external": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "links_nofollow": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "html_size_kb": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "response_time_ms": {
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          }
+        },
+        "desktop": {
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "divergences": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Diferencas significativas entre versao mobile e desktop (title, h1, canonical, etc.)"
+        }
+      }
+    },
+    "security_headers": {
+      "type": "object",
+      "description": "Analise de headers HTTP de seguranca. Preenchido a partir de client.json.page_audit.security.",
+      "properties": {
+        "https": {
+          "type": "boolean"
+        },
+        "hsts": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Valor do Strict-Transport-Security ou null se ausente"
+        },
+        "csp": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "x_frame_options": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "x_content_type_options": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "referrer_policy": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "permissions_policy": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "score": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 10
+        },
+        "issues": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "technical_diagnosis": {
+      "type": "object",
+      "required": [
+        "pagespeed_mobile",
+        "pagespeed_desktop"
+      ],
+      "properties": {
+        "pagespeed_mobile": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 100,
+          "description": "Score PageSpeed Insights mobile (0-100)"
+        },
+        "pagespeed_desktop": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 100,
+          "description": "Score PageSpeed Insights desktop (0-100)"
+        },
+        "lcp": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Largest Contentful Paint em segundos"
+        },
+        "cls": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Cumulative Layout Shift"
+        },
+        "inp": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Interaction to Next Paint em milissegundos"
+        },
+        "critical_issues": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Problemas criticos de velocidade identificados"
+        },
+        "estimated_conversion_loss": {
+          "type": "string",
+          "description": "Estimativa de perda de conversao por problemas tecnicos"
+        },
+        "tested": {
+          "type": "boolean",
+          "description": "Se o PageSpeed foi efetivamente testado"
+        }
+      }
+    },
+    "copy_audit": {
+      "type": "object",
+      "required": [
+        "above_fold",
+        "sections"
+      ],
+      "properties": {
+        "above_fold": {
+          "type": "object",
+          "required": [
+            "value_prop_clear",
+            "headline_complete",
+            "cta_visible",
+            "visitor_impression"
+          ],
+          "properties": {
+            "value_prop_clear": {
+              "type": "boolean",
+              "description": "Proposta de valor clara em menos de 5 segundos"
+            },
+            "value_prop_detail": {
+              "type": "string",
+              "description": "Justificativa da avaliacao da proposta de valor"
+            },
+            "headline_complete": {
+              "type": "boolean",
+              "description": "Headline responde o que + para quem + qual beneficio"
+            },
+            "current_headline": {
+              "type": "string",
+              "description": "Headline atual da pagina"
+            },
+            "suggested_headline": {
+              "type": "string",
+              "description": "Headline sugerida baseada na PUV"
+            },
+            "cta_visible": {
+              "type": "boolean",
+              "description": "CTA visivel sem rolar"
+            },
+            "current_cta": {
+              "type": "string",
+              "description": "Texto do CTA atual"
+            },
+            "suggested_cta": {
+              "type": "string",
+              "description": "Texto de CTA sugerido"
+            },
+            "visitor_impression": {
+              "type": "string",
+              "description": "O que um visitante do ICP provavelmente pensa ao chegar"
+            }
+          }
+        },
+        "sections": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "name",
+              "exists",
+              "evaluation",
+              "main_problem"
+            ],
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Nome da secao (Hero, Problema/Dor, Solucao, etc.)"
+              },
+              "exists": {
+                "type": "boolean",
+                "description": "Se a secao existe na pagina"
+              },
+              "evaluation": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 5,
+                "description": "Avaliacao da secao (1-5)"
+              },
+              "main_problem": {
+                "type": "string",
+                "description": "Problema principal da secao"
+              }
+            }
+          },
+          "description": "Avaliacao de cada secao da pagina"
+        },
+        "missing_sections": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Secoes criticas que deveriam existir e nao existem"
+        },
+        "unnecessary_sections": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Secoes que existem mas nao ajudam ou atrapalham"
+        }
+      }
+    },
+    "trust_analysis": {
+      "type": "object",
+      "required": [
+        "trust_signals",
+        "ssl_active",
+        "professional_appearance"
+      ],
+      "properties": {
+        "trust_signals": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "signal",
+              "present"
+            ],
+            "properties": {
+              "signal": {
+                "type": "string",
+                "description": "Tipo de sinal de confianca"
+              },
+              "present": {
+                "type": "boolean",
+                "description": "Se esta presente na pagina"
+              }
+            }
+          },
+          "description": "Sinais de confianca e se estao presentes"
+        },
+        "ssl_active": {
+          "type": "boolean",
+          "description": "Se o SSL (HTTPS) esta ativo"
+        },
+        "professional_appearance": {
+          "type": "boolean",
+          "description": "Se a pagina tem aparencia profissional para o ICP"
+        },
+        "professional_appearance_detail": {
+          "type": "string",
+          "description": "Justificativa da avaliacao de aparencia"
+        },
+        "trust_score": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 10,
+          "description": "Score de confianca geral (1-10)"
+        },
+        "biggest_trust_gap": {
+          "type": "string",
+          "description": "Maior gap de confianca identificado"
+        }
+      }
+    },
+    "test_hypotheses": {
+      "type": "array",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "hypothesis",
+          "element",
+          "expected_impact",
+          "difficulty",
+          "priority"
+        ],
+        "properties": {
+          "hypothesis": {
+            "type": "string",
+            "description": "Descricao da hipotese de teste"
+          },
+          "element": {
+            "type": "string",
+            "description": "Elemento a testar (headline, CTA, hero, secao, etc.)"
+          },
+          "current_version": {
+            "type": "string",
+            "description": "Como esta hoje"
+          },
+          "proposed_version": {
+            "type": "string",
+            "description": "Como deveria ficar"
+          },
+          "expected_impact": {
+            "type": "string",
+            "enum": [
+              "high",
+              "medium",
+              "low"
+            ],
+            "description": "Impacto esperado na conversao"
+          },
+          "difficulty": {
+            "type": "string",
+            "enum": [
+              "easy",
+              "medium",
+              "hard"
+            ],
+            "description": "Dificuldade de implementacao"
+          },
+          "priority": {
+            "type": "string",
+            "enum": [
+              "P1",
+              "P2",
+              "P3"
+            ],
+            "description": "Prioridade (P1 = alto impacto + facil)"
+          },
+          "success_metric": {
+            "type": "string",
+            "description": "Como medir se a hipotese funcionou"
+          },
+          "estimated_improvement": {
+            "type": "string",
+            "description": "Melhoria percentual estimada"
+          }
+        }
+      },
+      "description": "Hipoteses de teste priorizadas por impacto"
+    },
+    "wireframe_improvements": {
+      "type": "array",
+      "minItems": 5,
+      "items": {
+        "type": "object",
+        "required": [
+          "section_number",
+          "name",
+          "content_description"
+        ],
+        "properties": {
+          "section_number": {
+            "type": "integer",
+            "description": "Numero da secao na ordem da pagina"
+          },
+          "name": {
+            "type": "string",
+            "description": "Nome da secao (ex: Hero, Problema/Dor, Solucao)"
+          },
+          "content_description": {
+            "type": "string",
+            "description": "O que a secao deve conter"
+          },
+          "suggested_copy": {
+            "type": "string",
+            "description": "Rascunho de copy sugerida para a secao"
+          },
+          "format": {
+            "type": "string",
+            "description": "Formato recomendado (lista, cards, timeline, etc.)"
+          },
+          "visual_element": {
+            "type": "string",
+            "description": "Elemento visual recomendado (foto, video, icone, etc.)"
+          }
+        }
+      },
+      "description": "Wireframe da LP melhorada, secao a secao"
+    },
+    "transversal_elements": {
+      "type": "object",
+      "description": "Elementos que aparecem em toda a pagina",
+      "properties": {
+        "trust_bar": {
+          "type": "boolean",
+          "description": "Se deve ter barra de confianca (selos, CNPJ)"
+        },
+        "whatsapp_floating": {
+          "type": "boolean",
+          "description": "Se deve ter botao de WhatsApp flutuante"
+        },
+        "exit_intent_popup": {
+          "type": "boolean",
+          "description": "Se deve ter popup de exit intent"
+        },
+        "exit_intent_offer": {
+          "type": "string",
+          "description": "Oferta do popup de exit intent (se aplicavel)"
+        }
+      }
+    },
+    "tracking_stack": {
+      "type": "object",
+      "description": "Ferramentas de tracking/ads/analytics detectadas via Playwright. Preenchido a partir de client.json.page_audit_deep.tracking_stack.",
+      "properties": {
+        "tools_detected": {
+          "type": "object",
+          "description": "Dicionario {tool_id: {name, category, evidence[]}} das ferramentas identificadas",
+          "additionalProperties": true
+        },
+        "ids_found": {
+          "type": "object",
+          "description": "IDs extraidos: gtm, ga4, ua, google_ads, meta_pixel, tiktok_pixel, linkedin_partner",
+          "properties": {
+            "gtm": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "ga4": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "ua": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "google_ads": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "meta_pixel": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "tiktok_pixel": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "linkedin_partner": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "categories_summary": {
+          "type": "object",
+          "description": "Agrupamento por categoria: tracking, analytics, ads, heatmap, chat, cms, ecommerce, framework, lp_builder, cmp, hosting"
+        },
+        "total_tools": {
+          "type": "integer"
+        },
+        "setup_diagnosis": {
+          "type": "string",
+          "description": "Diagnostico narrativo do setup: coberturas, gaps, contradicoes. Ex: 'GTM presente mas sem GA4 — cliente opera cego.'"
+        }
+      }
+    },
+    "events_fired": {
+      "type": "object",
+      "description": "Eventos GA4 e Meta Pixel disparados durante navegacao.",
+      "properties": {
+        "ga4_event_count": {
+          "type": "integer"
+        },
+        "meta_event_count": {
+          "type": "integer"
+        },
+        "ga4_event_names": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "meta_event_names": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "events_diagnosis": {
+          "type": "string",
+          "description": "Avaliacao dos eventos: completude (page_view, scroll, click, form_submit), duplicatas, Consent Mode v2"
+        },
+        "expected_events_missing": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Eventos que DEVERIAM existir mas nao aparecem (ex: 'page_view', 'PageView', 'generate_lead')"
+        }
+      }
+    },
+    "quality_flags": {
+      "type": "array",
+      "description": "Red flags de qualidade do tagueamento (UA legacy, pixel duplicado, GTM sem analytics, etc.)",
+      "items": {
+        "type": "object",
+        "required": [
+          "severity",
+          "flag",
+          "title",
+          "detail"
+        ],
+        "properties": {
+          "severity": {
+            "type": "string",
+            "enum": [
+              "critical",
+              "high",
+              "medium",
+              "low"
+            ]
+          },
+          "flag": {
+            "type": "string",
+            "description": "Identificador curto do flag"
+          },
+          "title": {
+            "type": "string"
+          },
+          "detail": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "cro_elements_deep": {
+      "type": "object",
+      "description": "Analise profunda de elementos CRO via Playwright (CTAs, forms, WhatsApp, prova social, confianca, urgencia).",
+      "properties": {
+        "desktop": {
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "mobile": {
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "cta_diagnosis": {
+          "type": "string",
+          "description": "Avaliacao: quantidade de CTAs, above-fold, clareza, consistencia de texto"
+        },
+        "form_diagnosis": {
+          "type": "string",
+          "description": "Avaliacao: quantidade de forms, campos por form (regra: <= 5), campos obrigatorios, consentimento LGPD"
+        },
+        "social_proof_diagnosis": {
+          "type": "string",
+          "description": "Avaliacao de prova social (depoimentos, avaliacoes, numeros, certificacoes, logos)"
+        },
+        "trust_diagnosis": {
+          "type": "string",
+          "description": "Avaliacao: CNPJ, endereco, telefone, email, politica de privacidade, termos"
+        }
+      }
+    },
+    "compliance_lgpd": {
+      "type": "object",
+      "description": "Auditoria de compliance LGPD: CMP presente + scripts pre-consent.",
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": [
+            "compliant",
+            "partial",
+            "non_compliant"
+          ]
+        },
+        "score": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 10
+        },
+        "has_cmp": {
+          "type": "boolean"
+        },
+        "cmps_detected": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "pre_consent_trackers": {
+          "type": "object",
+          "description": "Trackers que disparam ANTES de qualquer consentimento {pattern: [urls]}"
+        },
+        "pre_consent_tracker_count": {
+          "type": "integer"
+        },
+        "issues": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "recommendation": {
+          "type": "string",
+          "description": "Recomendacao concreta: 'Instalar Cookiebot/OneTrust + gtag consent default denied + Consent Mode v2'"
+        }
+      }
+    },
+    "target_conversion_rate": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "description": "Meta de taxa de conversao apos melhorias"
+    },
+    "completed_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Data/hora de conclusao"
+    }
+  }
+}

--- a/.agents/skills/gt-diagnostico-cro/scripts/page_audit.py
+++ b/.agents/skills/gt-diagnostico-cro/scripts/page_audit.py
@@ -1,0 +1,414 @@
+#!/usr/bin/env python3
+"""
+page_audit.py — Auditoria tecnica de URL
+Camadas: PageSpeed Insights (mobile+desktop) + On-page parser (mobile+desktop UA) + Security headers.
+
+Uso:
+  page_audit.py <url> <output_json> [--api-key KEY] [--skip-psi]
+
+Saida: JSON estruturado com pagespeed, onpage, security.
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import json
+import os
+import re
+import sys
+import time
+import urllib.parse
+from typing import Any
+
+import requests
+from bs4 import BeautifulSoup
+
+PSI_ENDPOINT = "https://www.googleapis.com/pagespeedonline/v5/runPagespeed"
+UA_MOBILE = "Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36"
+UA_DESKTOP = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+
+OPPORTUNITY_AUDIT_IDS = [
+    "render-blocking-resources",
+    "unused-css-rules",
+    "unused-javascript",
+    "modern-image-formats",
+    "uses-optimized-images",
+    "uses-text-compression",
+    "uses-responsive-images",
+    "efficient-animated-content",
+    "duplicated-javascript",
+    "server-response-time",
+    "redirects",
+    "uses-long-cache-ttl",
+    "total-byte-weight",
+]
+
+
+def fetch_pagespeed(url: str, strategy: str, api_key: str | None, retries: int = 2) -> dict[str, Any]:
+    params = [
+        ("url", url),
+        ("strategy", strategy),
+        ("category", "performance"),
+        ("category", "accessibility"),
+        ("category", "best-practices"),
+        ("category", "seo"),
+        ("locale", "pt-BR"),
+    ]
+    if api_key:
+        params.append(("key", api_key))
+    qs = urllib.parse.urlencode(params)
+    full_url = f"{PSI_ENDPOINT}?{qs}"
+
+    last_err = None
+    for attempt in range(retries + 1):
+        try:
+            r = requests.get(full_url, timeout=90)
+            if r.status_code == 200:
+                return parse_psi_response(r.json(), strategy)
+            if r.status_code == 429 and attempt < retries:
+                time.sleep(2 ** (attempt + 1))
+                continue
+            if r.status_code >= 500 and attempt < retries:
+                time.sleep(2)
+                continue
+            return {
+                "error": f"HTTP {r.status_code}",
+                "detail": r.text[:500],
+                "strategy": strategy,
+            }
+        except requests.RequestException as e:
+            last_err = str(e)
+            if attempt < retries:
+                time.sleep(2)
+                continue
+    return {"error": "request_failed", "detail": last_err, "strategy": strategy}
+
+
+def parse_psi_response(data: dict, strategy: str) -> dict[str, Any]:
+    lh = data.get("lighthouseResult", {}) or {}
+    cats = lh.get("categories", {}) or {}
+    audits = lh.get("audits", {}) or {}
+    le = data.get("loadingExperience", {}) or {}
+
+    def score(cat: str) -> int | None:
+        v = (cats.get(cat) or {}).get("score")
+        return round(v * 100) if isinstance(v, (int, float)) else None
+
+    def audit_val(name: str, num: bool = True) -> Any:
+        a = audits.get(name) or {}
+        return a.get("numericValue") if num else a.get("displayValue")
+
+    scores = {
+        "performance": score("performance"),
+        "accessibility": score("accessibility"),
+        "best_practices": score("best-practices"),
+        "seo": score("seo"),
+    }
+
+    cwv_lab = {
+        "lcp_ms": audit_val("largest-contentful-paint"),
+        "fcp_ms": audit_val("first-contentful-paint"),
+        "tbt_ms": audit_val("total-blocking-time"),
+        "cls": audit_val("cumulative-layout-shift"),
+        "speed_index_ms": audit_val("speed-index"),
+        "tti_ms": audit_val("interactive"),
+        "ttfb_ms": audit_val("server-response-time"),
+    }
+
+    def field_metric(key: str) -> dict | None:
+        m = (le.get("metrics") or {}).get(key)
+        if not m:
+            return None
+        return {"percentile": m.get("percentile"), "category": m.get("category")}
+
+    cwv_field = {
+        "lcp": field_metric("LARGEST_CONTENTFUL_PAINT_MS"),
+        "inp": field_metric("INTERACTION_TO_NEXT_PAINT"),
+        "cls": field_metric("CUMULATIVE_LAYOUT_SHIFT_SCORE"),
+        "fcp": field_metric("FIRST_CONTENTFUL_PAINT_MS"),
+    }
+    crux_overall = le.get("overall_category")
+
+    opportunities = []
+    for audit_id in OPPORTUNITY_AUDIT_IDS:
+        a = audits.get(audit_id) or {}
+        s = a.get("score")
+        if s is None or (isinstance(s, (int, float)) and s >= 0.9):
+            continue
+        details = a.get("details") or {}
+        savings_ms = details.get("overallSavingsMs") or a.get("numericValue") or 0
+        savings_bytes = details.get("overallSavingsBytes")
+        opportunities.append(
+            {
+                "id": audit_id,
+                "title": a.get("title"),
+                "description": a.get("description"),
+                "savings_ms": round(savings_ms) if savings_ms else 0,
+                "savings_bytes": savings_bytes,
+                "display_value": a.get("displayValue"),
+            }
+        )
+    opportunities.sort(key=lambda x: x.get("savings_ms") or 0, reverse=True)
+
+    # Screenshot final (data URI base64). "final-screenshot" e o viewport do final do load.
+    final_ss = audits.get("final-screenshot") or {}
+    ss_data = (final_ss.get("details") or {}).get("data")
+    # Tamanho do viewport retornado para referencia (mobile=360x, desktop=412x)
+    ss_timing = (final_ss.get("details") or {}).get("timing")
+
+    return {
+        "strategy": strategy,
+        "scores": scores,
+        "cwv_lab": cwv_lab,
+        "cwv_field": cwv_field,
+        "crux_overall_category": crux_overall,
+        "opportunities": opportunities,
+        "final_screenshot": ss_data,
+        "final_screenshot_timing_ms": ss_timing,
+        "fetch_time": lh.get("fetchTime"),
+    }
+
+
+def fetch_onpage(url: str, user_agent: str, label: str) -> dict[str, Any]:
+    t0 = time.time()
+    try:
+        r = requests.get(
+            url,
+            headers={"User-Agent": user_agent, "Accept": "text/html,application/xhtml+xml"},
+            timeout=30,
+            allow_redirects=True,
+        )
+        elapsed_ms = round((time.time() - t0) * 1000)
+    except requests.RequestException as e:
+        return {"label": label, "error": str(e)}
+
+    html = r.text or ""
+    try:
+        soup = BeautifulSoup(html, "lxml")
+    except Exception:
+        soup = BeautifulSoup(html, "html.parser")
+
+    def meta(attr: str, name: str) -> str | None:
+        tag = soup.find("meta", attrs={attr: name})
+        return tag.get("content") if tag and tag.has_attr("content") else None
+
+    title_tag = soup.find("title")
+    title = title_tag.get_text(strip=True) if title_tag else None
+
+    canonical_tag = soup.find("link", rel="canonical")
+    canonical = canonical_tag.get("href") if canonical_tag else None
+
+    lang = (soup.html.get("lang") if soup.html and soup.html.has_attr("lang") else None)
+
+    og = {}
+    twitter = {}
+    for m in soup.find_all("meta"):
+        prop = m.get("property") or ""
+        name = m.get("name") or ""
+        content = m.get("content")
+        if prop.startswith("og:"):
+            og[prop[3:]] = content
+        elif name.startswith("twitter:"):
+            twitter[name[8:]] = content
+
+    schema_types = []
+    for s in soup.find_all("script", attrs={"type": "application/ld+json"}):
+        try:
+            raw = s.string or s.get_text() or ""
+            data = json.loads(raw)
+            items = data if isinstance(data, list) else [data]
+            for it in items:
+                if isinstance(it, dict):
+                    t = it.get("@type")
+                    if isinstance(t, list):
+                        schema_types.extend(t)
+                    elif t:
+                        schema_types.append(t)
+        except Exception:
+            continue
+    schema_types = sorted(set(str(t) for t in schema_types))
+
+    h1s = [h.get_text(strip=True) for h in soup.find_all("h1")]
+    h2_count = len(soup.find_all("h2"))
+    h3_count = len(soup.find_all("h3"))
+    h4_count = len(soup.find_all("h4"))
+
+    imgs = soup.find_all("img")
+    images_total = len(imgs)
+    images_without_alt = sum(1 for i in imgs if not (i.get("alt") or "").strip())
+
+    links = soup.find_all("a", href=True)
+    parsed_url = urllib.parse.urlparse(url)
+    host = parsed_url.netloc
+    internal = external = nofollow = 0
+    for a in links:
+        href = a["href"]
+        rel = " ".join(a.get("rel") or [])
+        if "nofollow" in rel:
+            nofollow += 1
+        if href.startswith("/") or host in href:
+            internal += 1
+        elif href.startswith("http://") or href.startswith("https://"):
+            external += 1
+
+    viewport = soup.find("meta", attrs={"name": "viewport"}) is not None
+    favicon = bool(
+        soup.find("link", rel=re.compile(r"(^|\s)(shortcut\s+)?icon(\s|$)", re.I))
+        or soup.find("link", rel="apple-touch-icon")
+    )
+
+    headers = {k: v for k, v in r.headers.items()}
+
+    return {
+        "label": label,
+        "status_code": r.status_code,
+        "final_url": r.url,
+        "response_time_ms": elapsed_ms,
+        "html_size_kb": round(len(html.encode("utf-8")) / 1024, 1),
+        "title": title,
+        "title_length": len(title) if title else 0,
+        "meta_description": meta("name", "description"),
+        "meta_description_length": len(meta("name", "description") or ""),
+        "robots": meta("name", "robots"),
+        "canonical": canonical,
+        "lang": lang,
+        "viewport": viewport,
+        "favicon": favicon,
+        "h1": h1s,
+        "h1_count": len(h1s),
+        "h2_count": h2_count,
+        "h3_count": h3_count,
+        "h4_count": h4_count,
+        "images_total": images_total,
+        "images_without_alt": images_without_alt,
+        "links_total": len(links),
+        "links_internal": internal,
+        "links_external": external,
+        "links_nofollow": nofollow,
+        "schema_types": schema_types,
+        "og": og,
+        "twitter_card": twitter,
+        "headers": headers,
+    }
+
+
+def compute_security(onpage_desktop: dict, onpage_mobile: dict, url: str) -> dict[str, Any]:
+    headers = (onpage_desktop.get("headers") or onpage_mobile.get("headers") or {})
+    h_lower = {k.lower(): v for k, v in headers.items()}
+
+    def hget(key: str) -> str | None:
+        return h_lower.get(key)
+
+    is_https = url.startswith("https://")
+    if not is_https:
+        final = onpage_desktop.get("final_url") or onpage_mobile.get("final_url") or ""
+        is_https = final.startswith("https://")
+
+    return {
+        "https": is_https,
+        "hsts": hget("strict-transport-security"),
+        "csp": hget("content-security-policy"),
+        "x_frame_options": hget("x-frame-options"),
+        "x_content_type_options": hget("x-content-type-options"),
+        "referrer_policy": hget("referrer-policy"),
+        "content_type": hget("content-type"),
+        "content_encoding": hget("content-encoding"),
+        "cache_control": hget("cache-control"),
+        "server": hget("server"),
+    }
+
+
+def compute_divergences(mob: dict, desk: dict) -> list[str]:
+    if mob.get("error") or desk.get("error"):
+        return []
+    diffs = []
+    fields = [("title", "Title"), ("meta_description", "Meta description"), ("canonical", "Canonical"), ("lang", "Lang"), ("h1_count", "H1 count")]
+    for key, label in fields:
+        a, b = mob.get(key), desk.get(key)
+        if a != b:
+            diffs.append(f"{label} divergente — mobile: {a!r} · desktop: {b!r}")
+    if mob.get("final_url") != desk.get("final_url"):
+        diffs.append(f"URL final divergente — mobile: {mob.get('final_url')} · desktop: {desk.get('final_url')}")
+    return diffs
+
+
+def run_audit(url: str, api_key: str | None, skip_psi: bool) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "url": url,
+        "fetched_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+
+    tasks: dict[str, concurrent.futures.Future] = {}
+    with concurrent.futures.ThreadPoolExecutor(max_workers=5) as ex:
+        if not skip_psi and api_key:
+            tasks["psi_mobile"] = ex.submit(fetch_pagespeed, url, "mobile", api_key)
+            tasks["psi_desktop"] = ex.submit(fetch_pagespeed, url, "desktop", api_key)
+        tasks["onpage_mobile"] = ex.submit(fetch_onpage, url, UA_MOBILE, "mobile")
+        tasks["onpage_desktop"] = ex.submit(fetch_onpage, url, UA_DESKTOP, "desktop")
+
+        for name, fut in tasks.items():
+            try:
+                result[name] = fut.result(timeout=120)
+            except Exception as e:
+                result[name] = {"error": str(e)}
+
+    if skip_psi or not api_key:
+        result["pagespeed_skipped"] = True
+        result["pagespeed_reason"] = "no_api_key" if not api_key else "skipped_by_flag"
+
+    onpage = {
+        "mobile": result.get("onpage_mobile"),
+        "desktop": result.get("onpage_desktop"),
+        "divergences": compute_divergences(result.get("onpage_mobile") or {}, result.get("onpage_desktop") or {}),
+    }
+    result["onpage"] = onpage
+    for k in ("onpage_mobile", "onpage_desktop"):
+        result.pop(k, None)
+
+    result["security"] = compute_security(onpage.get("desktop") or {}, onpage.get("mobile") or {}, url)
+
+    result["pagespeed"] = {
+        "mobile": result.pop("psi_mobile", None) if "psi_mobile" in result else None,
+        "desktop": result.pop("psi_desktop", None) if "psi_desktop" in result else None,
+    }
+    if result["pagespeed"]["mobile"] is None and result["pagespeed"]["desktop"] is None:
+        result["pagespeed"] = None
+
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("url")
+    parser.add_argument("output")
+    parser.add_argument("--api-key", default=os.environ.get("PSI_API_KEY"))
+    parser.add_argument("--skip-psi", action="store_true")
+    args = parser.parse_args()
+
+    if not args.url.startswith(("http://", "https://")):
+        print("ERROR: url precisa comecar com http:// ou https://", file=sys.stderr)
+        return 2
+
+    result = run_audit(args.url, args.api_key, args.skip_psi)
+
+    with open(args.output, "w", encoding="utf-8") as f:
+        json.dump(result, f, ensure_ascii=False, indent=2)
+
+    psi_m = (result.get("pagespeed") or {}).get("mobile") or {}
+    psi_d = (result.get("pagespeed") or {}).get("desktop") or {}
+    print(f"[OK] {args.url} -> {args.output}")
+    if isinstance(psi_m.get("scores"), dict):
+        print(f"  PSI mobile  perf={psi_m['scores'].get('performance')} a11y={psi_m['scores'].get('accessibility')} bp={psi_m['scores'].get('best_practices')} seo={psi_m['scores'].get('seo')}")
+    if isinstance(psi_d.get("scores"), dict):
+        print(f"  PSI desktop perf={psi_d['scores'].get('performance')} a11y={psi_d['scores'].get('accessibility')} bp={psi_d['scores'].get('best_practices')} seo={psi_d['scores'].get('seo')}")
+    op = result.get("onpage") or {}
+    mob = op.get("mobile") or {}
+    print(f"  On-page     title='{(mob.get('title') or '')[:60]}' h1={mob.get('h1_count')} images_no_alt={mob.get('images_without_alt')}/{mob.get('images_total')}")
+    sec = result.get("security") or {}
+    print(f"  Security    https={sec.get('https')} hsts={'sim' if sec.get('hsts') else 'nao'} csp={'sim' if sec.get('csp') else 'nao'}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.agents/skills/gt-diagnostico-cro/scripts/page_audit.sh
+++ b/.agents/skills/gt-diagnostico-cro/scripts/page_audit.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# page_audit.sh — Orquestra a auditoria tecnica de uma URL
+# Uso:  page_audit.sh <client_dir> <url>
+# Ex:   page_audit.sh squads/{squad}/clientes/{cliente} https://www.site-do-cliente.com.br
+#
+# Le:    .credentials/google.json (pagespeed_api_key)
+#        <client_dir>/client.json
+# Grava: <client_dir>/cache/page_audit-<timestamp>.json (raw)
+#        <client_dir>/client.json (campo page_audit com resumo)
+
+set -euo pipefail
+
+CLIENT_DIR="${1:?Uso: page_audit.sh <client_dir> <url>}"
+URL="${2:?Uso: page_audit.sh <client_dir> <url>}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PY_SCRIPT="$SCRIPT_DIR/page_audit.py"
+
+if [ ! -f "$PY_SCRIPT" ]; then
+  echo "ERROR: page_audit.py nao encontrado em $PY_SCRIPT" >&2
+  exit 1
+fi
+
+# Descobrir credenciais (sobe na arvore procurando .credentials/google.json)
+CRED_FILE=""
+SEARCH_DIR="$CLIENT_DIR"
+for i in 1 2 3 4 5; do
+  SEARCH_DIR="$(cd "$SEARCH_DIR/.." && pwd)"
+  if [ -f "$SEARCH_DIR/.credentials/google.json" ]; then
+    CRED_FILE="$SEARCH_DIR/.credentials/google.json"
+    break
+  fi
+done
+
+PSI_API_KEY=""
+if [ -n "$CRED_FILE" ]; then
+  PSI_API_KEY=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1])).get('pagespeed_api_key',''))" "$CRED_FILE" 2>/dev/null || true)
+fi
+
+# Cache dir
+mkdir -p "$CLIENT_DIR/cache"
+TS=$(date -u +%Y%m%d-%H%M%S)
+RAW_OUT="$CLIENT_DIR/cache/page_audit-$TS.json"
+
+# Rodar Python worker
+if [ -n "$PSI_API_KEY" ]; then
+  echo ">> Rodando auditoria (PSI mobile+desktop + on-page + security) em paralelo..."
+  PSI_API_KEY="$PSI_API_KEY" python3 "$PY_SCRIPT" "$URL" "$RAW_OUT"
+else
+  echo ">> Sem PSI_API_KEY — rodando apenas on-page + security (PageSpeed sera pulado)..."
+  python3 "$PY_SCRIPT" "$URL" "$RAW_OUT" --skip-psi
+fi
+
+# O Builders Hub não exige client.json. Quando ele não existe, preserve o
+# cache bruto e deixe a skill interpretar os dados junto com a KB do cliente.
+if [ ! -f "$CLIENT_DIR/client.json" ]; then
+  echo "[OK] Auditoria bruta concluída; client.json ausente, merge ignorado."
+  echo "Cache raw: $RAW_OUT"
+  exit 0
+fi
+
+# Merge resumo no client.json
+python3 << PYEOF
+import json, sys
+from datetime import datetime, timezone
+
+raw_path = "$RAW_OUT"
+client_path = "$CLIENT_DIR/client.json"
+
+with open(raw_path, encoding='utf-8') as f:
+    raw = json.load(f)
+
+with open(client_path, encoding='utf-8') as f:
+    client = json.load(f)
+
+# Resumo condensado para client.json (raw fica no cache)
+psi = raw.get("pagespeed") or {}
+mob = (psi.get("mobile") or {})
+des = (psi.get("desktop") or {})
+onp = raw.get("onpage") or {}
+sec = raw.get("security") or {}
+
+summary = {
+    "fetched_at": raw.get("fetched_at"),
+    "url": raw.get("url"),
+    "cache_file": raw_path.replace("$CLIENT_DIR/", ""),
+    "pagespeed": {
+        "mobile_scores": (mob or {}).get("scores") if isinstance(mob, dict) else None,
+        "desktop_scores": (des or {}).get("scores") if isinstance(des, dict) else None,
+        "mobile_cwv_lab": (mob or {}).get("cwv_lab") if isinstance(mob, dict) else None,
+        "desktop_cwv_lab": (des or {}).get("cwv_lab") if isinstance(des, dict) else None,
+        "mobile_cwv_field": (mob or {}).get("cwv_field") if isinstance(mob, dict) else None,
+        "desktop_cwv_field": (des or {}).get("cwv_field") if isinstance(des, dict) else None,
+        "mobile_top_opportunities": ((mob or {}).get("opportunities") or [])[:10] if isinstance(mob, dict) else [],
+        "desktop_top_opportunities": ((des or {}).get("opportunities") or [])[:10] if isinstance(des, dict) else [],
+        "mobile_error": (mob or {}).get("error") if isinstance(mob, dict) else None,
+        "desktop_error": (des or {}).get("error") if isinstance(des, dict) else None,
+        "skipped": raw.get("pagespeed_skipped", False),
+    },
+    "screenshots": {
+        "mobile": (mob or {}).get("final_screenshot") if isinstance(mob, dict) else None,
+        "desktop": (des or {}).get("final_screenshot") if isinstance(des, dict) else None,
+    },
+    "onpage": {
+        "mobile": onp.get("mobile"),
+        "desktop": onp.get("desktop"),
+        "divergences": onp.get("divergences") or [],
+    },
+    "security": sec,
+}
+
+# Remove 'headers' e payload pesado do summary (fica no raw)
+for k in ("mobile", "desktop"):
+    blk = summary["onpage"].get(k)
+    if isinstance(blk, dict):
+        blk.pop("headers", None)
+
+client["page_audit"] = summary
+
+with open(client_path, "w", encoding="utf-8") as f:
+    json.dump(client, f, ensure_ascii=False, indent=2)
+
+print(f"[OK] page_audit salvo em client.json (raw: {raw_path})")
+PYEOF
+
+echo "Cache raw: $RAW_OUT"

--- a/.agents/skills/gt-diagnostico-cro/scripts/page_audit_deep.py
+++ b/.agents/skills/gt-diagnostico-cro/scripts/page_audit_deep.py
@@ -1,0 +1,875 @@
+#!/usr/bin/env python3
+"""
+page_audit_deep.py — Auditoria profunda via Playwright headless.
+
+Captura:
+  - tracking_stack: quais ferramentas (GTM, GA4, Meta Pixel, Clarity, etc.) estao presentes
+  - events_fired: quais eventos GA4/Meta Pixel sao disparados no load + interacoes
+  - dataLayer: dump do window.dataLayer
+  - platform: CMS/plataforma (WordPress, Shopify, VTEX, Next.js...)
+  - cro_elements: analise profunda de CTAs, forms, WhatsApp, prova social, urgencia
+  - compliance_lgpd: deteccao de CMP + scripts pre-consent (2-pass)
+  - quality_flags: red flags de tagueamento (UA legacy, pixel duplicado, scripts parallel)
+
+Uso:
+  python3 page_audit_deep.py <url> <output_json>
+  python3 page_audit_deep.py <url> <output_json> --skip-compliance (pula 2-pass)
+
+Requisitos:
+  pip install -r requirements-deep.txt
+  python3 -m playwright install chromium
+"""
+import sys
+import os
+import re
+import json
+import time
+import asyncio
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.parse import urlparse, parse_qs
+import yaml
+
+try:
+    from playwright.async_api import async_playwright, Page, Request, Response, TimeoutError as PWTimeout
+except ImportError:
+    print("ERRO: Playwright nao instalado. Rode: pip3 install --user -r requirements-deep.txt && python3 -m playwright install chromium", file=sys.stderr)
+    sys.exit(1)
+
+try:
+    from bs4 import BeautifulSoup
+except ImportError:
+    BeautifulSoup = None
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+SIGNATURES_FILE = SCRIPT_DIR / "signatures" / "tools.yaml"
+
+USER_AGENT_MOBILE = "Mozilla/5.0 (Linux; Android 12; Pixel 6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36"
+USER_AGENT_DESKTOP = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+
+VIEWPORT_MOBILE = {"width": 390, "height": 844}
+VIEWPORT_DESKTOP = {"width": 1440, "height": 900}
+
+NAV_TIMEOUT_MS = 45000
+IDLE_TIMEOUT_MS = 15000
+
+
+def load_signatures():
+    with open(SIGNATURES_FILE, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f).get("tools", [])
+
+
+class NetworkLog:
+    """Coleta todas as requests/responses durante a navegacao."""
+    def __init__(self):
+        self.requests = []  # [{url, method, resource_type, headers, post_data_preview, timestamp}]
+        self.responses = []  # [{url, status, headers}]
+
+    def on_request(self, req: Request):
+        try:
+            post = None
+            try:
+                post = req.post_data
+                if post and len(post) > 2000:
+                    post = post[:2000]
+            except Exception:
+                pass
+            self.requests.append({
+                "url": req.url,
+                "method": req.method,
+                "resource_type": req.resource_type,
+                "post_data_preview": post,
+                "ts": time.time(),
+            })
+        except Exception:
+            pass
+
+    def on_response(self, resp: Response):
+        try:
+            self.responses.append({
+                "url": resp.url,
+                "status": resp.status,
+                "headers": dict(resp.headers),
+            })
+        except Exception:
+            pass
+
+
+def detect_tools(signatures, network_log: NetworkLog, html: str, window_globals: list, cookies: list):
+    """Cross-checks signatures against network URLs, HTML content, window globals, and cookies."""
+    detected = {}
+    all_urls = [r["url"] for r in network_log.requests]
+    all_resp_urls = [r["url"] for r in network_log.responses]
+    urls_combined = "\n".join(all_urls + all_resp_urls)
+    globals_set = set(window_globals or [])
+    cookie_names = set((c.get("name") for c in (cookies or [])))
+
+    soup = None
+    if BeautifulSoup is not None and html:
+        try:
+            soup = BeautifulSoup(html, "lxml")
+        except Exception:
+            try:
+                soup = BeautifulSoup(html, "html.parser")
+            except Exception:
+                soup = None
+
+    for sig in signatures:
+        evidence = []
+
+        # URL patterns
+        for pat in (sig.get("url_patterns") or []):
+            if pat in urls_combined:
+                matches = [u for u in all_urls if pat in u]
+                evidence.append({"type": "url", "pattern": pat, "sample": matches[0] if matches else pat})
+                break
+
+        # window globals
+        for g in (sig.get("window_globals") or []):
+            if g in globals_set:
+                evidence.append({"type": "window", "key": g})
+                break
+
+        # DOM selectors (usar BS4 CSS selector, senao fallback conservador)
+        for sel in (sig.get("dom_selectors") or []):
+            matched = False
+            if soup is not None:
+                try:
+                    if soup.select_one(sel):
+                        matched = True
+                except Exception:
+                    matched = False
+            else:
+                # Fallback: extrair todos valores de [attr="value"] do selector e exigir todos no HTML
+                attr_vals = re.findall(r'\[[^=\]]+=["\']?([^"\'\]]+)', sel)
+                if attr_vals and all(v.lower() in html.lower() for v in attr_vals):
+                    matched = True
+                elif not attr_vals:
+                    key = sel.lstrip(".#")
+                    if key and key.lower() in html.lower():
+                        matched = True
+            if matched:
+                evidence.append({"type": "dom", "selector": sel})
+                break
+
+        # cookies
+        for cname in (sig.get("cookies") or []):
+            if cname in cookie_names:
+                evidence.append({"type": "cookie", "name": cname})
+                break
+
+        # headers (resposta do doc principal)
+        hdrs = sig.get("headers") or {}
+        if hdrs and network_log.responses:
+            # usar primeira resposta 2xx/3xx do doc principal
+            doc_resp = next((r for r in network_log.responses if r["status"] < 400), None)
+            if doc_resp:
+                for hname, hpat in hdrs.items():
+                    hval = doc_resp["headers"].get(hname.lower(), "")
+                    if hval and re.search(hpat, hval):
+                        evidence.append({"type": "header", "name": hname, "value": hval[:120]})
+                        break
+
+        if evidence:
+            detected[sig["id"]] = {
+                "id": sig["id"],
+                "name": sig["name"],
+                "category": sig["category"],
+                "evidence": evidence,
+                "notes": sig.get("notes", ""),
+            }
+
+    return detected
+
+
+def extract_ids_from_urls(network_log: NetworkLog):
+    """Extrai IDs de conta (GTM-XXX, G-XXX, UA-XXX, AW-XXX, pixel_id) das URLs."""
+    ids = {
+        "gtm": set(),
+        "ga4": set(),
+        "ua": set(),
+        "google_ads": set(),
+        "meta_pixel": set(),
+        "tiktok_pixel": set(),
+        "linkedin_partner": set(),
+    }
+    for r in network_log.requests:
+        u = r["url"]
+        # GTM container
+        m = re.search(r'[?&]id=(GTM-[A-Z0-9]+)', u)
+        if m:
+            ids["gtm"].add(m.group(1))
+        # GA4
+        m = re.search(r'[?&]tid=(G-[A-Z0-9]+)', u)
+        if m:
+            ids["ga4"].add(m.group(1))
+        m = re.search(r'[?&]id=(G-[A-Z0-9]+)', u)
+        if m:
+            ids["ga4"].add(m.group(1))
+        # UA
+        m = re.search(r'[?&]tid=(UA-\d+-\d+)', u)
+        if m:
+            ids["ua"].add(m.group(1))
+        # Google Ads
+        m = re.search(r'(AW-\d+)', u)
+        if m:
+            ids["google_ads"].add(m.group(1))
+        # Meta Pixel
+        m = re.search(r'facebook\.com/tr[/?].*[?&]id=(\d+)', u)
+        if m:
+            ids["meta_pixel"].add(m.group(1))
+        # TikTok
+        m = re.search(r'tiktok.*[?&]sdkid=([A-Z0-9]+)', u, re.I)
+        if m:
+            ids["tiktok_pixel"].add(m.group(1))
+        # LinkedIn
+        m = re.search(r'linkedin.*pid=(\d+)', u, re.I)
+        if m:
+            ids["linkedin_partner"].add(m.group(1))
+
+    return {k: sorted(list(v)) for k, v in ids.items()}
+
+
+def parse_ga4_events(network_log: NetworkLog):
+    """Parse eventos GA4 de google-analytics.com/g/collect."""
+    events = []
+    for r in network_log.requests:
+        u = r["url"]
+        if "google-analytics.com/g/collect" not in u and "analytics.google.com/g/collect" not in u:
+            continue
+        try:
+            parsed = urlparse(u)
+            qs = parse_qs(parsed.query)
+            # Alguns eventos vem em POST body (batch)
+            body_qs = {}
+            if r.get("post_data_preview"):
+                try:
+                    body_qs = parse_qs(r["post_data_preview"])
+                except Exception:
+                    pass
+            merged = {**qs, **body_qs}
+            en = merged.get("en", [None])[0]
+            if not en:
+                continue
+            event = {
+                "name": en,
+                "tid": merged.get("tid", [None])[0],
+                "gcs": merged.get("gcs", [None])[0],  # Consent Mode v2 state
+                "dl": merged.get("dl", [None])[0],  # page url
+                "dt": merged.get("dt", [None])[0],  # page title
+                "params": {},
+            }
+            # ep.* = event params, epn.* = numeric
+            for k, v in merged.items():
+                if k.startswith("ep.") or k.startswith("epn."):
+                    event["params"][k.split(".", 1)[1]] = v[0] if v else None
+            events.append(event)
+        except Exception as e:
+            continue
+    return events
+
+
+def parse_meta_pixel_events(network_log: NetworkLog):
+    """Parse eventos Meta Pixel de facebook.com/tr."""
+    events = []
+    for r in network_log.requests:
+        u = r["url"]
+        if "facebook.com/tr" not in u:
+            continue
+        try:
+            parsed = urlparse(u)
+            qs = parse_qs(parsed.query)
+            ev = qs.get("ev", [None])[0]
+            if not ev:
+                continue
+            event = {
+                "name": ev,
+                "pixel_id": qs.get("id", [None])[0],
+                "dl": qs.get("dl", [None])[0],
+                "value": qs.get("cd[value]", [None])[0],
+                "currency": qs.get("cd[currency]", [None])[0],
+                "content_ids": qs.get("cd[content_ids]", [None])[0],
+                "content_type": qs.get("cd[content_type]", [None])[0],
+            }
+            events.append(event)
+        except Exception:
+            continue
+    return events
+
+
+def compute_quality_flags(detected_tools, ga4_events, meta_events, datalayer, ids_found):
+    """Gera red flags de qualidade/tagueamento."""
+    flags = []
+
+    # 1. UA legacy ainda presente
+    if "ga_ua" in detected_tools or ids_found.get("ua"):
+        flags.append({
+            "severity": "critical",
+            "flag": "ua_legacy_detected",
+            "title": "Google Analytics UA (legado) ainda presente",
+            "detail": f"UA descontinuado desde jul/2023. IDs: {ids_found.get('ua') or 'n/a'}. Remover tags UA do GTM.",
+        })
+
+    # 2. Pixel Meta duplicado
+    pixels = ids_found.get("meta_pixel") or []
+    if len(pixels) > 1:
+        flags.append({
+            "severity": "high",
+            "flag": "meta_pixel_duplicated",
+            "title": f"Meta Pixel duplicado ({len(pixels)} IDs)",
+            "detail": f"IDs: {pixels}. Eventos sao disparados duas vezes — duplica dados em Business Manager e gasta budget em audiencias infladas.",
+        })
+
+    # 3. GA4 sem PageView
+    has_ga4 = "ga4" in detected_tools
+    has_page_view = any(e["name"] == "page_view" for e in ga4_events)
+    if has_ga4 and not has_page_view:
+        flags.append({
+            "severity": "high",
+            "flag": "ga4_no_pageview",
+            "title": "GA4 instalado mas nao dispara page_view",
+            "detail": "Load da pagina nao gerou evento page_view. Pode ser bloqueio por consent, erro de config ou tag disparando so com interacao.",
+        })
+
+    # 4. Pixel sem PageView
+    has_pixel = "meta_pixel" in detected_tools
+    has_pixel_pv = any(e["name"] == "PageView" for e in meta_events)
+    if has_pixel and not has_pixel_pv:
+        flags.append({
+            "severity": "high",
+            "flag": "pixel_no_pageview",
+            "title": "Meta Pixel instalado mas nao dispara PageView",
+            "detail": "Eventos de remarketing nao vao contar. Checar fbq('init') + fbq('track','PageView') no codigo ou GTM.",
+        })
+
+    # 5. gtag + GTM em paralelo
+    has_gtm = "gtm" in detected_tools
+    has_gtag_only = has_ga4 and not has_gtm
+    if has_gtm and any("gtag/js" in r["url"] for r in []):  # checado indiretamente
+        pass  # refinar: se houver dois pontos de init GA4, flag
+
+    # 6. Consent Mode v2 presente?
+    has_cmp = any(detected_tools.get(t) for t in ["onetrust", "cookiebot", "usercentrics", "trustarc", "termly"])
+    has_gcs = any(e.get("gcs") for e in ga4_events)
+    if has_ga4 and not has_gcs and not has_cmp:
+        flags.append({
+            "severity": "medium",
+            "flag": "no_consent_mode",
+            "title": "Sem Consent Mode v2 nem CMP detectado",
+            "detail": "Desde mar/2024 Google exige Consent Mode v2 para audiencias. Sem CMP, site pode violar LGPD.",
+        })
+
+    # 7. dataLayer vazio (so com gtm.js)
+    if datalayer is not None:
+        if isinstance(datalayer, list) and len(datalayer) <= 1:
+            flags.append({
+                "severity": "medium",
+                "flag": "datalayer_empty",
+                "title": "dataLayer praticamente vazio",
+                "detail": "Sem variaveis customizadas no dataLayer alem do gtm.js. Nao ha contexto sendo passado ao GTM — eventos ricos (user_id, ecommerce, form_step) sao impossiveis.",
+            })
+
+    # 8. GTM instalado sem GA4 nem Pixel
+    if has_gtm and not has_ga4 and not has_pixel:
+        flags.append({
+            "severity": "critical",
+            "flag": "gtm_without_analytics",
+            "title": "GTM instalado sem GA4 nem Meta Pixel",
+            "detail": "Container GTM carrega mas nao dispara nenhuma tag de analytics ou ads conhecida. Investimento em midia opera cego — sem atribuicao de conversao.",
+        })
+
+    # 9. GA4 instalado mas sem Google Ads vinculado
+    has_gads = bool(ids_found.get("google_ads"))
+    if has_ga4 and not has_gads:
+        flags.append({
+            "severity": "low",
+            "flag": "ga4_no_google_ads",
+            "title": "GA4 presente mas sem tag Google Ads",
+            "detail": "Nao e red flag se cliente nao faz Google Ads. Se faz, conversoes nao estao importando para Ads — revisar vinculo GA4↔Ads.",
+        })
+
+    # 10. Multiplos containers GTM
+    gtms = ids_found.get("gtm") or []
+    if len(gtms) > 1:
+        flags.append({
+            "severity": "medium",
+            "flag": "multiple_gtm_containers",
+            "title": f"{len(gtms)} containers GTM carregados",
+            "detail": f"IDs: {gtms}. Aumenta JS bundle, pode causar conflitos de eventos e confusao de ownership.",
+        })
+
+    return flags
+
+
+async def detect_cro_elements(page: Page):
+    """Avaliacao profunda de elementos CRO visiveis na pagina."""
+    js = """
+    () => {
+      const text = (el) => (el?.textContent || '').trim().replace(/\\s+/g,' ');
+      const isVisible = (el) => {
+        if (!el) return false;
+        const rect = el.getBoundingClientRect();
+        const style = window.getComputedStyle(el);
+        return rect.width > 0 && rect.height > 0 && style.display !== 'none' && style.visibility !== 'hidden' && parseFloat(style.opacity) > 0;
+      };
+
+      // CTAs
+      const ctas = [...document.querySelectorAll('a, button')]
+        .filter(el => isVisible(el))
+        .map(el => {
+          const t = text(el);
+          if (!t || t.length > 60) return null;
+          const rect = el.getBoundingClientRect();
+          const href = el.getAttribute('href') || '';
+          const isWhatsApp = /wa\\.me|api\\.whatsapp/i.test(href);
+          const isTel = href.startsWith('tel:');
+          const isMail = href.startsWith('mailto:');
+          return {
+            text: t,
+            tag: el.tagName.toLowerCase(),
+            href: href.substring(0, 200),
+            is_whatsapp: isWhatsApp,
+            is_tel: isTel,
+            is_mail: isMail,
+            above_fold: rect.top < window.innerHeight,
+            width: Math.round(rect.width),
+            height: Math.round(rect.height),
+          };
+        })
+        .filter(Boolean);
+
+      // Forms
+      const forms = [...document.querySelectorAll('form')].map(f => {
+        const inputs = [...f.querySelectorAll('input, select, textarea')]
+          .filter(el => !['hidden','submit','button'].includes(el.type))
+          .map(el => ({
+            name: el.name || el.id || '',
+            type: el.type || el.tagName.toLowerCase(),
+            required: el.hasAttribute('required'),
+            placeholder: el.placeholder || '',
+          }));
+        return {
+          id: f.id || '',
+          action: (f.action || '').substring(0, 200),
+          method: (f.method || 'get').toLowerCase(),
+          field_count: inputs.length,
+          fields: inputs,
+          has_consent_checkbox: !!f.querySelector('input[type="checkbox"]'),
+        };
+      });
+
+      // Prova social (heuristica)
+      const bodyText = document.body.innerText.toLowerCase();
+      const socialProof = {
+        has_testimonials: /depoimento|testimonial|avalia[cç][aã]o|review/i.test(bodyText),
+        has_ratings: !!document.querySelector('[class*="star"], [class*="rating"], [itemprop="ratingValue"]'),
+        has_numbers: /[0-9]+\\s*(clientes|pacientes|alunos|pets|atendimentos|projetos|anos)/i.test(bodyText),
+        has_certifications: /(crmv|oab|crefito|crm|certificado|selo|iso\\s)/i.test(bodyText),
+        has_logos_clients: !!document.querySelector('[class*="clients"], [class*="parceir"], [class*="logos"]'),
+      };
+
+      // Urgencia/escassez
+      const urgency = {
+        has_countdown: !!document.querySelector('[class*="countdown"], [class*="timer"], [id*="countdown"]'),
+        has_limited: /vagas limitadas|[uú]ltimas? vagas|termina hoje|s[oó] hoje|oferta expira/i.test(bodyText),
+        has_discount: /desconto|off|%\\s*(off|menos)/i.test(bodyText),
+      };
+
+      // Confianca / credenciais
+      const trust = {
+        has_address: /(rua|avenida|av\\.|travessa|alameda)\\s+[A-Z]/i.test(document.body.innerText),
+        has_cnpj: /cnpj[:\\s]*[\\d\\.\\/\\-]+/i.test(document.body.innerText),
+        has_phone: !!document.querySelector('a[href^="tel:"]'),
+        has_email: !!document.querySelector('a[href^="mailto:"]'),
+        has_privacy_link: /pol[ií]tica\\s+de\\s+privacidade|privacy\\s+policy/i.test(bodyText),
+        has_terms_link: /termos\\s+de\\s+uso|terms\\s+of/i.test(bodyText),
+      };
+
+      // WhatsApp
+      const waLinks = [...document.querySelectorAll('a[href*="wa.me/"], a[href*="api.whatsapp.com"]')].map(a => ({
+        text: text(a).substring(0, 80),
+        href: a.getAttribute('href') || '',
+        visible: isVisible(a),
+        floating: /fix|sticky/i.test(window.getComputedStyle(a).position) || !!a.closest('[class*="float"],[class*="sticky"],[class*="fixed"]'),
+      }));
+
+      // Videos
+      const videos = [...document.querySelectorAll('video, iframe[src*="youtube"], iframe[src*="vimeo"], iframe[src*="wistia"]')].map(v => ({
+        tag: v.tagName.toLowerCase(),
+        src: (v.src || v.getAttribute('src') || '').substring(0, 200),
+      }));
+
+      // Hero analysis (first viewport)
+      const h1 = document.querySelector('h1');
+      const aboveFoldCtas = ctas.filter(c => c.above_fold).length;
+
+      return {
+        cta_count: ctas.length,
+        cta_above_fold: aboveFoldCtas,
+        cta_list: ctas.slice(0, 20),
+        whatsapp_links: waLinks,
+        forms: forms,
+        form_count: forms.length,
+        avg_fields_per_form: forms.length ? Math.round(forms.reduce((s,f)=>s+f.field_count,0)/forms.length) : 0,
+        social_proof: socialProof,
+        urgency: urgency,
+        trust: trust,
+        videos: videos,
+        h1_text: h1 ? text(h1).substring(0, 200) : null,
+        page_text_length: document.body.innerText.length,
+      };
+    }
+    """
+    try:
+        return await page.evaluate(js)
+    except Exception as e:
+        return {"error": str(e)}
+
+
+async def dump_window_globals_and_datalayer(page: Page):
+    """Lista props em window (filtradas) + dataLayer."""
+    js = """
+    () => {
+      const interesting = [
+        'gtag','dataLayer','google_tag_manager','ga','_gaq',
+        'fbq','_fbq','ttq','pintrk','_linkedin_data_partner_ids','twq',
+        'clarity','hj','_hjSettings','_mfq','FS',
+        'Intercom','_hsq','HubSpotConversations','zE','$zopim','$crisp','jivo_api','Tawk_API',
+        'OneTrust','OptanonConsent','Cookiebot','UC_UI',
+        'RdstationPopup','RDStationForms',
+        'Shopify','vtex','vtexjs','elementorFrontend','__NEXT_DATA__','React','Vue'
+      ];
+      const found = interesting.filter(k => typeof window[k] !== 'undefined');
+      let dl = null;
+      try {
+        if (Array.isArray(window.dataLayer)) {
+          dl = window.dataLayer.map(item => {
+            try { return JSON.parse(JSON.stringify(item)); } catch(e) { return String(item).substring(0,200); }
+          }).slice(0, 50);
+        }
+      } catch(e) {}
+      return { globals: found, datalayer: dl, datalayer_length: (Array.isArray(window.dataLayer) ? window.dataLayer.length : null) };
+    }
+    """
+    try:
+        return await page.evaluate(js)
+    except Exception as e:
+        return {"globals": [], "datalayer": None, "datalayer_length": None, "error": str(e)}
+
+
+async def audit_one_pass(browser, url: str, device: str, wait_for_consent: bool):
+    """Navega a URL uma vez (mobile ou desktop) e retorna snapshot completo."""
+    is_mobile = device == "mobile"
+    context = await browser.new_context(
+        user_agent=USER_AGENT_MOBILE if is_mobile else USER_AGENT_DESKTOP,
+        viewport=VIEWPORT_MOBILE if is_mobile else VIEWPORT_DESKTOP,
+        is_mobile=is_mobile,
+        locale="pt-BR",
+        timezone_id="America/Sao_Paulo",
+    )
+    page = await context.new_page()
+    netlog = NetworkLog()
+    page.on("request", netlog.on_request)
+    page.on("response", netlog.on_response)
+
+    nav_error = None
+    status = None
+    try:
+        response = await page.goto(url, wait_until="domcontentloaded", timeout=NAV_TIMEOUT_MS)
+        status = response.status if response else None
+        try:
+            await page.wait_for_load_state("networkidle", timeout=IDLE_TIMEOUT_MS)
+        except PWTimeout:
+            pass
+        # Scroll para ativar lazy loaders
+        try:
+            await page.evaluate("() => window.scrollTo(0, document.body.scrollHeight)")
+            await page.wait_for_timeout(1500)
+            await page.evaluate("() => window.scrollTo(0, 0)")
+            await page.wait_for_timeout(500)
+        except Exception:
+            pass
+    except Exception as e:
+        nav_error = str(e)
+
+    # Dump state
+    try:
+        html = await page.content()
+    except Exception:
+        html = ""
+    try:
+        cookies = await context.cookies()
+    except Exception:
+        cookies = []
+
+    globals_info = await dump_window_globals_and_datalayer(page)
+    cro = await detect_cro_elements(page) if not nav_error else {}
+
+    # Screenshot full-page (compressao leve)
+    screenshot_b64 = None
+    try:
+        ss_bytes = await page.screenshot(full_page=True, type="jpeg", quality=60)
+        import base64
+        screenshot_b64 = "data:image/jpeg;base64," + base64.b64encode(ss_bytes).decode("ascii")
+    except Exception:
+        pass
+
+    await context.close()
+
+    return {
+        "device": device,
+        "status": status,
+        "nav_error": nav_error,
+        "html_length": len(html),
+        "html_preview": html[:500],
+        "html": html,  # usado internamente pela deteccao, removido do output
+        "cookies": [{"name": c["name"], "domain": c.get("domain",""), "secure": c.get("secure", False), "httpOnly": c.get("httpOnly", False), "sameSite": c.get("sameSite","")} for c in cookies],
+        "window_globals": globals_info.get("globals", []),
+        "datalayer": globals_info.get("datalayer"),
+        "datalayer_length": globals_info.get("datalayer_length"),
+        "cro_elements": cro,
+        "requests_count": len(netlog.requests),
+        "responses_count": len(netlog.responses),
+        "_netlog": netlog,  # usado internamente, removido do output
+        "screenshot_fullpage": screenshot_b64,
+    }
+
+
+async def audit_compliance_pass(browser, url: str):
+    """Segunda passada: navega com flag de 'pre-consent' simulada (sem interagir com CMP).
+    Registra quais trackers disparam ANTES de qualquer consentimento.
+    """
+    # Mesma logica do pass principal, mas sem aceitar nenhum banner
+    context = await browser.new_context(
+        user_agent=USER_AGENT_DESKTOP,
+        viewport=VIEWPORT_DESKTOP,
+        locale="pt-BR",
+        timezone_id="America/Sao_Paulo",
+    )
+    page = await context.new_page()
+    netlog = NetworkLog()
+    page.on("request", netlog.on_request)
+
+    nav_error = None
+    try:
+        await page.goto(url, wait_until="domcontentloaded", timeout=NAV_TIMEOUT_MS)
+        try:
+            await page.wait_for_load_state("networkidle", timeout=IDLE_TIMEOUT_MS)
+        except PWTimeout:
+            pass
+        # NAO interagir com CMP — ficar parado
+        await page.wait_for_timeout(2500)
+    except Exception as e:
+        nav_error = str(e)
+
+    # Contar tracker requests ANTES de consent
+    tracker_patterns = [
+        "google-analytics.com",
+        "googletagmanager.com/gtm.js",
+        "facebook.com/tr",
+        "facebook.net/en_US/fbevents.js",
+        "analytics.tiktok.com",
+        "clarity.ms",
+        "hotjar.com",
+        "linkedin.com/li/",
+        "doubleclick.net",
+    ]
+    pre_consent_trackers = {}
+    for r in netlog.requests:
+        for pat in tracker_patterns:
+            if pat in r["url"]:
+                pre_consent_trackers.setdefault(pat, []).append(r["url"])
+                break
+
+    await context.close()
+
+    return {
+        "nav_error": nav_error,
+        "pre_consent_trackers": pre_consent_trackers,
+        "pre_consent_tracker_count": sum(len(v) for v in pre_consent_trackers.values()),
+    }
+
+
+def build_compliance_report(compliance_pass, detected_tools):
+    """Monta bloco de compliance LGPD."""
+    cmps = {k: detected_tools[k] for k in ["onetrust", "cookiebot", "usercentrics", "trustarc", "termly"] if k in detected_tools}
+    has_cmp = bool(cmps)
+    pre_count = compliance_pass.get("pre_consent_tracker_count", 0)
+    pre_trackers = compliance_pass.get("pre_consent_trackers", {})
+
+    issues = []
+    if not has_cmp:
+        issues.append("Sem CMP detectado — sem mecanismo de consentimento.")
+    if pre_count > 0:
+        issues.append(f"{pre_count} requests de tracking disparam ANTES de qualquer consentimento.")
+        for pat, urls in pre_trackers.items():
+            issues.append(f"  • {pat}: {len(urls)} request(s)")
+
+    # Score 0-10
+    score = 10
+    if not has_cmp:
+        score -= 5
+    if pre_count > 0:
+        score -= min(5, pre_count)
+    score = max(0, score)
+
+    status = "compliant" if (has_cmp and pre_count == 0) else ("partial" if has_cmp else "non_compliant")
+
+    return {
+        "status": status,
+        "score": score,
+        "has_cmp": has_cmp,
+        "cmps_detected": list(cmps.keys()),
+        "pre_consent_trackers": pre_trackers,
+        "pre_consent_tracker_count": pre_count,
+        "issues": issues,
+    }
+
+
+def sanitize_output(obj):
+    """Remove campos pesados/internos do output final."""
+    if isinstance(obj, dict):
+        return {k: sanitize_output(v) for k, v in obj.items() if not k.startswith("_") and k != "html"}
+    if isinstance(obj, list):
+        return [sanitize_output(x) for x in obj]
+    return obj
+
+
+async def run_audit(url: str, out_path: str, skip_compliance: bool = False):
+    signatures = load_signatures()
+    result = {
+        "url": url,
+        "fetched_at": datetime.now(timezone.utc).isoformat(),
+        "engine": "playwright-chromium",
+    }
+
+    async with async_playwright() as pw:
+        print(">> Iniciando Chromium headless...", file=sys.stderr)
+        browser = await pw.chromium.launch(headless=True, args=["--disable-blink-features=AutomationControlled"])
+
+        print(">> Pass 1: Desktop (full audit)...", file=sys.stderr)
+        desktop_pass = await audit_one_pass(browser, url, "desktop", wait_for_consent=False)
+
+        print(">> Pass 2: Mobile (full audit)...", file=sys.stderr)
+        mobile_pass = await audit_one_pass(browser, url, "mobile", wait_for_consent=False)
+
+        compliance_pass = None
+        if not skip_compliance:
+            print(">> Pass 3: Compliance LGPD (pre-consent tracking)...", file=sys.stderr)
+            compliance_pass = await audit_compliance_pass(browser, url)
+
+        await browser.close()
+
+    # Combinar netlogs de desktop + mobile para deteccao de ferramentas (mais robusto)
+    combined_netlog = NetworkLog()
+    combined_netlog.requests = desktop_pass["_netlog"].requests + mobile_pass["_netlog"].requests
+    combined_netlog.responses = desktop_pass["_netlog"].responses + mobile_pass["_netlog"].responses
+
+    detected = detect_tools(
+        signatures,
+        combined_netlog,
+        desktop_pass.get("html", "") + mobile_pass.get("html", ""),
+        list(set(desktop_pass.get("window_globals", []) + mobile_pass.get("window_globals", []))),
+        desktop_pass.get("cookies", []) + mobile_pass.get("cookies", []),
+    )
+    ids_found = extract_ids_from_urls(combined_netlog)
+    ga4_events = parse_ga4_events(combined_netlog)
+    meta_events = parse_meta_pixel_events(combined_netlog)
+    quality_flags = compute_quality_flags(detected, ga4_events, meta_events, desktop_pass.get("datalayer"), ids_found)
+
+    compliance_report = None
+    if compliance_pass is not None:
+        compliance_report = build_compliance_report(compliance_pass, detected)
+
+    # Categorizar ferramentas
+    by_category = {}
+    for tid, info in detected.items():
+        by_category.setdefault(info["category"], []).append(info["name"])
+
+    result["tracking_stack"] = {
+        "tools_detected": detected,
+        "ids_found": ids_found,
+        "categories_summary": {cat: sorted(names) for cat, names in by_category.items()},
+        "total_tools": len(detected),
+    }
+
+    result["events_fired"] = {
+        "ga4": ga4_events,
+        "meta_pixel": meta_events,
+        "ga4_event_count": len(ga4_events),
+        "meta_event_count": len(meta_events),
+        "ga4_event_names": sorted(set(e["name"] for e in ga4_events if e.get("name"))),
+        "meta_event_names": sorted(set(e["name"] for e in meta_events if e.get("name"))),
+    }
+
+    result["datalayer"] = {
+        "desktop": {
+            "length": desktop_pass.get("datalayer_length"),
+            "sample": desktop_pass.get("datalayer"),
+        },
+        "mobile": {
+            "length": mobile_pass.get("datalayer_length"),
+            "sample": mobile_pass.get("datalayer"),
+        },
+    }
+
+    result["cro_elements"] = {
+        "desktop": desktop_pass.get("cro_elements"),
+        "mobile": mobile_pass.get("cro_elements"),
+    }
+
+    result["quality_flags"] = quality_flags
+
+    result["compliance_lgpd"] = compliance_report
+
+    result["navigation"] = {
+        "desktop": {
+            "status": desktop_pass.get("status"),
+            "nav_error": desktop_pass.get("nav_error"),
+            "requests_count": desktop_pass.get("requests_count"),
+            "responses_count": desktop_pass.get("responses_count"),
+            "cookies_count": len(desktop_pass.get("cookies") or []),
+        },
+        "mobile": {
+            "status": mobile_pass.get("status"),
+            "nav_error": mobile_pass.get("nav_error"),
+            "requests_count": mobile_pass.get("requests_count"),
+            "responses_count": mobile_pass.get("responses_count"),
+            "cookies_count": len(mobile_pass.get("cookies") or []),
+        },
+    }
+
+    result["screenshots_fullpage"] = {
+        "desktop": desktop_pass.get("screenshot_fullpage"),
+        "mobile": mobile_pass.get("screenshot_fullpage"),
+    }
+
+    # Limpar campos internos
+    result = sanitize_output(result)
+
+    # Escrever output
+    os.makedirs(os.path.dirname(out_path) or ".", exist_ok=True)
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(result, f, ensure_ascii=False, indent=2)
+
+    print(f"[OK] Deep audit salvo em {out_path}", file=sys.stderr)
+    print(f"     Ferramentas detectadas: {len(detected)}", file=sys.stderr)
+    print(f"     Eventos GA4: {len(ga4_events)} | Meta Pixel: {len(meta_events)}", file=sys.stderr)
+    print(f"     Red flags: {len(quality_flags)}", file=sys.stderr)
+    if compliance_report:
+        print(f"     Compliance: {compliance_report['status']} (score {compliance_report['score']}/10)", file=sys.stderr)
+
+
+def main():
+    if len(sys.argv) < 3:
+        print("Uso: page_audit_deep.py <url> <output_json> [--skip-compliance]", file=sys.stderr)
+        sys.exit(1)
+    url = sys.argv[1]
+    out_path = sys.argv[2]
+    skip_compliance = "--skip-compliance" in sys.argv
+    asyncio.run(run_audit(url, out_path, skip_compliance=skip_compliance))
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/gt-diagnostico-cro/scripts/page_audit_deep.sh
+++ b/.agents/skills/gt-diagnostico-cro/scripts/page_audit_deep.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# page_audit_deep.sh — Orquestra a auditoria PROFUNDA de uma URL (Playwright).
+# Complementa page_audit.sh (PSI + on-page estatico) com:
+#   - Tracking stack (GTM, GA4, Meta Pixel, Clarity, etc.)
+#   - Eventos disparados (GA4 + Meta Pixel capturados via network)
+#   - dataLayer dump
+#   - CRO elements (CTAs, forms, WhatsApp, prova social)
+#   - Compliance LGPD (pre-consent tracker detection)
+#   - Quality flags (UA legacy, pixel duplicado, etc.)
+#
+# Uso:  page_audit_deep.sh <client_dir> <url>
+# Ex:   page_audit_deep.sh squads/{squad}/clientes/{cliente} https://www.site-do-cliente.com.br
+#
+# Le:    <client_dir>/client.json
+# Grava: <client_dir>/cache/page_audit_deep-<timestamp>.json (raw)
+#        <client_dir>/client.json (campo page_audit_deep com resumo)
+
+set -euo pipefail
+
+CLIENT_DIR="${1:?Uso: page_audit_deep.sh <client_dir> <url>}"
+URL="${2:?Uso: page_audit_deep.sh <client_dir> <url>}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PY_SCRIPT="$SCRIPT_DIR/page_audit_deep.py"
+
+if [ ! -f "$PY_SCRIPT" ]; then
+  echo "ERROR: page_audit_deep.py nao encontrado em $PY_SCRIPT" >&2
+  exit 1
+fi
+
+# Cache dir
+mkdir -p "$CLIENT_DIR/cache"
+TS=$(date -u +%Y%m%d-%H%M%S)
+RAW_OUT="$CLIENT_DIR/cache/page_audit_deep-$TS.json"
+
+echo ">> Deep audit (Playwright: 3 passes — desktop full, mobile full, compliance pre-consent)..."
+python3 "$PY_SCRIPT" "$URL" "$RAW_OUT"
+
+# O Builders Hub não exige client.json. Quando ele não existe, preserve o
+# cache bruto e deixe a skill interpretar os dados junto com a KB do cliente.
+if [ ! -f "$CLIENT_DIR/client.json" ]; then
+  echo "[OK] Auditoria profunda bruta concluída; client.json ausente, merge ignorado."
+  echo "Cache raw: $RAW_OUT"
+  exit 0
+fi
+
+# Merge resumo no client.json
+python3 << PYEOF
+import json
+from datetime import datetime, timezone
+
+raw_path = "$RAW_OUT"
+client_path = "$CLIENT_DIR/client.json"
+
+with open(raw_path, encoding='utf-8') as f:
+    raw = json.load(f)
+
+with open(client_path, encoding='utf-8') as f:
+    client = json.load(f)
+
+# Summary condensado — raw fica no cache (inclui screenshots full-page pesados)
+tracking = raw.get("tracking_stack") or {}
+events = raw.get("events_fired") or {}
+cro_el = raw.get("cro_elements") or {}
+dl = raw.get("datalayer") or {}
+flags = raw.get("quality_flags") or []
+compliance = raw.get("compliance_lgpd") or {}
+nav = raw.get("navigation") or {}
+
+# tools_detected no summary: so id+name+category (sem evidence detalhada)
+tools_light = {}
+for tid, info in (tracking.get("tools_detected") or {}).items():
+    tools_light[tid] = {
+        "name": info.get("name"),
+        "category": info.get("category"),
+    }
+
+summary = {
+    "fetched_at": raw.get("fetched_at"),
+    "url": raw.get("url"),
+    "cache_file": raw_path.replace("$CLIENT_DIR/", ""),
+    "engine": raw.get("engine"),
+    "tracking_stack": {
+        "tools_detected": tools_light,
+        "ids_found": tracking.get("ids_found") or {},
+        "categories_summary": tracking.get("categories_summary") or {},
+        "total_tools": tracking.get("total_tools") or 0,
+    },
+    "events_fired": {
+        "ga4_event_count": events.get("ga4_event_count") or 0,
+        "meta_event_count": events.get("meta_event_count") or 0,
+        "ga4_event_names": events.get("ga4_event_names") or [],
+        "meta_event_names": events.get("meta_event_names") or [],
+        # eventos detalhados so no raw
+    },
+    "datalayer": {
+        "desktop_length": (dl.get("desktop") or {}).get("length"),
+        "mobile_length": (dl.get("mobile") or {}).get("length"),
+    },
+    "cro_elements": cro_el,  # leve o suficiente p/ ficar no client.json
+    "quality_flags": flags,
+    "compliance_lgpd": compliance,
+    "navigation": nav,
+    # Screenshots full-page NAO vao pro client.json (pesados) — so no raw
+}
+
+client["page_audit_deep"] = summary
+
+with open(client_path, "w", encoding="utf-8") as f:
+    json.dump(client, f, ensure_ascii=False, indent=2)
+
+print(f"[OK] page_audit_deep salvo em client.json (raw: {raw_path})")
+PYEOF
+
+echo "Cache raw: $RAW_OUT"

--- a/.agents/skills/gt-diagnostico-cro/scripts/requirements-deep.txt
+++ b/.agents/skills/gt-diagnostico-cro/scripts/requirements-deep.txt
@@ -1,0 +1,2 @@
+playwright>=1.40
+pyyaml>=6.0

--- a/.agents/skills/gt-diagnostico-cro/scripts/requirements.txt
+++ b/.agents/skills/gt-diagnostico-cro/scripts/requirements.txt
@@ -1,0 +1,3 @@
+requests>=2.31
+beautifulsoup4>=4.12
+lxml>=4.9

--- a/.agents/skills/gt-diagnostico-maturidade-digital/SKILL.md
+++ b/.agents/skills/gt-diagnostico-maturidade-digital/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: gt-diagnostico-maturidade-digital
+description: "Analisa a maturidade digital do cliente (5 pilares: Mídia, Orgânico/SEO, Criativos, CRM, CRO) com base em dados V4MOS ou briefing. Gera score por pilar, benchmark setorial e sequência de turnaround. Use quando o operador disser 'maturidade', 'diagnóstico digital', 'score', ou na Semana 2 (POP 2.4)."
+area: gt
+author: luizfreitasv4
+version: 1.0.0
+dependencies: []
+outputs: ["gt-diagnostico-maturidade-digital.json"]
+week: 2
+estimated_time: "30-45 min"
+v4mos_integration: connectors_only
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta versao foi portada do sistema de Estruturacao Estrategica. As regras abaixo tem precedencia sobre caminhos e persistencia citados no fluxo original:
+
+- Trabalhe somente em `squads/{squad}/clientes/{cliente}/`, nunca em um diretorio `clientes/` solto na raiz.
+- Leia primeiro o `CLAUDE.md` ou `AGENTS.md` da KB, `mission-control/`, `calls/`, `docs/` e `campanhas/`.
+- Se `client.json` existir, use-o como fonte complementar. Se nao existir, derive o contexto da KB e do Mission Control; nao exija nem invente esse arquivo.
+- Salve entregaveis em `squads/{squad}/clientes/{cliente}/outputs/`, em JSON e Markdown quando o fluxo pedir ambos.
+- Registre decisoes e progresso no `mission-control/historico-checkins.md` ou no arquivo de historico equivalente encontrado na KB.
+- Resolva recursos empacotados a partir do proprio diretorio desta skill. Se uma integracao externa nao estiver configurada, declare o gap e continue apenas com os dados reais disponiveis.
+
+
+# Diagnóstico de Maturidade Digital (POP 2.4)
+
+> **Posição no fluxo:** sintetiza os diagnósticos de mídia, orgânico e criativos em um score por pilar. Rode depois dos diagnósticos especializados e antes do posicionamento.
+
+Você é um estrategista sênior de marketing digital. Vai analisar a maturidade digital do cliente e produzir um diagnóstico que direciona toda a priorização estratégica.
+
+> **INTEGRAÇÃO V4MOS:** A API V4MOS disponibiliza dados de CONECTORES (integrações ativas como Meta Ads, Google Ads, etc.). Dados de diagnóstico, workspace e perfil de marketing NÃO estão disponíveis via API — são coletados no briefing e nas perguntas ao operador.
+
+## Dados necessários
+
+### Fonte V4MOS (conectores)
+Leia `squads/{squad}/clientes/{cliente}/client.json` (seção `connectors`). Se `fetched_at` existir e não for null, extraia:
+- `google_ads` → campanhas Google Ads (total_campaigns, total_cost, avg_cpa, lista de campanhas com status)
+- `facebook_ads` → campanhas Meta Ads (total_campaigns, total_spend, avg_cpm, lista de campanhas)
+- Quais plataformas estão conectadas = indicador de maturidade em mídia paga
+
+Se `connectors.fetched_at` for nulo ou inexistente, use `/v4mos-dados-meta-ads` para Meta Ads. Para Google Ads, use exportações ou dados já presentes na KB. Se não houver integração, siga com briefing e evidências disponíveis, marcando claramente a limitação.
+
+**Formato atual dos connectors:**
+```json
+{
+  "fetched_at": "2026-04-18T15:30:00Z",
+  "period": { "start": "2025-01-01", "end": "2026-04-18" },
+  "google_ads": { "total_campaigns": 15, "total_cost": 13975, "avg_cpa": 11.41, "campaigns": [...] },
+  "facebook_ads": { "total_campaigns": 15, "total_spend": 3472, "avg_cpm": 10.10, "campaigns": [...] }
+}
+```
+
+### Fonte principal: Briefing + Operador
+Leia `squads/{squad}/clientes/{cliente}/client.json (briefing)`. Extraia:
+- `identification.segment` → segmento para benchmark
+- `digital_situation` → situação digital declarada pelo cliente
+- `accesses` → quais acessos o operador já tem
+
+---
+
+## Geração
+
+Gere o output COMPLETO de uma vez usando os dados de `client.json` (briefing, connectors) e outputs de skills dependentes em `outputs/`.
+
+### Cenário A: V4MOS tem dados de conectores
+Se `client.json.connectors.fetched_at` não é null, incorpore no diagnóstico:
+- Período dos dados (`period.start` → `period.end`)
+- Google Ads: quantas campanhas, gasto total, CPA médio, status das campanhas (ENABLED/PAUSED)
+- Facebook Ads: quantas campanhas, gasto total, CPM médio, objetivos usados
+- Quais plataformas estão ausentes (ex: sem Google Analytics = gap de rastreamento)
+
+Isso dá uma visão real da maturidade — não só "tem mídia paga" mas "como está performando".
+
+### Cenário B: Diagnóstico baseado em briefing + operador (SEMPRE executado)
+O diagnóstico completo sempre usa os dados do briefing (`digital_situation`) e as seguintes informações. Se não encontrar no client.json, pergunte ao operador TUDO de uma vez:
+
+**Mídia Paga:** plataformas usadas, investimento mensal, pixel/tag configurado, ROAS ou CPA atual
+**Criativos:** criativos ativos, quem produz, frequência de atualização
+**CRO (Conversão):** site/LP existente, taxa de conversão, pontos de conversão
+**CRM:** CRM usado, registros de leads, automação de follow-up
+**SEO:** posição no Google, blog/conteúdo indexado, Google Meu Negócio
+
+### Output completo
+
+Consulte `references/scoring-framework.md` para calibrar a análise. Gere:
+
+**Resumo Executivo (máx. 3 parágrafos)**
+
+Escreva em tom direto, sem eufemismo. Se o score é ruim, diga que é ruim e por quê.
+
+Parágrafo 1: Score geral e o que significa na prática para o negócio. Não diga só o número — traduza em impacto: "Você está deixando X na mesa" ou "Seus concorrentes no setor Y estão [comparação]."
+
+Parágrafo 2: Os 2 maiores gaps que estão custando resultado AGORA. Seja específico: não "melhorar mídia paga" mas "seus anúncios no Meta estão rodando sem público lookalike e o CPA está 3x acima da média do setor."
+
+Parágrafo 3: Os 2 pontos fortes que precisam ser aproveitados/acelerados.
+
+**Score por Pilar (tabela)**
+
+| Pilar | Score | Classificação | Destaque |
+|-------|-------|---------------|----------|
+| Mídia Paga | X/100 | [Crítico/Baixo/Médio/Bom/Excelente] | [1 frase] |
+| Criativos | X/100 | ... | ... |
+| CRO | X/100 | ... | ... |
+| CRM | X/100 | ... | ... |
+| SEO | X/100 | ... | ... |
+| **GERAL** | **X/100** | ... | ... |
+
+Se não houver dados V4MOS, atribua scores estimados com base na conversa com o operador, marcando como "(estimado)" na tabela.
+
+**Prioridades de Ação (5 ações, ranqueadas)**
+
+Para cada ação:
+1. **O que fazer** (específico e acionável)
+2. **Por que é prioridade** (impacto esperado)
+3. **Esforço** (baixo/médio/alto)
+4. **Dependências** (o que precisa estar pronto antes)
+
+**Benchmark do Setor**
+
+Compare o score do cliente com a média do setor (use `references/scoring-framework.md`).
+- Quais pilares estão acima da média?
+- Quais estão abaixo?
+- Qual o gap mais crítico vs. o setor?
+
+### Estrutura visual (obrigatória)
+
+Siga o padrão canônico de `references/padrao-output.md`. Além dos campos acima, SEMPRE inclua:
+
+- **`summary_headline`** (max 200 char) — manchete com o veredito. Ex: "[Cliente] tem 5.2/10 de maturidade digital — Mídia e CRM são os pilares que mais travam crescimento."
+- **`summary_highlights`** (4-6 itens, `{category, label, value, subtext, tone}`) — para maturidade sugestões:
+  - `maturidade`: score geral, pilar mais forte, pilar mais fraco
+  - `posicao`: score vs benchmark do setor (gap %)
+  - `oportunidade`: pilar com maior upside e retorno estimado
+  - `risco`: pilar crítico que bloqueia outros
+- **`summary_key_findings`** (3-5 itens, `{category, text}`) — `vantagem|contexto|ameaca|acao`.
+
+### Ponto de alavancagem
+
+Em diagnóstico de maturidade, o ponto de alavancagem é o **pilar mais fraco com maior impacto sistêmico** (bloqueia outros pilares ou representa o maior gap vs benchmark). Estruture em `key_insight`:
+```json
+"key_insight": {
+  "headline": "Frase sobre o pilar-chave (ex: 'CRM em 2/10 bloqueia ROI de toda mídia paga')",
+  "context": "2-3 linhas sobre cascata de efeitos",
+  "numbered_reasons": ["(1) evidência do score baixo", "(2) efeito cascata", "(3) ROI de destravar"],
+  "discussion_anchor": "Por que o stakeholder precisa priorizar este pilar antes dos outros"
+}
+```
+
+Se o diagnóstico revelou maturidade baixa em todos os pilares (ex: score médio < 4) ou dados insuficientes, inclua `honesty_alert`.
+
+## Auto-validação
+
+Antes de mostrar ao operador, verifique:
+
+- [ ] Mencionou o cliente pelo nome?
+- [ ] Usou dados reais do client.json (não inventou)?
+- [ ] Nenhum item genérico (ex: "quer crescer", "qualidade e compromisso")?
+- [ ] Schema da skill validou?
+- [ ] Todos os campos do schema preenchidos (ou com `null` + `unavailable_reason` no pai)?
+- [ ] Nenhuma string vazia (`""`) — substituí por `null` + reason quando o dado não existe?
+- [ ] Estimativas marcadas com `estimated: true` ou `[E]`?
+- [ ] Consistente com outputs anteriores?
+- [ ] Resumo executivo traduz scores em impacto de negócio (não só números)?
+- [ ] Prioridades são específicas e acionáveis (não "melhorar mídia")?
+- [ ] Benchmark do setor está referenciado com fonte?
+- [ ] Tem `summary_headline` específico?
+- [ ] `summary_highlights` tem 4-6 itens com categorias e tons válidos?
+- [ ] `summary_key_findings` cobre pelo menos 3 dos 4 tipos?
+- [ ] Identificou `key_insight` (pilar-chave com efeito sistêmico)?
+- [ ] Se há fragilidade geral, incluiu `honesty_alert`?
+
+Se falhou → regenere silenciosamente. Não avise o operador.
+
+## Apresentação e decisões
+
+Apresente o output COMPLETO ao operador.
+
+Revise o output. O que está errado, exagerado ou faltando?
+
+- "A análise condiz com o que você vê no dia a dia do cliente?"
+- "As prioridades fazem sentido na ordem apresentada?"
+- "Tem algum contexto que muda a priorização? (ex: cliente já fechou contrato de mídia, CRM já está em implementação)"
+
+## Finalização
+
+Operador aprova (com ou sem ajustes).
+1. Salve em `squads/{squad}/clientes/{cliente}/outputs/gt-diagnostico-maturidade-digital.json` (com campo `summary` no topo)
+2. Atualize `client.json`: progress.skills → completed, version++, append em history[]
+3. Salve também uma versão Markdown do entregável na mesma pasta de outputs.
+4. Sugira a próxima skill com base nas dependências e no estado da KB
+   - "Diagnóstico de maturidade salvo. Fecha o bloco de diagnósticos da Semana 2; o próximo passo é o Posicionamento (geral-posicionamento-estrategico), que sintetiza tudo."
+   - O score por pilar e a sequência de turnaround alimentam o posicionamento e o forecast de mídia.

--- a/.agents/skills/gt-diagnostico-maturidade-digital/references/padrao-output.md
+++ b/.agents/skills/gt-diagnostico-maturidade-digital/references/padrao-output.md
@@ -1,0 +1,202 @@
+# Padrão de Output das Skills — V4 Estruturação IA
+
+Este documento define a **estrutura canônica** que todos os outputs de skill devem seguir para renderizar no portal com hierarquia visual consistente. O objetivo é que o operador e o stakeholder final abram qualquer entregável e encontrem o mesmo ritmo: manchete → KPIs → achados categorizados → ponto de alavancagem destacado → detalhes expansíveis.
+
+---
+
+## Princípios
+
+1. **Manchete antes de texto.** Toda skill abre com uma frase única e específica que resume a conclusão. Não é parágrafo, é headline.
+2. **Números em destaque, não escondidos no corpo do texto.** KPIs que importam viram cards. Texto corrido é para contexto, não para fato quantitativo.
+3. **Achados categorizados por intenção.** Cada insight é classificado como `vantagem | contexto | ameaca | acao` — o leitor identifica o tom antes de ler.
+4. **Ponto de alavancagem visualmente isolado.** Toda skill tem UM ponto onde a conversa com o stakeholder precisa acontecer. Esse ponto ganha hero visual (border, gradient, quote destacada).
+5. **Detalhe denso → colapsável.** Listas longas (concorrentes, itens de checklist, fontes) ficam em `<details>` para não afogar a leitura.
+
+---
+
+## Campos obrigatórios no JSON
+
+Todo output de skill DEVE ter estes campos no topo (antes dos campos específicos da skill):
+
+```json
+{
+  "client_name": "Nome do Cliente",
+  "summary": "Resumo em 1-2 frases. Específico, com dados reais. Alimenta o resumo executivo do portal.",
+
+  "summary_headline": "Manchete em 1 linha (max 120 caracteres). A frase que o stakeholder lê primeiro.",
+
+  "summary_highlights": [
+    {
+      "category": "posicao | competicao | janela | maturidade | oportunidade | risco",
+      "label": "Rótulo curto (max 30 char)",
+      "value": "Valor em destaque (número, %, status)",
+      "subtext": "Contexto em 1 linha (max 60 char)",
+      "tone": "green | yellow | red | blue | gray"
+    }
+  ],
+
+  "summary_key_findings": [
+    {
+      "category": "vantagem | contexto | ameaca | acao",
+      "text": "Achado em 1-2 linhas. Específico, acionável."
+    }
+  ]
+}
+```
+
+### Regras dos campos de summary
+
+**`summary_headline`**: É a ÚNICA frase que o stakeholder precisa ler se só tiver 5 segundos. Deve conter o veredito da skill. Exemplos bons:
+- ✓ "[Cliente] é o ÚNICO player premium da microrregião com [diferencial declarado] — janela competitiva de 12-18 meses."
+- ✗ "Análise de mercado concluída com sucesso."
+
+**`summary_highlights`** (4-6 itens): KPIs visuais. Categorias sugeridas:
+- `posicao` — onde o cliente está hoje vs potencial
+- `competicao` — quem disputa o mesmo espaço
+- `janela` — tempo/urgência
+- `maturidade` — estágio atual em algum eixo
+- `oportunidade` — tamanho do ganho possível
+- `risco` — tamanho da ameaça
+
+Agrupar de 2 em 2 por categoria no renderer (dá layout balanceado 3x2 ou 2x2).
+
+**`summary_key_findings`** (3-5 itens): Achados que embasam a manchete. Categorias:
+- `vantagem` (✓ verde) — o que o cliente tem a favor
+- `contexto` (i azul) — o que é fato do mercado, neutro
+- `ameaca` (! vermelho) — o que pode dar errado
+- `acao` (▸ laranja) — o que precisa ser feito
+
+---
+
+## Ponto de Alavancagem (hero block)
+
+Toda skill deve identificar **UM bloco que merece destaque visual especial** — o ponto onde a conversa estratégica precisa acontecer. O nome do campo varia por skill, mas a estrutura é consistente:
+
+```json
+{
+  "key_leverage_point": {
+    "headline": "Frase-manchete do ponto (pode ir como quote)",
+    "context": "Contexto em 2-3 linhas explicando o cenário",
+    "numbered_reasons": [
+      "Razão 1 (parse-friendly, pode começar com texto direto)",
+      "Razão 2",
+      "Razão 3"
+    ],
+    "discussion_anchor": "Frase curta sobre POR QUE este é o ponto de conversa com o stakeholder"
+  }
+}
+```
+
+Exemplos por skill:
+- `pesquisa-mercado` → `unexploited_opportunity` (whitespace estratégico)
+- `persona-icp` → persona principal + dor mais ignorada
+- `swot` → combinação força × oportunidade mais assimétrica
+- `posicionamento` → PUV vs alternativas descartadas
+- `diagnostico-midia` → canal mais subotimizado + upside estimado
+- `diagnostico-maturidade` → pilar mais fraco com maior impacto
+
+O renderer aplica:
+- Border verde 2px + gradient sutil
+- Selo "Whitespace Estratégico · Discussão com Stakeholder" no topo
+- Pill de viabilidade/urgência à direita
+- Quote/headline em card branco isolado
+- Razões numeradas em 3 círculos
+- Footer "💬 Momento de validar com a stakeholder"
+
+---
+
+## Alerta de honestidade
+
+Se a pesquisa/análise revelou fragilidade do cliente (não há diferencial real, ICP mal definido, mercado saturado, etc.), inclua:
+
+```json
+{
+  "honesty_alert": "Texto explicando a fragilidade encontrada e o que precisa ser feito antes de seguir."
+}
+```
+
+Esse campo renderiza em box amarelo/vermelho após os achados. **Nunca omita** se a realidade justifica. O valor do sistema depende de não vender aspiracional como real.
+
+---
+
+## Instrução para a IA da skill
+
+Em cada `SKILL.md`, incluir esta seção na geração:
+
+> ### Estrutura visual (obrigatória)
+>
+> Além dos campos específicos desta skill, gere SEMPRE:
+>
+> - `summary_headline` — manchete em 1 linha com o veredito
+> - `summary_highlights` — 4-6 KPIs categorizados (`posicao|competicao|janela|maturidade|oportunidade|risco`) com `{label, value, subtext, tone}`
+> - `summary_key_findings` — 3-5 achados categorizados (`vantagem|contexto|ameaca|acao`)
+> - `honesty_alert` se houver fragilidade
+>
+> Identifique o **ponto de alavancagem** desta skill (o bloco que merece hero visual) e estruture-o com headline + contexto + razões numeradas + discussion anchor.
+>
+> Consulte `references/padrao-output.md` para especificação completa.
+
+E na auto-validação:
+
+> - [ ] Tem `summary_headline` específico (não "análise concluída")?
+> - [ ] `summary_highlights` tem 4-6 itens com categorias válidas?
+> - [ ] `summary_key_findings` cobre pelo menos 3 dos 4 tipos (vantagem/contexto/ameaça/ação)?
+> - [ ] Identificou o ponto de alavancagem para discussão com stakeholder?
+> - [ ] Se há fragilidade, incluiu `honesty_alert`?
+
+---
+
+## Completude (regra crítica)
+
+**Todo campo definido no schema da skill é obrigatório no output.** Não omitir campos — o renderer assume que os campos do schema existem e quebra/fica vazio silenciosamente quando faltam.
+
+Se um dado **não pode ser obtido** (GA4 não instalado, conector não conectado, cliente não sabe, etc.), preencher com `null` E adicionar `unavailable_reason` no objeto pai:
+
+```json
+{
+  "current_conversion_rate": null,
+  "current_bounce_rate": null,
+  "avg_time_on_page": null,
+  "unavailable_reason": "GA4 não instalado no site — métricas de analytics não coletadas nesta auditoria"
+}
+```
+
+Para arrays vazios legitimamente (ex: nenhum competidor identificado), preencher com `[]` e adicionar uma nota no campo irmão `{campo}_note`:
+
+```json
+{
+  "competitors": [],
+  "competitors_note": "Nenhum concorrente direto identificado na microrregião após busca em Google Maps + Instagram."
+}
+```
+
+Para valores **estimados** (sem fonte pública), adicionar flag `[E]` no texto OU campo `estimated: true` no objeto:
+
+```json
+{ "tam_brl": 450000000, "estimated": true, "estimation_basis": "IBGE população × SEBRAE ticket médio" }
+```
+
+**Nunca** deixar string vazia (`""`), zero falso (`0` quando não é zero real), ou omitir o campo. Essas três formas são invisíveis para o renderer e geram o bug "coluna vazia".
+
+Valide o JSON contra o `schema.json` empacotado na skill e corrija campos ausentes ou `null` sem `unavailable_reason`.
+
+### Checklist adicional de auto-validação
+
+> - [ ] Todos os campos do schema estão presentes (preenchidos ou com `null` + `unavailable_reason`)?
+> - [ ] Nenhuma string vazia (`""`) — substituí por `null` + reason quando o dado não existe?
+> - [ ] Arrays vazios legítimos têm `{campo}_note` explicando por quê?
+> - [ ] Estimativas marcadas com `estimated: true` ou `[E]`?
+
+---
+
+## Tons de voz
+
+- `green` — oportunidade/vantagem/confirmado
+- `yellow` — atenção/potencial/médio
+- `red` — risco/ameaça/fraco
+- `blue` — contexto/informativo/neutro
+- `gray` — desativado/aspiracional/ausente
+
+Usar tons consistentemente: nunca pintar ameaça de verde ou vantagem de vermelho para "chamar atenção". O tom é semântico.
+
+---

--- a/.agents/skills/gt-diagnostico-maturidade-digital/references/scoring-framework.md
+++ b/.agents/skills/gt-diagnostico-maturidade-digital/references/scoring-framework.md
@@ -1,0 +1,232 @@
+# Framework de Scoring — Maturidade Digital
+
+## Visao Geral
+
+O score de maturidade digital avalia 5 pilares do marketing digital de um negocio. Cada pilar e pontuado de 0 a 100, e o score geral e a media ponderada.
+
+### Pesos dos Pilares
+
+| Pilar | Peso | Justificativa |
+|-------|------|---------------|
+| Midia Paga | 25% | Principal alavanca de resultado de curto prazo |
+| Criativos | 20% | Qualidade dos criativos impacta diretamente CPA e CTR |
+| CRO (Conversao) | 25% | De nada adianta trazer trafego se nao converte |
+| CRM | 15% | Retenção e reativação — receita recorrente |
+| SEO | 15% | Aquisição orgânica e autoridade de longo prazo |
+
+### Classificacoes
+
+| Score | Classificação | Significado |
+|-------|---------------|-------------|
+| 0-20 | Crítico | Praticamente inexistente ou completamente disfuncional. Ação imediata necessária. |
+| 21-40 | Baixo | Existe mas com gaps severos. Muitas oportunidades de melhoria básica. |
+| 41-60 | Médio | Funcional mas sem otimização. Concorrentes provavelmente estão melhor. |
+| 61-80 | Bom | Acima da média. Otimizações incrementais podem acelerar resultado. |
+| 81-100 | Excelente | Best-in-class. Manter e inovar. |
+
+---
+
+## Pilar 1: Midia Paga (Peso 25%)
+
+### Critérios de Avaliação
+
+| Critério | Peso no pilar | 0-20 (Crítico) | 21-40 (Baixo) | 41-60 (Médio) | 61-80 (Bom) | 81-100 (Excelente) |
+|----------|---------------|-----------------|----------------|----------------|--------------|---------------------|
+| Estrutura de conta | 15% | Sem conta ou conta bagunçada | Conta existe mas campanhas desorganizadas | Estrutura básica (1-2 campanhas por objetivo) | Estrutura por funil (topo/meio/fundo) | Estrutura granular com testes A/B contínuos |
+| Pixel/Tag | 15% | Sem pixel instalado | Pixel instalado mas sem eventos | Eventos básicos (PageView, Lead) | Eventos customizados + conversões offline | Tracking completo + server-side + CAPI |
+| Segmentação | 20% | Público amplo sem critério | Interesses básicos | Lookalike + custom audiences | Lookalike por valor + retargeting por etapa | Segmentação dinâmica + exclusões inteligentes |
+| Criativos em mídia | 15% | Sem criativos ou 1 criativo rodando há meses | 2-3 criativos sem variação | 5+ criativos com alguma variação | Testes A/B regulares (semanal) | Framework criativo com iteração contínua |
+| Budget allocation | 15% | Sem critério / "R$X por dia" | Baseado em feeling | Baseado em CPA meta | Alocação dinâmica por ROAS | Alocação por margem de contribuição |
+| Performance (ROAS/CPA) | 20% | CPA 5x+ acima da meta | CPA 2-5x acima | CPA até 2x acima | CPA na meta | CPA abaixo da meta com escala |
+
+### Benchmarks por Segmento — Mídia Paga
+
+| Segmento | Score médio | CPA referência | ROAS referência |
+|----------|-------------|----------------|-----------------|
+| E-commerce moda | 52 | R$25-45 | 4-8x |
+| E-commerce geral | 48 | R$20-60 | 3-6x |
+| Saúde/estética | 38 | R$30-80 | 3-5x |
+| Educação (cursos) | 45 | R$15-40 | 5-12x |
+| SaaS | 42 | R$50-200 | 4-10x |
+| Serviços locais | 35 | R$20-50 | N/A (lead) |
+| Imobiliário | 40 | R$80-300 | N/A (lead) |
+| Alimentação/restaurante | 32 | R$10-30 | 2-5x |
+| Varejo físico | 30 | R$15-40 | 3-7x |
+| B2B serviços | 38 | R$100-500 | N/A (lead) |
+| Advocacia | 35 | R$50-150 | N/A (lead) |
+
+---
+
+## Pilar 2: Criativos (Peso 20%)
+
+### Critérios de Avaliação
+
+| Critério | Peso no pilar | 0-20 (Crítico) | 21-40 (Baixo) | 41-60 (Médio) | 61-80 (Bom) | 81-100 (Excelente) |
+|----------|---------------|-----------------|----------------|----------------|--------------|---------------------|
+| Volume | 20% | 0-1 criativo ativo | 2-3 criativos | 4-8 criativos | 9-15 criativos | 15+ com rotação ativa |
+| Variedade de formatos | 20% | Só imagem estática | Imagem + carrossel | Imagem + vídeo curto | Múltiplos formatos + UGC | Full-stack (estático, vídeo, UGC, animação, catálogo) |
+| Qualidade visual | 20% | Amador / genérico Canva | Visual básico, sem identidade | Identidade visual presente | Identidade forte e consistente | Premium, para scroll, diferenciado |
+| Copy | 20% | Sem copy ou genérica | Copy básica sem hook | Hook + benefício | Hook + benefício + prova social + CTA | Framework de copy com variações A/B |
+| Renovação | 20% | Mesmo criativo há 3+ meses | Troca a cada 2-3 meses | Troca mensal | Troca semanal | Iteração contínua com dados |
+
+### Benchmarks por Segmento — Criativos
+
+| Segmento | Score médio | Volume típico | Formato dominante |
+|----------|-------------|---------------|-------------------|
+| E-commerce moda | 55 | 10-20 | Carrossel + vídeo curto |
+| Saúde/estética | 40 | 3-8 | Antes/depois + depoimento |
+| Educação | 50 | 8-15 | Vídeo longo + headline forte |
+| Serviços locais | 28 | 1-3 | Imagem estática |
+| B2B serviços | 32 | 2-5 | Imagem + texto longo |
+
+---
+
+## Pilar 3: CRO — Conversão (Peso 25%)
+
+### Critérios de Avaliação
+
+| Critério | Peso no pilar | 0-20 (Crítico) | 21-40 (Baixo) | 41-60 (Médio) | 61-80 (Bom) | 81-100 (Excelente) |
+|----------|---------------|-----------------|----------------|----------------|--------------|---------------------|
+| Proposta de valor | 20% | Não existe ou confusa | Existe mas genérica | Clara na homepage | Clara + diferenciada na primeira dobra | Testada e otimizada por conversão |
+| CTA principal | 15% | Sem CTA ou perdido | CTA existe mas fraco | CTA visível | CTA visível + urgência + benefício | Múltiplos CTAs contextuais por etapa |
+| Prova social | 15% | Nenhuma | Logo de clientes | Depoimentos genéricos | Depoimentos com nome + foto + resultado | Cases completos + rating + volume |
+| Velocidade/mobile | 15% | 5s+ de load / quebra no mobile | 3-5s / funciona no mobile | 2-3s / responsivo | <2s / mobile-first | <1.5s / PWA ou experience nativa |
+| Formulário/conversão | 15% | Sem formulário ou WhatsApp quebrado | Formulário básico no rodapé | Formulário acima da dobra | Formulário otimizado + poucos campos | Multi-step + lead scoring + automação |
+| Objeções | 10% | Não trata objeções | FAQ básico | FAQ + garantia | Tratamento de objeções ao longo da página | Prova social contextual + FAQ + chat + garantia |
+| Tracking | 10% | Sem Analytics | GA4 básico | GA4 + eventos de conversão | GA4 + funil completo + heatmap | Full tracking + atribuição + testes A/B |
+
+### Benchmarks por Segmento — CRO
+
+| Segmento | Score médio | Taxa de conversão referência (site) |
+|----------|-------------|--------------------------------------|
+| E-commerce | 45 | 1.5-3% |
+| Lead gen (serviços) | 38 | 3-8% |
+| Saúde/estética | 35 | 2-5% |
+| Educação (LP curso) | 50 | 5-15% |
+| SaaS (trial) | 42 | 2-7% |
+| Imobiliário | 32 | 1-3% |
+
+---
+
+## Pilar 4: CRM (Peso 15%)
+
+### Critérios de Avaliação
+
+| Critério | Peso no pilar | 0-20 (Crítico) | 21-40 (Baixo) | 41-60 (Médio) | 61-80 (Bom) | 81-100 (Excelente) |
+|----------|---------------|-----------------|----------------|----------------|--------------|---------------------|
+| Ferramenta | 20% | Sem CRM (planilha/WhatsApp) | CRM básico sem uso | CRM usado parcialmente | CRM ativo com pipeline configurado | CRM integrado com automações |
+| Pipeline | 20% | Sem pipeline | Pipeline genérico (1 etapa) | Pipeline por funil (3-5 etapas) | Pipeline com SLA por etapa | Pipeline com scoring + rotação automática |
+| Automação | 20% | Nenhuma | Auto-resposta básica | Sequência de nurturing | Réguas multicanal (email + WhatsApp) | Automação contextual por comportamento |
+| Dados/Higiene | 20% | Sem dados ou dados sujos | Dados básicos (nome + telefone) | Dados completos + segmentação | Enriquecimento + limpeza periódica | CDP com visão 360 do cliente |
+| Métricas | 20% | Sem métricas | Sabe quantos leads entram | Taxa de conversão por etapa | LTV + churn + velocidade de pipeline | Dashboard em tempo real + predições |
+
+### Benchmarks por Segmento — CRM
+
+| Segmento | Score médio | Ferramenta típica |
+|----------|-------------|-------------------|
+| E-commerce | 35 | Plataforma nativa (Shopify, Nuvemshop) |
+| Serviços (saúde, educação) | 30 | Kommo, RD Station, ou planilha |
+| SaaS | 55 | HubSpot, Pipedrive |
+| Imobiliário | 40 | CRM específico (Anapro, CV) |
+| Varejo | 25 | Nenhum ou WhatsApp manual |
+
+---
+
+## Pilar 5: SEO (Peso 15%)
+
+### Critérios de Avaliação
+
+| Critério | Peso no pilar | 0-20 (Crítico) | 21-40 (Baixo) | 41-60 (Médio) | 61-80 (Bom) | 81-100 (Excelente) |
+|----------|---------------|-----------------|----------------|----------------|--------------|---------------------|
+| SEO técnico | 25% | Site sem HTTPS ou não indexado | Erros graves (404, canonical) | Técnico básico OK | Sitemap + robots + schema markup | Core Web Vitals verde + schema rico |
+| Conteúdo | 25% | Sem blog/conteúdo | Blog com 1-5 posts antigos | Blog ativo mas sem estratégia | Blog com palavras-chave mapeadas | Cluster de conteúdo + internal linking |
+| Autoridade | 20% | DA 0-10 / sem backlinks | DA 10-20 | DA 20-35 | DA 35-50 | DA 50+ com backlinks relevantes |
+| Local SEO | 15% | Sem GMB | GMB criado mas incompleto | GMB completo + fotos | GMB otimizado + reviews | GMB dominante + pack local |
+| Keywords | 15% | Não ranqueia para nada | Ranqueia para marca própria | Ranqueia para 5-10 termos | Ranqueia top 10 para termos relevantes | Domina 50+ keywords no nicho |
+
+### Benchmarks por Segmento — SEO
+
+| Segmento | Score médio | Importância relativa |
+|----------|-------------|---------------------|
+| E-commerce | 35 | Alta (tráfego orgânico escala) |
+| Serviços locais | 40 | Muito alta (GMB é decisivo) |
+| SaaS | 50 | Alta (conteúdo é canal principal) |
+| Saúde | 30 | Média-alta (busca por especialista) |
+| Educação | 45 | Alta (busca por curso) |
+| Restaurante | 38 | Alta (GMB + reviews) |
+
+---
+
+## Score Geral — Cálculo
+
+```
+score_geral = (midia_paga * 0.25) + (criativos * 0.20) + (cro * 0.25) + (crm * 0.15) + (seo * 0.15)
+```
+
+### Interpretação do Score Geral por Segmento
+
+| Segmento | Score médio geral | Faixa "normal" |
+|----------|-------------------|----------------|
+| E-commerce moda/geral | 42 | 30-55 |
+| Saúde/estética | 34 | 20-45 |
+| Educação | 46 | 35-60 |
+| SaaS | 45 | 30-60 |
+| Serviços locais | 32 | 20-45 |
+| Imobiliário | 36 | 25-50 |
+| Alimentação | 28 | 15-40 |
+| B2B serviços | 35 | 25-50 |
+| Advocacia | 30 | 18-42 |
+| Varejo físico | 30 | 18-42 |
+
+### Mensagem por Faixa
+
+**0-20 (Crítico):**
+"O negócio está praticamente invisível no digital. Cada dia sem ação é receita perdida. Prioridade: montar o básico (pixel, LP, CRM mínimo) e começar a rodar mídia com estrutura."
+
+**21-40 (Baixo):**
+"As peças existem mas estão desconectadas. Tem tráfego sem conversão, ou conversão sem follow-up, ou CRM sem dados. Prioridade: conectar os pontos e eliminar os vazamentos do funil."
+
+**41-60 (Médio):**
+"O digital funciona mas está no piloto automático. Concorrentes mais maduros estão capturando a demanda que você está deixando na mesa. Prioridade: otimizar o que já roda e atacar o pilar mais fraco."
+
+**61-80 (Bom):**
+"Acima da média do mercado. O digital já gera resultado. Prioridade: escalar o que funciona, testar canais novos, e automatizar para eficiência."
+
+**81-100 (Excelente):**
+"Best-in-class. Poucos concorrentes no seu setor estão neste nível. Prioridade: inovar (IA, personalização, omnichannel) e proteger a vantagem competitiva."
+
+---
+
+## Como usar quando NAO tem dados V4MOS
+
+Quando o operador não tem dados automáticos:
+
+1. Para cada pilar, faça 3-5 perguntas diretas ao operador
+2. Com base nas respostas, atribua um score estimado usando as faixas acima
+3. Marque o score como "(estimado)" no output
+4. Seja conservador: na dúvida, score para baixo. É melhor o cliente descobrir que está melhor do que pior
+5. Recomende conectar o V4MOS para scores automáticos nas skills de diagnóstico detalhado (semana 2)
+
+## Sinais de alerta por pilar
+
+### Sinais de que Mídia Paga é Crítica
+- Não sabe o CPA
+- Nunca ouviu falar de pixel/CAPI
+- "Deixa o Meta decidir tudo" (broad sem lookalalike)
+- Mesmo criativo há 3+ meses
+
+### Sinais de que CRO é Crítico
+- Site não tem HTTPS
+- CTA é "Entre em contato" no rodapé
+- Sem prova social nenhuma
+- Carrega em mais de 5s no mobile
+
+### Sinais de que CRM é Crítico
+- Leads vão pro WhatsApp pessoal e morrem lá
+- Não sabe quantos leads recebeu no último mês
+- "Responde quando dá"
+
+### Sinais de que SEO é Crítico
+- Não aparece no Google nem para o nome da empresa
+- Site sem SSL
+- GMB não reivindicado

--- a/.agents/skills/gt-diagnostico-maturidade-digital/schema.json
+++ b/.agents/skills/gt-diagnostico-maturidade-digital/schema.json
@@ -1,0 +1,358 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DiagnosticoMaturidade",
+  "description": "Output estruturado da skill diagnostico-maturidade: score por pilar, resumo executivo, prioridades e benchmark.",
+  "type": "object",
+  "required": [
+    "summary",
+    "overall_score",
+    "pillar_scores",
+    "executive_summary",
+    "priorities",
+    "sector_benchmark",
+    "client_name",
+    "summary_headline",
+    "summary_highlights",
+    "summary_key_findings"
+  ],
+  "properties": {
+    "client_name": {
+      "type": "string",
+      "description": "Nome do cliente — sempre presente em todo output."
+    },
+    "summary": {
+      "type": "string",
+      "description": "Resumo de 1-2 frases do diagnóstico. Usado como referência rápida por outras skills."
+    },
+    "summary_headline": {
+      "type": "string",
+      "maxLength": 200,
+      "description": "Manchete em 1 linha com o veredito desta skill (hero do resumo executivo no portal). Ver references/padrao-output.md"
+    },
+    "summary_highlights": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 8,
+      "description": "KPIs visuais categorizados para o resumo executivo. Cada item: {category, label, value, subtext, tone}.",
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "label",
+          "value"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "posicao",
+              "competicao",
+              "janela",
+              "maturidade",
+              "oportunidade",
+              "risco"
+            ]
+          },
+          "label": {
+            "type": "string",
+            "maxLength": 40
+          },
+          "value": {
+            "type": "string"
+          },
+          "subtext": {
+            "type": "string",
+            "maxLength": 80
+          },
+          "tone": {
+            "type": "string",
+            "enum": [
+              "green",
+              "yellow",
+              "red",
+              "blue",
+              "gray"
+            ]
+          }
+        }
+      }
+    },
+    "summary_key_findings": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 6,
+      "description": "Achados categorizados por intenção (vantagem/contexto/ameaça/ação). Pelo menos 3 dos 4 tipos cobertos.",
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "text"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "vantagem",
+              "contexto",
+              "ameaca",
+              "acao"
+            ]
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "data_source": {
+      "type": "string",
+      "enum": [
+        "v4mos",
+        "manual",
+        "mixed"
+      ],
+      "description": "De onde vieram os dados: V4MOS automático, coleta manual com operador, ou misto."
+    },
+    "overall_score": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 100,
+      "description": "Score geral de maturidade digital (média ponderada dos pilares)."
+    },
+    "overall_classification": {
+      "type": "string",
+      "enum": [
+        "critical",
+        "low",
+        "medium",
+        "good",
+        "excellent"
+      ],
+      "description": "Classificação textual do score geral."
+    },
+    "pillar_scores": {
+      "type": "array",
+      "minItems": 5,
+      "maxItems": 5,
+      "items": {
+        "type": "object",
+        "required": [
+          "pillar",
+          "score",
+          "classification",
+          "highlight"
+        ],
+        "properties": {
+          "pillar": {
+            "type": "string",
+            "enum": [
+              "midia_paga",
+              "criativos",
+              "cro",
+              "crm",
+              "seo"
+            ],
+            "description": "Nome do pilar."
+          },
+          "score": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 100,
+            "description": "Score do pilar (0-100)."
+          },
+          "classification": {
+            "type": "string",
+            "enum": [
+              "critical",
+              "low",
+              "medium",
+              "good",
+              "excellent"
+            ],
+            "description": "Classificação do pilar."
+          },
+          "highlight": {
+            "type": "string",
+            "description": "1 frase destacando o principal achado deste pilar."
+          },
+          "estimated": {
+            "type": "boolean",
+            "description": "Se true, o score foi estimado manualmente (sem dados V4MOS)."
+          },
+          "details": {
+            "type": "object",
+            "description": "Detalhes específicos por pilar.",
+            "properties": {
+              "strengths": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Pontos fortes identificados."
+              },
+              "weaknesses": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Pontos fracos identificados."
+              },
+              "metrics": {
+                "type": "object",
+                "description": "Métricas específicas do pilar (CPA, ROAS, taxa de conversão, etc.).",
+                "additionalProperties": true
+              }
+            }
+          }
+        }
+      },
+      "description": "Scores detalhados por pilar de maturidade."
+    },
+    "executive_summary": {
+      "type": "string",
+      "description": "Resumo executivo de 3 parágrafos: significado do score, top 2 gaps, top 2 forças."
+    },
+    "priorities": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 7,
+      "items": {
+        "type": "object",
+        "required": [
+          "rank",
+          "action",
+          "rationale",
+          "effort",
+          "pillar"
+        ],
+        "properties": {
+          "rank": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Posição na prioridade (1 = mais importante)."
+          },
+          "action": {
+            "type": "string",
+            "description": "Ação específica e acionável."
+          },
+          "rationale": {
+            "type": "string",
+            "description": "Por que é prioridade (impacto esperado)."
+          },
+          "effort": {
+            "type": "string",
+            "enum": [
+              "low",
+              "medium",
+              "high"
+            ],
+            "description": "Nível de esforço para implementar."
+          },
+          "pillar": {
+            "type": "string",
+            "description": "Qual pilar essa ação impacta."
+          },
+          "dependencies": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "O que precisa estar pronto antes."
+          }
+        }
+      },
+      "description": "Ações prioritárias ranqueadas por impacto."
+    },
+    "sector_benchmark": {
+      "type": "object",
+      "required": [
+        "sector",
+        "sector_average",
+        "comparison"
+      ],
+      "properties": {
+        "sector": {
+          "type": "string",
+          "description": "Segmento/setor do cliente para benchmark."
+        },
+        "sector_average": {
+          "type": "number",
+          "description": "Score médio do setor (referência)."
+        },
+        "comparison": {
+          "type": "string",
+          "enum": [
+            "above_average",
+            "at_average",
+            "below_average",
+            "significantly_below"
+          ],
+          "description": "Posição do cliente vs. média do setor."
+        },
+        "pillar_comparison": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "pillar": {
+                "type": "string"
+              },
+              "client_score": {
+                "type": "number"
+              },
+              "sector_average": {
+                "type": "number"
+              },
+              "gap": {
+                "type": "number"
+              },
+              "position": {
+                "type": "string",
+                "enum": [
+                  "above",
+                  "at",
+                  "below",
+                  "critical_gap"
+                ]
+              }
+            }
+          },
+          "description": "Comparação por pilar vs. média do setor."
+        },
+        "key_insight": {
+          "type": "string",
+          "description": "Insight principal da comparação com o setor."
+        }
+      }
+    },
+    "key_insight": {
+      "type": "object",
+      "description": "Ponto de alavancagem desta skill — o bloco que merece destaque visual para conversa com o stakeholder. Ver PADRAO-OUTPUT.md.",
+      "properties": {
+        "headline": {
+          "type": "string",
+          "description": "Frase-manchete do ponto (pode virar quote destacada no renderer)"
+        },
+        "context": {
+          "type": "string",
+          "description": "Contexto em 2-3 linhas explicando o cenário"
+        },
+        "numbered_reasons": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Razões numeradas (o renderer vira 3 cards numerados)"
+        },
+        "discussion_anchor": {
+          "type": "string",
+          "description": "Por que este é o ponto para stakeholder decidir/validar"
+        }
+      }
+    },
+    "honesty_alert": {
+      "type": "string",
+      "description": "Alerta se a análise revelou fragilidade real do cliente (não há diferencial claro, premissa contraditória, etc.). Nunca omitir se justificado."
+    }
+  }
+}

--- a/.agents/skills/gt-diagnostico-midia-paga/SKILL.md
+++ b/.agents/skills/gt-diagnostico-midia-paga/SKILL.md
@@ -1,0 +1,365 @@
+---
+name: gt-diagnostico-midia-paga
+description: "Diagnostico de midia paga: metricas atuais vs benchmarks, top 3 problemas e plano de acao 30 dias. Puxa dados reais do V4MOS (MediaInvestment). Use quando o operador disser /gt-diagnostico-midia-paga ou 'analisar midia paga' ou 'diagnostico de ads' ou 'como esta a conta de anuncios'."
+area: gt
+author: luizfreitasv4
+version: 1.0.0
+dependencies:
+  - geral-persona-icp
+tools: []
+week: 2
+estimated_time: "3h"
+output_file: "gt-diagnostico-midia-paga.json"
+v4mos_data: true
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta versao foi portada do sistema de Estruturacao Estrategica. As regras abaixo tem precedencia sobre caminhos e persistencia citados no fluxo original:
+
+- Trabalhe somente em `squads/{squad}/clientes/{cliente}/`, nunca em um diretorio `clientes/` solto na raiz.
+- Leia primeiro o `CLAUDE.md` ou `AGENTS.md` da KB, `mission-control/`, `calls/`, `docs/` e `campanhas/`.
+- Se `client.json` existir, use-o como fonte complementar. Se nao existir, derive o contexto da KB e do Mission Control; nao exija nem invente esse arquivo.
+- Salve entregaveis em `squads/{squad}/clientes/{cliente}/outputs/`, em JSON e Markdown quando o fluxo pedir ambos.
+- Registre decisoes e progresso no `mission-control/historico-checkins.md` ou no arquivo de historico equivalente encontrado na KB.
+- Resolva recursos empacotados a partir do proprio diretorio desta skill. Se uma integracao externa nao estiver configurada, declare o gap e continue apenas com os dados reais disponiveis.
+
+
+# Diagnostico de Midia Paga (POP 2.1)
+
+Voce e um especialista em midia paga com foco em performance para PMEs brasileiras. Vai analisar a conta de midia do cliente, comparar com benchmarks do setor, e gerar um plano de acao prioritizado.
+
+> **Posição no fluxo:** Semana 2 — comum a todos os modelos. Pull de 90 dias, CAC/CPL/ROAS vs benchmark, diagnóstico campanha a campanha, plano de 30 dias e cenários de realocação. Alimenta o forecast (POP 3.12).
+
+**DIFERENCIAL V4MOS:** Se o cliente tem workspace ativo no V4MOS, voce puxa dados REAIS de MediaInvestment via API. Isso e ouro — a maioria das ferramentas so trabalha com dados que o operador exporta manualmente.
+
+## Dados necessários
+
+1. Leia `client.json` (seção `briefing`) — extraia: NOME_CLIENTE, SEGMENTO, BUDGET_MENSAL, OBJETIVO_MIDIA
+2. Leia `outputs/geral-persona-icp.json` — extraia: RESUMO_ICP, canais preferenciais do ICP
+3. Verifique `client.json` (seção `connectors`):
+   - Se `connectors.fetched_at` não é null: use os dados de `google_ads` e `facebook_ads` já salvos
+   - Se `connectors.fetched_at` é null: use `/v4mos-dados-meta-ads` para Meta Ads e os dados reais disponíveis na KB para Google Ads
+   - Se não há `workspace_id` no client.json: peça dados ao operador (exportação manual dos últimos 90 dias)
+
+   **Estrutura dos dados V4MOS em connectors (atualizada — agregações temporais e por dimensão):**
+   - `connectors.google_ads.campaigns[]` → {name, type, status, cost, clicks, impressions, conversions, ctr, cpa}
+   - `connectors.google_ads.monthly_evolution[]` → {month, cost, clicks, impressions, conversions, ctr, cpa} — **use direto em `google_ads.monthly_evolution`**
+   - `connectors.google_ads.day_of_week[]` → {day, clicks, impressions, cost, pct, ctr} — ordem Seg→Dom
+   - `connectors.google_ads.gender_breakdown[]` → {gender, clicks, cost, pct_clicks, ctr, cpa}
+   - `connectors.google_ads.top_keywords[]` → {keyword, match_type, clicks, impressions, ctr, cost, cpc, cpa, conversions}
+   - `connectors.facebook_ads.campaigns[]` → {name, objective, spend, impressions, clicks, reach, cpm, ctr}
+   - `connectors.facebook_ads.monthly_evolution[]` → {month, spend, impressions, clicks, reach, cpm, ctr}
+   - `connectors.facebook_ads.creatives[]` → {ad_id, ad_name, spend, impressions, clicks, ctr, cpc, cpm, reach, object_type, thumbnail_url, instagram_permalink_url, ad_created_time, ...}
+   - `connectors.period` → {start, end} — período dos dados (normalmente 90 dias)
+
+   **IMPORTANTE — evite a armadilha de totais inflados:** o endpoint V4MOS `facebook/ads/campaigns` (e potencialmente outros) **ignora** o filtro de data `createdStart/createdEnd` e retorna histórico completo. O script `v4mos_fetch.sh` agora filtra por `segments_date`/`date_start` no Python — portanto os totais em `connectors.*.total_*` refletem o período real. Não some campanhas brutas por conta própria sem filtrar data.
+
+   **API V4MOS (para referência, se precisar buscar manualmente):**
+   ```bash
+   # workspaceId é QUERY PARAMETER — não path
+   curl -s "https://api.data.v4.marketing/v1/google/ads/campaigns?workspaceId={WORKSPACE_ID}&limit=500" \
+     -H "x-client-id: {CLIENT_ID}" -H "x-client-secret: {CLIENT_SECRET}"
+   curl -s "https://api.data.v4.marketing/v1/facebook/ads/campaigns?workspaceId={WORKSPACE_ID}&limit=500" \
+     -H "x-client-id: {CLIENT_ID}" -H "x-client-secret: {CLIENT_SECRET}"
+   ```
+   Nunca exponha credenciais. Se a integração não estiver configurada, peça uma exportação dos últimos 90 dias.
+
+### Se o cliente NAO investe em midia
+
+Se nao ha dados de midia paga (nem no V4MOS, nem exportacao):
+
+> Este cliente ainda nao investe em midia paga. Em vez de diagnostico, vou gerar um **plano de lancamento** de midia alinhado ao ICP e posicionamento. Posso seguir?
+
+Se sim, adapte a geração para plano de lancamento (estrutura de campanhas, budget recomendado, publicos iniciais, criativos prioritarios).
+
+---
+
+## Geração
+
+Gere o output COMPLETO de uma vez usando os dados de `client.json` (briefing, connectors) e outputs de skills dependentes em `outputs/`.
+
+Consulte `references/benchmarks-por-setor.md` para os benchmarks do segmento.
+
+### Dados de mídia e status de integração
+
+Apresente fonte dos dados, período, budget, integrações V4MOS e métricas atuais (CPL, CTR, taxa de conversão LP, ROAS, CPC). Liste dados faltantes.
+
+Se algum dado crítico estiver faltando, pergunte ao operador de uma vez.
+
+### Blocos `google_ads` e `meta_ads` — obrigatórios (por canal)
+
+O portal renderiza cada canal em uma seção separada, iniciando por um **bloco de abertura** com 4 cards + 1 card "Resumo Executivo". Gere os dois objetos top-level `google_ads` e `meta_ads` com os campos abaixo — o renderer NÃO inventa fallback, se o campo estiver ausente o card some.
+
+**`google_ads` — campos esperados:**
+```json
+{
+  "integration": "nome da conta no V4MOS",
+  "budget_monthly_declared": 2400,
+  "budget_monthly_actual": 1450.92,
+  "total_campaigns": 6,
+  "active_campaigns": 1,
+  "paused_campaigns": 5,
+  "status": "healthy_but_choked | subscale | healthy | critical | broken",
+  "score": 62,
+  "score_classification": "medium",
+  "total_spend_90d": 4352.77,
+  "total_clicks_90d": 1751,
+  "total_impressions_90d": 46491,
+  "total_conversions_90d": 300,
+  "avg_cpa": 14.51,
+  "avg_ctr": 3.77,
+  "strategic_diagnosis": "3-5 linhas. Veredito do canal: o que está acontecendo, por que acontece, qual é o destravamento. Usado no card Resumo Executivo.",
+  "active_campaign": { "name":"...", "type":"SEARCH", "status":"ENABLED", "cost_90d":..., "ctr":..., "cpa":..., "note":"..." },
+  "paused_campaigns_opportunity": [ {name,type,cost_90d,clicks,impressions,conversions,ctr,cpa,note} ],
+  "monthly_evolution": [ {month,cost,clicks,impressions,conversions,ctr,cpa} ],
+  "day_of_week": [ {day,clicks,impressions,cost,pct,ctr} ],
+  "gender_breakdown": [ {gender,clicks,cost,pct_clicks,ctr,cpa} ],
+  "top_keywords": [ {keyword,match_type,clicks,impressions,ctr,cost,cpc,cpa,conversions,insight?,tag?} ]
+}
+```
+
+**`meta_ads` — campos esperados:**
+```json
+{
+  "integration": "nome da conta no V4MOS",
+  "budget_monthly_declared": 800,
+  "budget_monthly_actual": 424.53,
+  "total_campaigns": 5,
+  "total_ads": 43,
+  "total_creatives": 43,
+  "status": "critical | subscale | healthy | broken",
+  "score": 38,
+  "score_classification": "medium_low",
+  "total_spend_90d": 1273.60,
+  "total_clicks_90d": 1442,
+  "total_impressions_90d": 112295,
+  "total_reach_90d": 71890,
+  "avg_ctr": 1.28,
+  "avg_cpm": 11.34,
+  "strategic_diagnosis": "3-5 linhas. Veredito do canal. Usado no card Resumo Executivo.",
+  "critical_issues": [ "marcador por linha, começa com ▲ implicitamente no render" ],
+  "top_5_ads_by_spend": [ {ad_name,campaign_context,spend,impressions,clicks,ctr,cpc,cpm,object_type,creative_id,note} ],
+  "icp_aligned_creatives": [ ... ],          // opcional — destaques temáticos alinhados ao ICP
+  "monthly_evolution": [ {month,spend,impressions,clicks,reach,cpm,ctr} ],
+  "creative_gallery": [ ... ],              // vem do connectors.facebook_ads.creatives, mas com verdict M/O/E por ad
+  "creative_gallery_summary": { total_displayed, total_ads, manter, otimizar, eliminar, note }
+}
+```
+
+**COMO O PORTAL RENDERIZA O BLOCO DE ABERTURA (Google e Meta):**
+1. **4 cards** com cores semáforo:
+   - Google: Investido 90d · CTR médio · CPA médio · Conversões 90d
+   - Meta: Investido 90d · CTR médio · CPM médio · Alcance 90d (fallback: Clicks 90d)
+2. **Linha de stats secundárias** (muted): Média mensal · Clicks · Impressões · Ads/Campanhas
+3. **Card "Resumo Executivo"** com o texto de `strategic_diagnosis` (use este campo para a narrativa do canal — não é local para sinônimo do `summary` global, é o veredito específico de Google OU Meta).
+
+Se `strategic_diagnosis` estiver ausente, o card some. Sempre preencha.
+
+### Métricas vs benchmarks por segmento
+
+| Metrica | Atual | Benchmark setor | Status | Gap |
+|---------|-------|-----------------|--------|-----|
+| CPL | R$ {atual} | R$ {bench} | {acima/abaixo/ok} | {%} |
+| CTR | {atual}% | {bench}% | ... | ... |
+| Conv. LP | {atual}% | {bench}% | ... | ... |
+| ROAS | {atual}x | {bench}x | ... | ... |
+| CPC | R$ {atual} | R$ {bench} | ... | ... |
+
+Legenda: 🔴 Critico (>50% abaixo) | 🟡 Atencao (20-50% abaixo) | 🟢 Saudavel
+
+### Diagnóstico por dimensão
+
+**ESTRUTURA DE CONTA:** organização, segmentação, budget allocation
+**CRIATIVOS:** ativos, melhor/pior performance, teste A/B, frequência
+**PÁGINAS DE DESTINO:** LPs usadas, coerência, taxa de rejeição
+**PÚBLICOS:** tipos usados, sobreposição, retargeting
+
+### Top 3 problemas críticos
+
+Para cada: título, evidência nos dados, impacto estimado, dimensão afetada.
+
+### Plano de ação — 30 dias
+
+| # | Acao | Prioridade | Impacto esperado | Responsavel | Prazo |
+|---|------|-----------|------------------|-------------|-------|
+
+### Keyword Clusters (OBRIGATÓRIO — search)
+
+Não trate keywords como lista única. Agrupe em 4-6 clusters estratégicos. Para cada:
+- `cluster`: nome (ex: "Marca", "Produto/Serviço", "Localização", "Genéricas")
+- `keywords`: exemplos (5-15) — keywords ATUALMENTE EM USO no cluster
+- `intent`: navegacional | informacional | transacional | comercial
+- `budget_allocation_pct`: % do budget de search para esse cluster
+- `expected_cpc_range`: faixa esperada (R$)
+- `bid_strategy`: estratégia (máx. conv., CPA alvo, manual)
+- `copy_angle`: ângulo da copy para esse cluster
+- `risk`: principal risco (ex: concorrência alta, baixa intenção, canibalização)
+- `opportunity_keywords`: **opcional mas RECOMENDADO** — lista de keywords relevantes para o ICP que o cliente NÃO usa hoje. Itens `{keyword, intent?, volume_estimate?|search_volume_monthly?, expected_cpc?|cpc_range?, rationale}`. Base: compare `google_ads.top_keywords` (ativas) contra ICP + segmento + concorrentes. O portal renderiza uma tabela "Keywords Relevantes Não Utilizadas Hoje — Oportunidades" agregando estes campos de todos os clusters.
+
+Alternativa: gere `opportunity_keywords` como array top-level (fora dos clusters) no formato `[{keyword, cluster, intent, volume_estimate, expected_cpc, rationale}]` — o renderer aceita ambos.
+
+### Budget Reallocation Scenarios (OBRIGATÓRIO — 3 cenários)
+
+Não entregue apenas uma recomendação de budget — gere 3 cenários para o operador escolher.
+- **A. Conservador:** mantém budget atual, reorganiza mix
+- **B. Realista (RECOMENDADO):** reorganização + leve aumento, mapeamento de campanhas — o renderer marca automaticamente o cenário do meio como "★ Recomendado"
+- **C. Agressivo:** aumento significativo para buscar teto de demanda
+
+Para cada cenário, gere os seguintes campos (os nomes **preferidos** são os primeiros; alternativas são aceitas pelo renderer):
+
+**Obrigatórios / estruturais:**
+- `name` (pref) ou `label` — nome do cenário
+- `total_budget_monthly` — budget total mensal. Se ausente, o renderer soma automaticamente os splits.
+- `google_split` (pref) ou `google_allocation{value|amount|brl, pct}` — valor em R$ no Google
+- `meta_split` (pref) ou `meta_allocation{value|amount|brl, pct}` — valor em R$ no Meta
+- `expected_leads_monthly` (pref) ou `projected_leads_month` — leads/mês esperados
+- `expected_cpl` (pref) ou `projected_cpl` — CPL esperado em R$
+- `expected_roas` — ROAS esperado
+- `risk_assessment` — avaliação do risco
+
+**Opcionais (enriquecem o card do cenário):**
+- `delta_leads` — variação vs. atual (número ou "+15%")
+- `effort_weeks` — semanas para implementar
+- `confidence` — high/medium/low (ou alta/média/baixa)
+- `campaigns_structure[]` — lista de campanhas com {campaign, platform, budget_monthly, objective}
+
+> **COMO O PORTAL RENDERIZA:** Tabela side-by-side com cenários como colunas e métricas (Budget, Google, Meta, Leads/mês, CPL, ROAS) como linhas. Cada linha tem barras normalizadas por métrica para comparação visual. **Não existe mais gráfico de barras agrupadas com escalas mistas** — escolha os campos acima e o renderer formata o resto.
+
+### Creative Testing Hypotheses (OBRIGATÓRIO — 4-6 hipóteses)
+
+Cada hipótese é um teste A/B real, não uma ideia vaga. Para cada (H1, H2, ...):
+- `hypothesis`: afirmação testável ("Se X, então Y, porque Z")
+- `angle`: ângulo de comunicação
+- `format`: formato (single image, carousel, reels, VSL)
+- `hook`: primeiras 3 segundos / headline
+- `body`: copy principal
+- `cta`: call to action
+- `target_audience`: público específico
+- `success_criteria`: métrica + threshold (ex: "CTR > 1.5% E CPL < R$20")
+- `testing_budget`: R$ do teste
+- `testing_duration_days`: dias
+
+Feche com `testing_budget_total_week_1`.
+
+### Daypart Optimization (OBRIGATÓRIO)
+
+Não basta "rodar o dia todo". Proponha ajustes de lance por dia/hora baseados no comportamento da persona. Para cada ajuste:
+- `day_time`: janela (ex: "Segunda-Sexta 9-12h", "Sábado 10-18h", "Domingo")
+- `bid_adjustment_pct`: +X% ou -X%
+- `rationale`: por que (dado de comportamento, padrão do segmento)
+
+### Forecast Sensitivity Analysis (opcional)
+
+**Status:** Não é mais obrigatório. O portal suporta o bloco mas ele é dispensável — `honesty_alert` e `realistic_goal_90d.alert` cobrem os riscos principais. Gere apenas se:
+- O caso tem múltiplas variáveis interdependentes que mudam significativamente o forecast, ou
+- O operador pede explicitamente o what-if.
+
+Se gerar, use a estrutura:
+- `base_case`: meta central com `leads_monthly`, `cpl`, `cac`, `revenue_monthly`, `roas`.
+- `variations`: 4-6 cenários "what-if" `{scenario, variable_change, impact_on_leads, impact_on_cpl, impact_on_revenue, delta_vs_base_pct}`.
+
+O renderer exibe apenas os cards (sem gráfico).
+
+### Meta realista — 90 dias
+
+Gere `realistic_goal_90d` com os seguintes campos (o portal renderiza 4 cards + card "Premissas"):
+- `current_cpl`, `target_cpl` — CPL atual e alvo em R$
+- `current_cac`, `target_cac` — CAC atual e alvo em R$
+- `current_leads_month`, `target_leads_month` — volume de leads atual e alvo
+- `current_agendamentos_month`, `target_agendamentos_month` — opcional, se a skill de posicionamento define funil lead→agendamento
+- `premissas`: lista de 3-6 premissas concretas (ex: "LP do produto principal no ar na Semana 3")
+
+**NÃO gere** o campo `alert` em `realistic_goal_90d` — o portal não renderiza mais essa caixa. Se há risco de prazo/acesso/budget, inclua em `honesty_alert` (global) ou como premissa condicional.
+
+Gere também `realistic_goal` com `target_cpl`, `target_roas`, `justification`, `assumptions`, `risk_factors` — usado como texto de apoio.
+
+### Estrutura visual (obrigatória)
+
+Siga o padrão canônico de `references/padrao-output.md`. Além dos campos acima, SEMPRE inclua:
+
+- **`summary_headline`** (max 200 char) — manchete com o veredito. Ex: "CPL atual (R$ 85) está 40% acima do benchmark — realocação B recupera R$ 12K/mês sem subir orçamento."
+- **`summary_highlights`** (4-6 itens, `{category, label, value, subtext, tone}`) — para diagnóstico de mídia sugestões:
+  - `posicao`: CPL atual vs benchmark, leads/mês, CAC, ROAS
+  - `oportunidade`: cenário de realocação com maior upside, economia projetada
+  - `risco`: plataforma/campanha queimando verba sem retorno
+  - `janela`: tempo de ramp-up para estabilizar CPL alvo
+- **`summary_key_findings`** (3-5 itens, `{category, text}`) — `vantagem|contexto|ameaca|acao`.
+
+### Ponto de alavancagem
+
+Em diagnóstico de mídia, o ponto de alavancagem é o **canal/campanha com maior gap entre performance atual e potencial** — tipicamente o cenário de realocação recomendado + hipótese criativa principal. Estruture em `key_insight`:
+```json
+"key_insight": {
+  "headline": "Frase sobre o destravamento (ex: 'Cortar Performance Max e dobrar Search Branded baixa CPL em 35%')",
+  "context": "2-3 linhas sobre por que o desperdício acontece e o caminho",
+  "numbered_reasons": ["(1) evidência do gap", "(2) causa-raiz (estrutura/copy/segmentação)", "(3) upside projetado"],
+  "discussion_anchor": "Por que o stakeholder precisa aprovar a realocação antes do próximo ciclo"
+}
+```
+
+Se os dados são insuficientes (menos de 60 dias, tracking quebrado) ou o orçamento é incompatível com o objetivo, inclua `honesty_alert`.
+
+## Auto-validação
+
+Antes de mostrar ao operador, verifique:
+
+- [ ] Mencionou o cliente pelo nome?
+- [ ] Usou dados reais do client.json (não inventou)?
+- [ ] Nenhum item genérico (ex: "quer crescer", "qualidade e compromisso")?
+- [ ] Schema da skill validou?
+- [ ] Todos os campos do schema preenchidos (ou com `null` + `unavailable_reason` no pai)?
+- [ ] Nenhuma string vazia (`""`) — substituí por `null` + reason quando o dado não existe?
+- [ ] Estimativas marcadas com `estimated: true` ou `[E]`?
+- [ ] Consistente com outputs anteriores (ICP)?
+- [ ] Benchmarks são do segmento correto do cliente?
+- [ ] Plano de ação tem responsáveis e prazos realistas?
+- [ ] Meta de 90 dias é honesta (não promessa mágica)?
+- [ ] `google_ads` tem total_spend_90d, avg_ctr, avg_cpa, total_conversions_90d E `strategic_diagnosis` preenchido (3-5 linhas)?
+- [ ] `meta_ads` tem total_spend_90d, avg_ctr, avg_cpm, total_reach_90d E `strategic_diagnosis` preenchido (3-5 linhas)?
+- [ ] Totais 90d de google_ads e meta_ads BATEM com `connectors.google_ads.total_cost` e `connectors.facebook_ads.total_spend` (V4MOS filtrado)?
+- [ ] `budget_monthly_actual` por canal é `total_spend_90d / 3` (cliente pode estar subinvestindo — flag isso se delta vs declarado > 20%)?
+- [ ] `keyword_clusters` (search) tem 4-6 clusters com intent, budget %, copy angle e risco?
+- [ ] Pelo menos 1 cluster tem `opportunity_keywords[]` (keywords relevantes para o ICP NÃO ativas hoje)?
+- [ ] `budget_reallocation_scenarios` tem 3 cenários (A/B/C) com estrutura de campanhas e projeção?
+- [ ] `creative_testing_hypotheses` tem 4-6 hipóteses testáveis com success_criteria numérico e budget?
+- [ ] `daypart_optimization` traz ajustes específicos por janela com rationale?
+- [ ] `forecast_sensitivity_analysis` (opcional) — se gerar, tem base_case + 4-6 variações?
+- [ ] Tem `summary_headline` específico?
+- [ ] `summary_highlights` tem 4-6 itens com categorias e tons válidos?
+- [ ] `summary_key_findings` cobre pelo menos 3 dos 4 tipos?
+- [ ] Identificou `key_insight` (realocação/hipótese com maior upside)?
+- [ ] Se há limitação de dados/orçamento, incluiu `honesty_alert`?
+
+Se falhou → regenere silenciosamente. Não avise o operador.
+
+## Apresentação e decisões
+
+Apresente o output COMPLETO ao operador.
+
+Revise o output. O que está errado, exagerado ou faltando?
+
+- "Os benchmarks fazem sentido para a realidade deste cliente especifico? Algum contexto que mude a leitura?"
+- "O plano de acao e executavel na realidade deste cliente? Alguma acao que depende de algo que nao temos?"
+- "A meta de 90 dias parece realista?"
+
+## Finalização
+
+Operador aprova (com ou sem ajustes).
+1. Salve em `squads/{squad}/clientes/{cliente}/outputs/gt-diagnostico-midia-paga.json` (com campo `summary` no topo)
+2. Atualize `client.json`: progress.skills → completed, version++, append em history[]
+3. Salve também uma versão Markdown do entregável na mesma pasta de outputs.
+4. Sugira próxima skill do dependency_graph
+   - "Diagnóstico concluído. CPL atual: R$ {atual} → Meta 90d: R$ {meta}. Problemas críticos: {numero}."
+   - "Este diagnostico alimenta: /gt-forecast-midia, /copy-anuncios, /designer-criativos-anuncios"
+   - "Proximo passo recomendado: /gt-diagnostico-criativos"
+
+
+## Campo obrigatório: summary
+
+Sempre inclua no JSON de saída:
+```json
+"summary": "Resumo de 1-2 frases do diagnóstico de mídia: principal problema e ROAS atual vs benchmark. Seja específico — mencione o cliente, números reais e a conclusão principal."
+```
+
+Este campo alimenta o Resumo Executivo do portal de entregas. Deve ser objetivo, com dados reais, sem genéricos.

--- a/.agents/skills/gt-diagnostico-midia-paga/references/benchmarks-por-setor.md
+++ b/.agents/skills/gt-diagnostico-midia-paga/references/benchmarks-por-setor.md
@@ -1,0 +1,196 @@
+# Benchmarks de Midia Paga por Setor — PMEs Brasileiras
+
+## Como usar estes benchmarks
+
+Estes benchmarks sao REFERENCIAS baseadas em medias de mercado para PMEs brasileiras. Use-os como ponto de partida para o diagnostico, nao como verdade absoluta.
+
+**Fatores que alteram benchmarks:**
+- Regiao (capital vs interior — CPL pode variar 2-3x)
+- Ticket medio do produto/servico (ticket alto = CPL aceitavel mais alto)
+- Maturidade digital do cliente (contas novas tem CPL mais alto)
+- Sazonalidade (Black Friday, volta as aulas, etc.)
+- Nivel de concorrencia local (mais concorrentes = CPC mais alto)
+
+**Fontes:** Dados agregados de agencias V4 Company (2024-2025), WordStream, HubSpot Latin America, RD Station Benchmarks, Resultados Digitais.
+
+---
+
+## Benchmarks por setor
+
+### 1. Odontologia / Clinicas Dentarias
+
+| Metrica | Benchmark | Range aceitavel |
+|---------|-----------|-----------------|
+| CPL (Meta Ads) | R$ 15-30 | R$ 10-45 |
+| CPL (Google Ads) | R$ 25-50 | R$ 15-70 |
+| CTR (Meta Ads) | 1.2-2.0% | 0.8-3.0% |
+| CTR (Google Search) | 3.5-6.0% | 2.5-8.0% |
+| Conv. LP | 8-15% | 5-25% |
+| CPC (Meta) | R$ 1.50-3.00 | R$ 0.80-4.50 |
+| CPC (Google) | R$ 3.00-6.00 | R$ 2.00-10.00 |
+
+**Observacoes:** Implantes e ortodontia tem CPL mais alto (R$ 40-80). Limpeza e clareamento tem CPL mais baixo (R$ 8-20). Google Ads geralmente entrega leads mais qualificados (busca ativa).
+
+### 2. Clinicas de Estetica / Beleza
+
+| Metrica | Benchmark | Range aceitavel |
+|---------|-----------|-----------------|
+| CPL (Meta Ads) | R$ 8-20 | R$ 5-35 |
+| CPL (Google Ads) | R$ 20-40 | R$ 12-55 |
+| CTR (Meta Ads) | 1.5-2.5% | 1.0-4.0% |
+| CTR (Google Search) | 3.0-5.5% | 2.0-7.0% |
+| Conv. LP | 10-18% | 6-25% |
+| CPC (Meta) | R$ 1.00-2.50 | R$ 0.50-3.50 |
+| CPC (Google) | R$ 2.50-5.00 | R$ 1.50-8.00 |
+
+**Observacoes:** Harmonizacao facial gera muito lead frio. Filtragem por WhatsApp e essencial. Video criativos performam 2-3x melhor que estaticos neste setor.
+
+### 3. Imobiliarias / Construtoras
+
+| Metrica | Benchmark | Range aceitavel |
+|---------|-----------|-----------------|
+| CPL (Meta Ads) | R$ 25-60 | R$ 15-100 |
+| CPL (Google Ads) | R$ 40-90 | R$ 25-150 |
+| CTR (Meta Ads) | 0.8-1.5% | 0.5-2.5% |
+| CTR (Google Search) | 2.5-5.0% | 1.5-7.0% |
+| Conv. LP | 3-8% | 2-12% |
+| CPC (Meta) | R$ 2.00-4.00 | R$ 1.00-6.00 |
+| CPC (Google) | R$ 5.00-12.00 | R$ 3.00-20.00 |
+
+**Observacoes:** CPL alto e aceitavel porque ticket e alto. ROAS e mais relevante que CPL. Imobiliarios tem ciclo de venda longo — considere atribuicao multi-touch.
+
+### 4. Restaurantes / Delivery / Alimentacao
+
+| Metrica | Benchmark | Range aceitavel |
+|---------|-----------|-----------------|
+| CPL (Meta Ads) | R$ 3-10 | R$ 2-15 |
+| CTR (Meta Ads) | 2.0-3.5% | 1.2-5.0% |
+| Conv. LP | 12-25% | 8-35% |
+| CPC (Meta) | R$ 0.50-1.50 | R$ 0.30-2.50 |
+| ROAS (delivery) | 4-8x | 3-12x |
+
+**Observacoes:** Funciona melhor com Meta Ads (impulso visual). Google Ads Local (Maps) e poderoso para presencial. Cupom de desconto funciona bem como conversao de primeiro pedido.
+
+### 5. Academias / Studios Fitness
+
+| Metrica | Benchmark | Range aceitavel |
+|---------|-----------|-----------------|
+| CPL (Meta Ads) | R$ 10-25 | R$ 6-40 |
+| CPL (Google Ads) | R$ 20-45 | R$ 12-60 |
+| CTR (Meta Ads) | 1.5-2.5% | 1.0-3.5% |
+| Conv. LP | 8-15% | 5-20% |
+| CPC (Meta) | R$ 1.00-2.00 | R$ 0.50-3.00 |
+
+**Observacoes:** Sazonalidade forte (janeiro, pos-carnaval). Oferta de "aula experimental gratis" converte bem. Video com transformacao real performa melhor que foto de equipamento.
+
+### 6. E-commerce / Varejo Online
+
+| Metrica | Benchmark | Range aceitavel |
+|---------|-----------|-----------------|
+| CPC (Meta Ads) | R$ 1.00-3.00 | R$ 0.50-5.00 |
+| CPC (Google Shopping) | R$ 0.80-2.50 | R$ 0.40-4.00 |
+| CTR (Meta Ads) | 1.0-2.0% | 0.6-3.0% |
+| CTR (Google Shopping) | 2.0-4.0% | 1.0-6.0% |
+| Conv. site | 1.5-3.0% | 0.8-5.0% |
+| ROAS (Meta) | 3-6x | 2-10x |
+| ROAS (Google) | 4-8x | 3-12x |
+| CAC | R$ 30-80 | R$ 15-120 |
+
+**Observacoes:** ROAS e a metrica mais importante. Google Shopping e obrigatorio. Retargeting geralmente tem ROAS 2-3x superior a cold traffic. LTV importa mais que CAC isolado.
+
+### 7. Advocacia / Servicos Juridicos
+
+| Metrica | Benchmark | Range aceitavel |
+|---------|-----------|-----------------|
+| CPL (Google Ads) | R$ 30-70 | R$ 20-100 |
+| CPL (Meta Ads) | R$ 15-40 | R$ 10-60 |
+| CTR (Google Search) | 3.0-6.0% | 2.0-8.0% |
+| Conv. LP | 5-12% | 3-18% |
+| CPC (Google) | R$ 5.00-15.00 | R$ 3.00-25.00 |
+
+**Observacoes:** Google Ads Search e o canal principal (busca ativa). Palavras-chave de urgencia ("advogado trabalhista urgente") tem CPL alto mas conversao melhor. Meta Ads funciona para educacao/awareness.
+
+### 8. Contabilidade / Servicos Financeiros
+
+| Metrica | Benchmark | Range aceitavel |
+|---------|-----------|-----------------|
+| CPL (Google Ads) | R$ 25-55 | R$ 15-80 |
+| CPL (Meta Ads) | R$ 12-30 | R$ 8-45 |
+| CTR (Google Search) | 2.5-5.0% | 1.5-7.0% |
+| Conv. LP | 6-12% | 4-18% |
+| CPC (Google) | R$ 3.00-8.00 | R$ 2.00-12.00 |
+
+**Observacoes:** Nicho e o diferencial. "Contabilidade para e-commerce" tem CPL menor que "contabilidade" generico. Conteudo educativo (planilha, calculadora) funciona como isca.
+
+### 9. Educacao / Cursos / Coaching
+
+| Metrica | Benchmark | Range aceitavel |
+|---------|-----------|-----------------|
+| CPL (Meta Ads) | R$ 5-20 | R$ 3-35 |
+| CPL (Google Ads) | R$ 15-40 | R$ 10-60 |
+| CTR (Meta Ads) | 1.5-3.0% | 1.0-4.5% |
+| Conv. LP | 10-20% | 6-30% |
+| CPC (Meta) | R$ 0.80-2.00 | R$ 0.40-3.00 |
+
+**Observacoes:** Webinar/aula gratis tem alta conversao para captura. Lead de "aula gratis" e frio — qualificacao via email/WhatsApp e essencial. Video longo (2-5min) funciona como criativo de topo.
+
+### 10. SaaS / Software B2B
+
+| Metrica | Benchmark | Range aceitavel |
+|---------|-----------|-----------------|
+| CPL (Google Ads) | R$ 50-120 | R$ 30-200 |
+| CPL (Meta Ads) | R$ 30-70 | R$ 20-100 |
+| CPL (LinkedIn Ads) | R$ 80-200 | R$ 50-350 |
+| CTR (Google Search) | 2.0-4.5% | 1.5-6.0% |
+| Conv. LP trial | 3-8% | 2-12% |
+| CPC (Google) | R$ 8.00-20.00 | R$ 5.00-35.00 |
+
+**Observacoes:** CPL alto e aceitavel se LTV justifica. Free trial ou demo gratis converte melhor que "fale com vendas". LinkedIn tem CPL alto mas qualidade de lead B2B superior.
+
+### 11. Pet Shops / Veterinarias
+
+| Metrica | Benchmark | Range aceitavel |
+|---------|-----------|-----------------|
+| CPL (Meta Ads) | R$ 5-15 | R$ 3-25 |
+| CTR (Meta Ads) | 2.0-3.5% | 1.2-5.0% |
+| Conv. LP | 10-20% | 6-30% |
+| CPC (Meta) | R$ 0.50-1.50 | R$ 0.30-2.50 |
+
+**Observacoes:** Fotos de pets reais do cliente performam muito melhor que stock. Google Local e poderoso para veterinarias (emergencia). Oferta de "primeiro banho gratis" converte bem.
+
+### 12. Construcao / Reformas / Home Services
+
+| Metrica | Benchmark | Range aceitavel |
+|---------|-----------|-----------------|
+| CPL (Google Ads) | R$ 20-50 | R$ 12-80 |
+| CPL (Meta Ads) | R$ 10-30 | R$ 6-45 |
+| CTR (Google Search) | 3.0-5.5% | 2.0-7.0% |
+| Conv. LP | 5-12% | 3-18% |
+| CPC (Google) | R$ 3.00-8.00 | R$ 2.00-12.00 |
+
+**Observacoes:** Antes/depois e o criativo mais poderoso. Google Ads Local converte bem (busca urgente). Orcamento gratis como CTA funciona melhor que "saiba mais".
+
+---
+
+## Como interpretar os benchmarks no diagnostico
+
+### Status por gap
+
+| Gap vs benchmark | Status | Acao |
+|---|---|---|
+| Dentro do range aceitavel | Saudavel | Monitorar, otimizar gradualmente |
+| 20-50% acima do benchmark | Atencao | Investigar causa, prioridade media |
+| >50% acima do benchmark | Critico | Acao imediata, prioridade alta |
+| Abaixo do benchmark | Excelente | Documentar o que funciona, escalar |
+
+### Meta realista de melhoria em 90 dias
+
+| Situacao atual | Meta realista |
+|---|---|
+| CPL 2x acima do benchmark | Reduzir 30-40% (atingir range aceitavel) |
+| CPL 3x+ acima do benchmark | Reduzir 50% (ainda pode estar acima do benchmark ideal) |
+| CTR abaixo de 0.5% | Dobrar (indicativo de criativo/segmentacao ruim) |
+| Conv. LP abaixo de 3% | Subir para 5-8% (landing page precisa de rebuild) |
+| Sem retargeting | Implementar retargeting = reducao de 15-25% no CPL |
+
+**ATENCAO:** Nunca prometa atingir o benchmark ideal em 90 dias se o cliente esta 3x acima. Melhoria de 30-50% e realista. Atingir benchmark leva 4-6 meses de otimizacao continua.

--- a/.agents/skills/gt-diagnostico-midia-paga/references/padrao-output.md
+++ b/.agents/skills/gt-diagnostico-midia-paga/references/padrao-output.md
@@ -1,0 +1,202 @@
+# Padrão de Output das Skills — V4 Estruturação IA
+
+Este documento define a **estrutura canônica** que todos os outputs de skill devem seguir para renderizar no portal com hierarquia visual consistente. O objetivo é que o operador e o stakeholder final abram qualquer entregável e encontrem o mesmo ritmo: manchete → KPIs → achados categorizados → ponto de alavancagem destacado → detalhes expansíveis.
+
+---
+
+## Princípios
+
+1. **Manchete antes de texto.** Toda skill abre com uma frase única e específica que resume a conclusão. Não é parágrafo, é headline.
+2. **Números em destaque, não escondidos no corpo do texto.** KPIs que importam viram cards. Texto corrido é para contexto, não para fato quantitativo.
+3. **Achados categorizados por intenção.** Cada insight é classificado como `vantagem | contexto | ameaca | acao` — o leitor identifica o tom antes de ler.
+4. **Ponto de alavancagem visualmente isolado.** Toda skill tem UM ponto onde a conversa com o stakeholder precisa acontecer. Esse ponto ganha hero visual (border, gradient, quote destacada).
+5. **Detalhe denso → colapsável.** Listas longas (concorrentes, itens de checklist, fontes) ficam em `<details>` para não afogar a leitura.
+
+---
+
+## Campos obrigatórios no JSON
+
+Todo output de skill DEVE ter estes campos no topo (antes dos campos específicos da skill):
+
+```json
+{
+  "client_name": "Nome do Cliente",
+  "summary": "Resumo em 1-2 frases. Específico, com dados reais. Alimenta o resumo executivo do portal.",
+
+  "summary_headline": "Manchete em 1 linha (max 120 caracteres). A frase que o stakeholder lê primeiro.",
+
+  "summary_highlights": [
+    {
+      "category": "posicao | competicao | janela | maturidade | oportunidade | risco",
+      "label": "Rótulo curto (max 30 char)",
+      "value": "Valor em destaque (número, %, status)",
+      "subtext": "Contexto em 1 linha (max 60 char)",
+      "tone": "green | yellow | red | blue | gray"
+    }
+  ],
+
+  "summary_key_findings": [
+    {
+      "category": "vantagem | contexto | ameaca | acao",
+      "text": "Achado em 1-2 linhas. Específico, acionável."
+    }
+  ]
+}
+```
+
+### Regras dos campos de summary
+
+**`summary_headline`**: É a ÚNICA frase que o stakeholder precisa ler se só tiver 5 segundos. Deve conter o veredito da skill. Exemplos bons:
+- ✓ "[Cliente] é o ÚNICO player premium da microrregião com [diferencial declarado] — janela competitiva de 12-18 meses."
+- ✗ "Análise de mercado concluída com sucesso."
+
+**`summary_highlights`** (4-6 itens): KPIs visuais. Categorias sugeridas:
+- `posicao` — onde o cliente está hoje vs potencial
+- `competicao` — quem disputa o mesmo espaço
+- `janela` — tempo/urgência
+- `maturidade` — estágio atual em algum eixo
+- `oportunidade` — tamanho do ganho possível
+- `risco` — tamanho da ameaça
+
+Agrupar de 2 em 2 por categoria no renderer (dá layout balanceado 3x2 ou 2x2).
+
+**`summary_key_findings`** (3-5 itens): Achados que embasam a manchete. Categorias:
+- `vantagem` (✓ verde) — o que o cliente tem a favor
+- `contexto` (i azul) — o que é fato do mercado, neutro
+- `ameaca` (! vermelho) — o que pode dar errado
+- `acao` (▸ laranja) — o que precisa ser feito
+
+---
+
+## Ponto de Alavancagem (hero block)
+
+Toda skill deve identificar **UM bloco que merece destaque visual especial** — o ponto onde a conversa estratégica precisa acontecer. O nome do campo varia por skill, mas a estrutura é consistente:
+
+```json
+{
+  "key_leverage_point": {
+    "headline": "Frase-manchete do ponto (pode ir como quote)",
+    "context": "Contexto em 2-3 linhas explicando o cenário",
+    "numbered_reasons": [
+      "Razão 1 (parse-friendly, pode começar com texto direto)",
+      "Razão 2",
+      "Razão 3"
+    ],
+    "discussion_anchor": "Frase curta sobre POR QUE este é o ponto de conversa com o stakeholder"
+  }
+}
+```
+
+Exemplos por skill:
+- `pesquisa-mercado` → `unexploited_opportunity` (whitespace estratégico)
+- `persona-icp` → persona principal + dor mais ignorada
+- `swot` → combinação força × oportunidade mais assimétrica
+- `posicionamento` → PUV vs alternativas descartadas
+- `diagnostico-midia` → canal mais subotimizado + upside estimado
+- `diagnostico-maturidade` → pilar mais fraco com maior impacto
+
+O renderer aplica:
+- Border verde 2px + gradient sutil
+- Selo "Whitespace Estratégico · Discussão com Stakeholder" no topo
+- Pill de viabilidade/urgência à direita
+- Quote/headline em card branco isolado
+- Razões numeradas em 3 círculos
+- Footer "💬 Momento de validar com a stakeholder"
+
+---
+
+## Alerta de honestidade
+
+Se a pesquisa/análise revelou fragilidade do cliente (não há diferencial real, ICP mal definido, mercado saturado, etc.), inclua:
+
+```json
+{
+  "honesty_alert": "Texto explicando a fragilidade encontrada e o que precisa ser feito antes de seguir."
+}
+```
+
+Esse campo renderiza em box amarelo/vermelho após os achados. **Nunca omita** se a realidade justifica. O valor do sistema depende de não vender aspiracional como real.
+
+---
+
+## Instrução para a IA da skill
+
+Em cada `SKILL.md`, incluir esta seção na geração:
+
+> ### Estrutura visual (obrigatória)
+>
+> Além dos campos específicos desta skill, gere SEMPRE:
+>
+> - `summary_headline` — manchete em 1 linha com o veredito
+> - `summary_highlights` — 4-6 KPIs categorizados (`posicao|competicao|janela|maturidade|oportunidade|risco`) com `{label, value, subtext, tone}`
+> - `summary_key_findings` — 3-5 achados categorizados (`vantagem|contexto|ameaca|acao`)
+> - `honesty_alert` se houver fragilidade
+>
+> Identifique o **ponto de alavancagem** desta skill (o bloco que merece hero visual) e estruture-o com headline + contexto + razões numeradas + discussion anchor.
+>
+> Consulte `references/padrao-output.md` para especificação completa.
+
+E na auto-validação:
+
+> - [ ] Tem `summary_headline` específico (não "análise concluída")?
+> - [ ] `summary_highlights` tem 4-6 itens com categorias válidas?
+> - [ ] `summary_key_findings` cobre pelo menos 3 dos 4 tipos (vantagem/contexto/ameaça/ação)?
+> - [ ] Identificou o ponto de alavancagem para discussão com stakeholder?
+> - [ ] Se há fragilidade, incluiu `honesty_alert`?
+
+---
+
+## Completude (regra crítica)
+
+**Todo campo definido no schema da skill é obrigatório no output.** Não omitir campos — o renderer assume que os campos do schema existem e quebra/fica vazio silenciosamente quando faltam.
+
+Se um dado **não pode ser obtido** (GA4 não instalado, conector não conectado, cliente não sabe, etc.), preencher com `null` E adicionar `unavailable_reason` no objeto pai:
+
+```json
+{
+  "current_conversion_rate": null,
+  "current_bounce_rate": null,
+  "avg_time_on_page": null,
+  "unavailable_reason": "GA4 não instalado no site — métricas de analytics não coletadas nesta auditoria"
+}
+```
+
+Para arrays vazios legitimamente (ex: nenhum competidor identificado), preencher com `[]` e adicionar uma nota no campo irmão `{campo}_note`:
+
+```json
+{
+  "competitors": [],
+  "competitors_note": "Nenhum concorrente direto identificado na microrregião após busca em Google Maps + Instagram."
+}
+```
+
+Para valores **estimados** (sem fonte pública), adicionar flag `[E]` no texto OU campo `estimated: true` no objeto:
+
+```json
+{ "tam_brl": 450000000, "estimated": true, "estimation_basis": "IBGE população × SEBRAE ticket médio" }
+```
+
+**Nunca** deixar string vazia (`""`), zero falso (`0` quando não é zero real), ou omitir o campo. Essas três formas são invisíveis para o renderer e geram o bug "coluna vazia".
+
+Valide o JSON contra o `schema.json` empacotado na skill e corrija campos ausentes ou `null` sem `unavailable_reason`.
+
+### Checklist adicional de auto-validação
+
+> - [ ] Todos os campos do schema estão presentes (preenchidos ou com `null` + `unavailable_reason`)?
+> - [ ] Nenhuma string vazia (`""`) — substituí por `null` + reason quando o dado não existe?
+> - [ ] Arrays vazios legítimos têm `{campo}_note` explicando por quê?
+> - [ ] Estimativas marcadas com `estimated: true` ou `[E]`?
+
+---
+
+## Tons de voz
+
+- `green` — oportunidade/vantagem/confirmado
+- `yellow` — atenção/potencial/médio
+- `red` — risco/ameaça/fraco
+- `blue` — contexto/informativo/neutro
+- `gray` — desativado/aspiracional/ausente
+
+Usar tons consistentemente: nunca pintar ameaça de verde ou vantagem de vermelho para "chamar atenção". O tom é semântico.
+
+---

--- a/.agents/skills/gt-diagnostico-midia-paga/schema.json
+++ b/.agents/skills/gt-diagnostico-midia-paga/schema.json
@@ -1,0 +1,991 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DiagnosticoMidia",
+  "description": "Output estruturado do diagnostico de midia paga: metricas, benchmarks, diagnostico por dimensao, problemas e plano de acao.",
+  "type": "object",
+  "required": [
+    "summary",
+    "client_name",
+    "segment",
+    "data_source",
+    "data_period",
+    "current_metrics",
+    "benchmarks",
+    "diagnosis_by_dimension",
+    "top_problems",
+    "action_plan",
+    "realistic_goal",
+    "summary_headline",
+    "summary_highlights",
+    "summary_key_findings"
+  ],
+  "properties": {
+    "client_name": {
+      "type": "string",
+      "description": "Nome do cliente"
+    },
+    "summary": {
+      "type": "string",
+      "description": "Resumo de 1-2 frases do diagnóstico de mídia. Inclui principal problema identificado e ROAS atual vs benchmark."
+    },
+    "summary_headline": {
+      "type": "string",
+      "maxLength": 200,
+      "description": "Manchete em 1 linha com o veredito desta skill (hero do resumo executivo no portal). Ver references/padrao-output.md"
+    },
+    "summary_highlights": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 8,
+      "description": "KPIs visuais categorizados para o resumo executivo. Cada item: {category, label, value, subtext, tone}.",
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "label",
+          "value"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "posicao",
+              "competicao",
+              "janela",
+              "maturidade",
+              "oportunidade",
+              "risco"
+            ]
+          },
+          "label": {
+            "type": "string",
+            "maxLength": 40
+          },
+          "value": {
+            "type": "string"
+          },
+          "subtext": {
+            "type": "string",
+            "maxLength": 80
+          },
+          "tone": {
+            "type": "string",
+            "enum": [
+              "green",
+              "yellow",
+              "red",
+              "blue",
+              "gray"
+            ]
+          }
+        }
+      }
+    },
+    "summary_key_findings": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 6,
+      "description": "Achados categorizados por intenção (vantagem/contexto/ameaça/ação). Pelo menos 3 dos 4 tipos cobertos.",
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "text"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "vantagem",
+              "contexto",
+              "ameaca",
+              "acao"
+            ]
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "segment": {
+      "type": "string",
+      "description": "Segmento de atuacao"
+    },
+    "data_source": {
+      "type": "string",
+      "enum": [
+        "v4mos_api",
+        "manual_export",
+        "operator_provided",
+        "no_data"
+      ],
+      "description": "Origem dos dados de midia"
+    },
+    "data_period": {
+      "type": "string",
+      "description": "Periodo dos dados analisados (ex: ultimos 90 dias)"
+    },
+    "monthly_budget": {
+      "type": "number",
+      "description": "Budget mensal em reais"
+    },
+    "platforms_active": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Plataformas de midia paga ativas"
+    },
+    "integrations_status": {
+      "type": "object",
+      "description": "Status das integracoes V4MOS",
+      "properties": {
+        "meta_ads": {
+          "type": "string",
+          "enum": [
+            "connected",
+            "disconnected",
+            "not_configured"
+          ]
+        },
+        "google_ads": {
+          "type": "string",
+          "enum": [
+            "connected",
+            "disconnected",
+            "not_configured"
+          ]
+        },
+        "google_analytics": {
+          "type": "string",
+          "enum": [
+            "connected",
+            "disconnected",
+            "not_configured"
+          ]
+        }
+      }
+    },
+    "current_metrics": {
+      "type": "object",
+      "required": [
+        "cpl",
+        "ctr",
+        "conversion_rate"
+      ],
+      "properties": {
+        "cpl": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Custo por Lead em reais"
+        },
+        "ctr": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Taxa de clique em percentual"
+        },
+        "conversion_rate": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Taxa de conversao da landing page em percentual"
+        },
+        "roas": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Return on Ad Spend (multiplicador)"
+        },
+        "cpc": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Custo por clique em reais"
+        },
+        "total_investment": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Investimento total no periodo em reais"
+        },
+        "total_leads": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Total de leads gerados no periodo"
+        },
+        "total_clicks": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Total de cliques no periodo"
+        },
+        "impressions": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Total de impressoes no periodo"
+        },
+        "frequency": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Frequencia media dos anuncios"
+        }
+      }
+    },
+    "benchmarks": {
+      "type": "object",
+      "description": "Benchmarks do setor para comparacao",
+      "properties": {
+        "cpl": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "CPL benchmark do setor em reais"
+        },
+        "ctr": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "CTR benchmark do setor em percentual"
+        },
+        "conversion_rate": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Taxa de conversao benchmark do setor"
+        },
+        "roas": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "ROAS benchmark do setor"
+        },
+        "cpc": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "CPC benchmark do setor em reais"
+        },
+        "source": {
+          "type": "string",
+          "description": "Fonte dos benchmarks"
+        }
+      }
+    },
+    "diagnosis_by_dimension": {
+      "type": "object",
+      "required": [
+        "account_structure",
+        "creatives",
+        "landing_pages",
+        "audiences"
+      ],
+      "properties": {
+        "account_structure": {
+          "type": "object",
+          "required": [
+            "organization",
+            "segmentation",
+            "budget_allocation",
+            "observation"
+          ],
+          "properties": {
+            "organization": {
+              "type": "string",
+              "enum": [
+                "adequate",
+                "fragmented",
+                "nonexistent"
+              ],
+              "description": "Organizacao de campanhas e conjuntos"
+            },
+            "segmentation": {
+              "type": "string",
+              "description": "Avaliacao da segmentacao vs ICP"
+            },
+            "budget_allocation": {
+              "type": "string",
+              "enum": [
+                "well_distributed",
+                "concentrated",
+                "dispersed"
+              ],
+              "description": "Distribuicao do budget entre campanhas"
+            },
+            "observation": {
+              "type": "string",
+              "description": "Observacao especifica"
+            }
+          }
+        },
+        "creatives": {
+          "type": "object",
+          "required": [
+            "evaluation"
+          ],
+          "properties": {
+            "active_count": {
+              "type": "integer",
+              "description": "Numero de criativos ativos"
+            },
+            "best_performer": {
+              "type": "string",
+              "description": "Criativo com melhor performance e metricas"
+            },
+            "worst_performer": {
+              "type": "string",
+              "description": "Criativo com pior performance e metricas"
+            },
+            "ab_testing_active": {
+              "type": "boolean",
+              "description": "Se ha teste A/B ativo"
+            },
+            "average_frequency": {
+              "type": [
+                "number",
+                "null"
+              ],
+              "description": "Frequencia media"
+            },
+            "fatigue_detected": {
+              "type": "boolean",
+              "description": "Se ha fadiga de criativo detectada"
+            },
+            "evaluation": {
+              "type": "string",
+              "description": "Avaliacao geral dos criativos"
+            }
+          }
+        },
+        "landing_pages": {
+          "type": "object",
+          "required": [
+            "evaluation"
+          ],
+          "properties": {
+            "lp_count": {
+              "type": "integer",
+              "description": "Numero de LPs usadas"
+            },
+            "coherence_with_ads": {
+              "type": "string",
+              "enum": [
+                "high",
+                "medium",
+                "low"
+              ],
+              "description": "Coerencia entre anuncios e LPs"
+            },
+            "estimated_bounce_rate": {
+              "type": [
+                "number",
+                "null"
+              ],
+              "description": "Taxa de rejeicao estimada"
+            },
+            "evaluation": {
+              "type": "string",
+              "description": "Avaliacao geral das LPs"
+            }
+          }
+        },
+        "audiences": {
+          "type": "object",
+          "required": [
+            "evaluation"
+          ],
+          "properties": {
+            "types_used": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "broad",
+                  "interest",
+                  "lookalike",
+                  "retargeting",
+                  "custom"
+                ]
+              },
+              "description": "Tipos de publico usados"
+            },
+            "overlap_detected": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "description": "Se ha sobreposicao de publicos"
+            },
+            "retargeting_active": {
+              "type": "boolean",
+              "description": "Se retargeting esta ativo"
+            },
+            "evaluation": {
+              "type": "string",
+              "description": "Avaliacao geral de publicos"
+            }
+          }
+        }
+      }
+    },
+    "top_problems": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "problem",
+          "data_evidence",
+          "impact"
+        ],
+        "properties": {
+          "problem": {
+            "type": "string",
+            "description": "Descricao do problema"
+          },
+          "data_evidence": {
+            "type": "string",
+            "description": "Evidencia nos dados que comprova o problema"
+          },
+          "impact": {
+            "type": "string",
+            "description": "Impacto estimado (quanto esta custando)"
+          },
+          "dimension": {
+            "type": "string",
+            "enum": [
+              "account_structure",
+              "creatives",
+              "landing_pages",
+              "audiences"
+            ],
+            "description": "Dimensao do problema"
+          }
+        }
+      },
+      "description": "Top 3 problemas criticos, em ordem de impacto"
+    },
+    "action_plan": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "action",
+          "priority",
+          "expected_impact",
+          "responsible"
+        ],
+        "properties": {
+          "action": {
+            "type": "string",
+            "description": "Descricao da acao"
+          },
+          "priority": {
+            "type": "string",
+            "enum": [
+              "high",
+              "medium",
+              "normal"
+            ],
+            "description": "Prioridade da acao"
+          },
+          "expected_impact": {
+            "type": "string",
+            "description": "Impacto esperado"
+          },
+          "responsible": {
+            "type": "string",
+            "description": "Quem e responsavel pela execucao"
+          },
+          "deadline": {
+            "type": "string",
+            "description": "Prazo (ex: Semana 1, Semana 2)"
+          }
+        }
+      },
+      "description": "Plano de acao para os proximos 30 dias"
+    },
+    "realistic_goal": {
+      "type": "object",
+      "required": [
+        "justification"
+      ],
+      "properties": {
+        "target_cpl": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "CPL alvo em 90 dias (em reais)"
+        },
+        "target_roas": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "ROAS alvo em 90 dias (multiplicador)"
+        },
+        "justification": {
+          "type": "string",
+          "description": "Justificativa da meta com base nos dados"
+        },
+        "assumptions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Premissas para atingir a meta"
+        },
+        "risk_factors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Fatores de risco que podem impedir a meta"
+        }
+      }
+    },
+    "keyword_clusters": {
+      "type": "array",
+      "description": "Agrupamento estratégico de keywords de search (4-6 clusters).",
+      "items": {
+        "type": "object",
+        "required": [
+          "cluster"
+        ],
+        "properties": {
+          "cluster": {
+            "type": "string"
+          },
+          "keywords": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "intent": {
+            "type": "string",
+            "enum": [
+              "navigational",
+              "informational",
+              "transactional",
+              "commercial"
+            ]
+          },
+          "budget_allocation_pct": {
+            "type": "number"
+          },
+          "expected_cpc_range": {
+            "type": "string"
+          },
+          "bid_strategy": {
+            "type": "string"
+          },
+          "copy_angle": {
+            "type": "string"
+          },
+          "risk": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "budget_reallocation_scenarios": {
+      "type": "object",
+      "description": "3 cenários de realocação de budget (A conservador, B realista, C agressivo).",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "scenario_a_conservative": {
+          "$ref": "#/definitions/budgetScenario"
+        },
+        "scenario_b_realistic": {
+          "$ref": "#/definitions/budgetScenario"
+        },
+        "scenario_c_aggressive": {
+          "$ref": "#/definitions/budgetScenario"
+        },
+        "recommendation": {
+          "type": "string"
+        }
+      }
+    },
+    "creative_testing_hypotheses": {
+      "type": "object",
+      "description": "Hipóteses de testes A/B de criativos.",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "hypotheses": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "id",
+              "hypothesis"
+            ],
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "hypothesis": {
+                "type": "string"
+              },
+              "angle": {
+                "type": "string"
+              },
+              "format": {
+                "type": "string"
+              },
+              "hook": {
+                "type": "string"
+              },
+              "body": {
+                "type": "string"
+              },
+              "cta": {
+                "type": "string"
+              },
+              "target_audience": {
+                "type": "string"
+              },
+              "success_criteria": {
+                "type": "string"
+              },
+              "testing_budget": {
+                "type": "number"
+              },
+              "testing_duration_days": {
+                "type": "number"
+              }
+            }
+          }
+        },
+        "testing_budget_total_week_1": {
+          "type": "number"
+        }
+      }
+    },
+    "daypart_optimization": {
+      "type": "object",
+      "description": "Ajustes de lance por janela de dia/hora.",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "adjustments": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "day_time"
+            ],
+            "properties": {
+              "day_time": {
+                "type": "string"
+              },
+              "bid_adjustment_pct": {
+                "type": "number"
+              },
+              "rationale": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "forecast_sensitivity_analysis": {
+      "type": "object",
+      "description": "Análise de sensibilidade da meta: base_case + variações what-if. NOTA: o renderer do portal NÃO exibe mais o gráfico de sensibilidade — apenas os cards de detalhe (base_case + lista de variations). Mantenha os dados ricos mesmo assim, eles alimentam os cards.",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "base_case": {
+          "type": "object",
+          "description": "Caso base da projeção. Aceita nomenclatura com sufixo '_90d' ou sem.",
+          "properties": {
+            "leads_monthly": {
+              "type": "number",
+              "description": "Leads mensais no base case. Nome preferido."
+            },
+            "leads_month_90d": {
+              "type": "number",
+              "description": "Alternativa a leads_monthly (leads projetados ao final de 90d)."
+            },
+            "cpl": {
+              "type": "number",
+              "description": "CPL no base case (R$). Nome preferido."
+            },
+            "cpl_90d_brl": {
+              "type": "number",
+              "description": "Alternativa a cpl."
+            },
+            "cac": {
+              "type": "number",
+              "description": "CAC no base case (R$)."
+            },
+            "cac_90d_brl": {
+              "type": "number",
+              "description": "Alternativa a cac."
+            },
+            "revenue_monthly": {
+              "type": "number",
+              "description": "Receita mensal projetada."
+            },
+            "roas": {
+              "type": "number",
+              "description": "ROAS no base case."
+            }
+          }
+        },
+        "variations": {
+          "type": "array",
+          "description": "Cenários what-if. O renderer exibe como lista de cards (sem gráfico). 4-6 itens.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "scenario": {
+                "type": "string",
+                "description": "Nome do cenário (ex: 'CPC +10%'). Nome preferido."
+              },
+              "scenario_name": {
+                "type": "string",
+                "description": "Alternativa a scenario."
+              },
+              "variable_change": {
+                "type": "string",
+                "description": "Descrição da mudança na variável."
+              },
+              "impact_on_leads": {
+                "type": "string",
+                "description": "Impacto em leads (texto ou número). Nome preferido."
+              },
+              "impact_on_leads_month_90d": {
+                "type": [
+                  "string",
+                  "number"
+                ],
+                "description": "Alternativa numérica — variação em leads/mês no 90d."
+              },
+              "impact_on_cpl": {
+                "type": "string",
+                "description": "Impacto no CPL. Nome preferido."
+              },
+              "impact_on_cpl_brl": {
+                "type": [
+                  "string",
+                  "number"
+                ],
+                "description": "Alternativa numérica (R$)."
+              },
+              "impact_on_revenue": {
+                "type": "string",
+                "description": "Impacto na receita."
+              },
+              "delta_vs_base_pct": {
+                "type": "number",
+                "description": "Variação vs. base_case em % (ex: -15.5 = -15.5%). Usado pelos cards de detalhe."
+              }
+            }
+          }
+        }
+      }
+    },
+    "is_launch_plan": {
+      "type": "boolean",
+      "default": false,
+      "description": "Se true, este e um plano de lancamento (cliente nao tem midia ativa)"
+    },
+    "completed_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Data/hora de conclusao"
+    },
+    "key_insight": {
+      "type": "object",
+      "description": "Ponto de alavancagem desta skill — o bloco que merece destaque visual para conversa com o stakeholder. Ver PADRAO-OUTPUT.md.",
+      "properties": {
+        "headline": {
+          "type": "string",
+          "description": "Frase-manchete do ponto (pode virar quote destacada no renderer)"
+        },
+        "context": {
+          "type": "string",
+          "description": "Contexto em 2-3 linhas explicando o cenário"
+        },
+        "numbered_reasons": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Razões numeradas (o renderer vira 3 cards numerados)"
+        },
+        "discussion_anchor": {
+          "type": "string",
+          "description": "Por que este é o ponto para stakeholder decidir/validar"
+        }
+      }
+    },
+    "honesty_alert": {
+      "type": "string",
+      "description": "Alerta se a análise revelou fragilidade real do cliente (não há diferencial claro, premissa contraditória, etc.). Nunca omitir se justificado."
+    }
+  },
+  "definitions": {
+    "budgetScenario": {
+      "type": "object",
+      "description": "Cenário de realocação de budget. Aceita dois conjuntos de nomes — o renderer do portal usa '??' para cair no alternativo quando o preferido está ausente.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Nome do cenário (ex: 'Conservador'). Nome preferido."
+        },
+        "label": {
+          "type": "string",
+          "description": "Alternativa a name."
+        },
+        "total_budget_monthly": {
+          "type": "number",
+          "description": "Budget total mensal em R$. Se ausente, o renderer soma google_split + meta_split (ou os valores dentro de google_allocation/meta_allocation)."
+        },
+        "google_split": {
+          "type": "number",
+          "description": "Valor em R$ para Google Ads. Nome preferido."
+        },
+        "meta_split": {
+          "type": "number",
+          "description": "Valor em R$ para Meta Ads. Nome preferido."
+        },
+        "google_allocation": {
+          "type": "object",
+          "description": "Alternativa estruturada a google_split. Se presente, o renderer usa .value (ou .amount/.brl) como valor.",
+          "properties": {
+            "value": {
+              "type": "number"
+            },
+            "amount": {
+              "type": "number"
+            },
+            "brl": {
+              "type": "number"
+            },
+            "pct": {
+              "type": "number",
+              "description": "Percentual do total alocado."
+            }
+          }
+        },
+        "meta_allocation": {
+          "type": "object",
+          "description": "Alternativa estruturada a meta_split.",
+          "properties": {
+            "value": {
+              "type": "number"
+            },
+            "amount": {
+              "type": "number"
+            },
+            "brl": {
+              "type": "number"
+            },
+            "pct": {
+              "type": "number"
+            }
+          }
+        },
+        "campaigns_structure": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "campaign": {
+                "type": "string"
+              },
+              "platform": {
+                "type": "string"
+              },
+              "budget_monthly": {
+                "type": "number"
+              },
+              "objective": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "expected_leads_monthly": {
+          "type": "number",
+          "description": "Leads mensais esperados. Nome preferido."
+        },
+        "projected_leads_month": {
+          "type": "number",
+          "description": "Alternativa a expected_leads_monthly."
+        },
+        "expected_cpl": {
+          "type": "number",
+          "description": "CPL esperado (R$). Nome preferido."
+        },
+        "projected_cpl": {
+          "type": "number",
+          "description": "Alternativa a expected_cpl."
+        },
+        "expected_roas": {
+          "type": "number",
+          "description": "ROAS esperado."
+        },
+        "delta_leads": {
+          "type": [
+            "number",
+            "string"
+          ],
+          "description": "Variação de leads vs. cenário atual (número absoluto ou '+15%')."
+        },
+        "effort_weeks": {
+          "type": "number",
+          "description": "Semanas de esforço para implementar o cenário."
+        },
+        "confidence": {
+          "type": "string",
+          "enum": [
+            "high",
+            "medium",
+            "low",
+            "alta",
+            "média",
+            "media",
+            "baixa"
+          ],
+          "description": "Nível de confiança na projeção."
+        },
+        "risk_assessment": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/.agents/skills/gt-diagnostico-organico-instagram/SKILL.md
+++ b/.agents/skills/gt-diagnostico-organico-instagram/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: gt-diagnostico-organico-instagram
+description: "Diagnostico de conteudo organico no Instagram — cliente vs 2 concorrentes, ultimos 90 dias, via Instagram Graph API + business_discovery. Use quando o operador disser /gt-diagnostico-organico-instagram ou 'analisar conteudo organico' ou 'diagnostico de instagram' ou 'analise de conteudo do cliente'."
+area: gt
+author: luizfreitasv4
+version: 1.0.0
+dependencies:
+  - geral-persona-icp
+  - geral-pesquisa-mercado
+tools: []
+week: 2
+estimated_time: "45min"
+output_file: "gt-diagnostico-organico-instagram.json"
+multimodal: true
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta versao foi portada do sistema de Estruturacao Estrategica. As regras abaixo tem precedencia sobre caminhos e persistencia citados no fluxo original:
+
+- Trabalhe somente em `squads/{squad}/clientes/{cliente}/`, nunca em um diretorio `clientes/` solto na raiz.
+- Leia primeiro o `CLAUDE.md` ou `AGENTS.md` da KB, `mission-control/`, `calls/`, `docs/` e `campanhas/`.
+- Se `client.json` existir, use-o como fonte complementar. Se nao existir, derive o contexto da KB e do Mission Control; nao exija nem invente esse arquivo.
+- Salve entregaveis em `squads/{squad}/clientes/{cliente}/outputs/`, em JSON e Markdown quando o fluxo pedir ambos.
+- Registre decisoes e progresso no `mission-control/historico-checkins.md` ou no arquivo de historico equivalente encontrado na KB.
+- Resolva recursos empacotados a partir do proprio diretorio desta skill. Se uma integracao externa nao estiver configurada, declare o gap e continue apenas com os dados reais disponiveis.
+
+
+# Diagnostico de Conteudo Organico — Instagram (POP 2.2)
+
+> **Posição no fluxo:** Semana 2 — comum a todos os modelos. Engagement sempre **normalizado por seguidores** (taxa, não absoluto). Gera ações editoriais guiadas por gaps dos concorrentes.
+
+Voce e um diretor de conteudo digital focado em PMEs brasileiras. Vai rodar um diagnostico comparativo do feed organico do cliente contra 2 concorrentes no Instagram — ultimos 90 dias — usando dados reais da Instagram Graph API (sem necessidade de acesso do cliente), com embed oficial dos posts no portal.
+
+**CAPACIDADE MULTIMODAL:** Voce pode analisar visualmente as mídias baixadas (imagens e thumbnails de vídeo) para complementar a analise quantitativa.
+
+## Pre-requisitos
+
+1. `.credentials/meta-graph-api.json` preenchido com token de longa duracao (60 dias) valido.
+   - O token DEVE incluir as permissions: `instagram_basic`, `instagram_manage_insights`, `pages_show_list`, `pages_read_engagement`. Sem `instagram_manage_insights` o endpoint `business_discovery` retorna erro #10.
+2. Cliente com conta Instagram Business ou Creator (validar via business_discovery antes).
+3. `outputs/geral-pesquisa-mercado.json` presente (usado para selecionar os 2 concorrentes automaticamente).
+
+## Selecao automatica de concorrentes (regra fixa)
+
+1. Ler `outputs/geral-pesquisa-mercado.json` → `competitors[]`
+2. Ordenar por `digital_score` DESC
+3. Pegar os **TOP 2** com handle Instagram conhecido
+4. Validar via `business_discovery` — se algum nao for Business/Creator, cair para o #3, e assim por diante
+5. Se o @handle de um concorrente nao estiver mapeado no briefing ou na pesquisa, perguntar ao operador uma unica vez
+
+Nunca deixe o operador decidir manualmente a menos que a regra falhe — padrao e automatico.
+
+## Dados necessarios
+
+1. Leia `client.json` (seção `briefing`) — extraia: NOME_CLIENTE, SEGMENTO, instagram (handle do cliente), ICP resumido, tom de voz
+2. Leia `outputs/geral-persona-icp.json` — extraia: RESUMO_ICP, dores, linguagem
+3. Leia `outputs/geral-posicionamento-estrategico.json` — extraia: PUV, tagline, territorio, tom
+4. Leia `outputs/geral-pesquisa-mercado.json` — extraia TOP 2 competitors por `digital_score`
+
+Se faltar o @handle do cliente no briefing, pergunte:
+
+> Qual o @ do Instagram do {NOME_CLIENTE}?
+
+## Execucao
+
+O script empacotado usa `client.json` para descobrir o handle do cliente e os concorrentes. Se esse arquivo não existir na KB do Hub, não o crie só para satisfazer o script: peça os três handles ao operador e faça a coleta pela integração disponível ou trabalhe com uma exportação fornecida, sempre registrando a limitação.
+
+```bash
+bash .claude/skills/gt-diagnostico-organico-instagram/scripts/ig_organic_audit.sh squads/{squad}/clientes/{cliente}
+```
+
+O script:
+1. Lê `.credentials/meta-graph-api.json`, `client.json`, `outputs/geral-pesquisa-mercado.json`
+2. Identifica o handle do cliente + 2 concorrentes top do scorecard
+3. Chama `business_discovery` para cada um (perfil + posts 90 dias)
+4. Calcula metricas publicas (engagement proxy) e classifica por formato/cadencia
+5. Salva raw em `squads/{squad}/clientes/{cliente}/cache/ig_organic_audit-{ts}.json`
+6. Condensa em `squads/{squad}/clientes/{cliente}/cache/ig_organic_audit-summary.json` — input direto pra skill gerar o output
+
+## Geracao
+
+Gere o output COMPLETO de uma vez usando o summary do script + outputs de dependencias.
+
+Interpretacoes obrigatorias (nao pular):
+
+### `top_posts` (top 3 por conta)
+Para CADA post nos top 3 de CADA uma das 3 contas:
+- `permalink` → `embed_url` = `permalink` + `embed/` (o portal vai montar o iframe)
+- Caption completa, formato (FEED/REELS/CAROUSEL), likes, comments, engagement_proxy
+- **Diagnostico qualitativo**: o que esta funcionando neste post (hook, visual, angulo). 2 frases objetivas.
+- Se for concorrente e o cliente NAO tem algo similar, marcar `gap_para_cliente: true` e explicar o que replicar.
+
+### `bottom_posts` (bottom 3 do CLIENTE apenas)
+Os 3 piores do cliente por engagement_proxy:
+- Mesmo formato dos top_posts
+- **Diagnostico de por que quebrou** — hipotese: caption fraca? hora errada? formato errado? falta de hook?
+
+### `format_distribution` e `cadence`
+Tabela comparativa das 3 contas. Aponte especificamente onde o cliente esta DESALINHADO com quem performa melhor (ex: concorrente posta 60% em Reels, cliente posta 10%).
+
+### `competitor_patterns_missing` (priorizado)
+Padroes recorrentes que aparecem nos concorrentes e NAO aparecem no cliente. Cada item com:
+- Descricao do padrao
+- Quantos posts dos concorrentes usam
+- Por que provavelmente funciona para o ICP do cliente
+- Como o cliente poderia implementar
+
+Esta e a parte mais acionavel do relatorio.
+
+### `client_winning_patterns`
+Padroes do cliente acima da media — replicar e amplificar.
+
+### `instagram_compliance`
+Checagem rapida de aspect ratio, uso de texto em imagem, safe zones de Reels. Usar dados publicos (aspect ratio via media_url, analise visual dos frames extraidos).
+
+### `next_actions`
+Lista priorizada de 5-8 acoes (o que mudar, qual formato testar, qual tipo de conteudo replicar). Cada uma com impacto estimado + facilidade.
+
+## Auto-validacao
+
+- [ ] Mencionou o cliente pelo nome?
+- [ ] Usou dados reais da Graph API (nao inventou numeros)?
+- [ ] Nenhum item generico?
+- [ ] Schema validou?
+- [ ] Top 3 de cada conta tem permalink valido + embed_url?
+- [ ] Consistente com ICP e posicionamento?
+- [ ] Padroes missing sao acionaveis (nao "melhorar conteudo")?
+- [ ] next_actions sao especificos?
+
+Se falhou → regenere silenciosamente.
+
+## Apresentacao e decisoes
+
+Apresente o output COMPLETO ao operador.
+
+- "Os posts top 3 do cliente e concorrentes batem com o que voce observou empiricamente?"
+- "Algum padrao dos concorrentes que voce ja sabia que funciona e esta aqui listado?"
+- "As proximas acoes sao factiveis no time atual?"
+- "Alguma limitacao do cliente que eu nao considerei? (ex: nao pode gravar Reels pra quem tem pouco tempo de filmagem)"
+
+## Finalizacao
+
+1. Salve `squads/{squad}/clientes/{cliente}/outputs/gt-diagnostico-organico-instagram.json` (com `summary` no topo)
+2. Atualize `client.json`: progress.skills → completed, version++, history[]
+3. Salve também uma versão Markdown do diagnóstico na pasta de outputs compatível com o Hub.
+4. Sugira proxima skill:
+   - "Diagnostico organico IG concluido. Cliente: {followers} seguidores, {posts_90d} posts/90d. Top formato do cliente: {formato}. Gaps identificados: {numero}."
+   - "Este diagnostico alimenta: /designer-criativos-anuncios (padroes que funcionam para o ICP no organico)"
+   - "Próximo passo recomendado: consolidar os diagnósticos com /gt-diagnostico-maturidade-digital e fechar com /geral-posicionamento-estrategico."
+
+## Campo obrigatorio: summary
+
+```json
+"summary": "Resumo 1-2 frases com nome do cliente, metricas-chave (eng_proxy cliente vs top concorrente), gap principal e acao prioritaria. Sem generico."
+```

--- a/.agents/skills/gt-diagnostico-organico-instagram/schema.json
+++ b/.agents/skills/gt-diagnostico-organico-instagram/schema.json
@@ -1,0 +1,522 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DiagnosticoOrganicoIG",
+  "description": "Diagnostico comparativo de conteudo organico no Instagram — cliente vs 2 concorrentes, 90 dias, via Graph API + business_discovery.",
+  "type": "object",
+  "required": [
+    "summary",
+    "client_name",
+    "period",
+    "client_account",
+    "competitor_accounts",
+    "format_distribution",
+    "cadence",
+    "engagement_benchmark",
+    "top_posts",
+    "bottom_posts",
+    "competitor_patterns_missing",
+    "client_winning_patterns",
+    "next_actions",
+    "summary_headline",
+    "summary_highlights",
+    "summary_key_findings"
+  ],
+  "properties": {
+    "client_name": {
+      "type": "string"
+    },
+    "summary": {
+      "type": "string",
+      "description": "Resumo 1-2 frases com cliente, metricas-chave, gap principal, acao prioritaria."
+    },
+    "summary_headline": {
+      "type": "string",
+      "description": "Manchete em 1 linha (~120 caracteres) com o veredito da skill."
+    },
+    "summary_highlights": {
+      "type": "array",
+      "description": "KPIs em destaque (4-6 itens). Categorias: posicao | competicao | janela | maturidade | oportunidade | risco.",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "label",
+          "value",
+          "tone"
+        ],
+        "properties": {
+          "category": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "subtext": {
+            "type": "string"
+          },
+          "tone": {
+            "type": "string",
+            "enum": [
+              "green",
+              "yellow",
+              "red",
+              "blue",
+              "gray"
+            ]
+          }
+        }
+      }
+    },
+    "summary_key_findings": {
+      "type": "array",
+      "description": "3-5 achados categorizados (vantagem | contexto | ameaca | acao).",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "text"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "vantagem",
+              "contexto",
+              "ameaca",
+              "acao"
+            ]
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "period": {
+      "type": "object",
+      "required": [
+        "start",
+        "end",
+        "days"
+      ],
+      "properties": {
+        "start": {
+          "type": "string",
+          "format": "date"
+        },
+        "end": {
+          "type": "string",
+          "format": "date"
+        },
+        "days": {
+          "type": "integer"
+        }
+      }
+    },
+    "client_account": {
+      "$ref": "#/definitions/account"
+    },
+    "competitor_accounts": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 3,
+      "items": {
+        "$ref": "#/definitions/account"
+      }
+    },
+    "format_distribution": {
+      "type": "object",
+      "description": "Distribuicao por formato (FEED_IMAGE / CAROUSEL / REELS / VIDEO) por conta.",
+      "required": [
+        "by_account",
+        "insight"
+      ],
+      "properties": {
+        "by_account": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "username",
+              "counts"
+            ],
+            "properties": {
+              "username": {
+                "type": "string"
+              },
+              "counts": {
+                "type": "object",
+                "properties": {
+                  "FEED_IMAGE": {
+                    "type": "integer"
+                  },
+                  "CAROUSEL": {
+                    "type": "integer"
+                  },
+                  "REELS": {
+                    "type": "integer"
+                  },
+                  "VIDEO": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "insight": {
+          "type": "string",
+          "description": "Leitura comparativa (onde o cliente esta desalinhado)."
+        }
+      }
+    },
+    "cadence": {
+      "type": "object",
+      "required": [
+        "by_account",
+        "insight"
+      ],
+      "properties": {
+        "by_account": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "username",
+              "posts_per_week"
+            ],
+            "properties": {
+              "username": {
+                "type": "string"
+              },
+              "posts_per_week": {
+                "type": "number"
+              },
+              "preferred_weekday": {
+                "type": "string"
+              },
+              "preferred_hour": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "insight": {
+          "type": "string"
+        }
+      }
+    },
+    "engagement_benchmark": {
+      "type": "object",
+      "required": [
+        "by_account",
+        "insight"
+      ],
+      "properties": {
+        "by_account": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "username",
+              "avg_likes",
+              "avg_comments",
+              "avg_engagement_proxy"
+            ],
+            "properties": {
+              "username": {
+                "type": "string"
+              },
+              "avg_likes": {
+                "type": "number"
+              },
+              "avg_comments": {
+                "type": "number"
+              },
+              "avg_engagement_proxy": {
+                "type": "number",
+                "description": "(likes + 3*comments) / followers * 100"
+              },
+              "best_format_by_engagement": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "insight": {
+          "type": "string"
+        }
+      }
+    },
+    "top_posts": {
+      "type": "array",
+      "description": "Top 3 posts de cada conta (cliente + 2 concorrentes) por engagement_proxy.",
+      "minItems": 3,
+      "items": {
+        "$ref": "#/definitions/post"
+      }
+    },
+    "bottom_posts": {
+      "type": "array",
+      "description": "Bottom 3 posts do CLIENTE apenas — posts com menor engagement_proxy.",
+      "minItems": 1,
+      "maxItems": 3,
+      "items": {
+        "$ref": "#/definitions/post"
+      }
+    },
+    "competitor_patterns_missing": {
+      "type": "array",
+      "description": "Padroes recorrentes em concorrentes que o cliente nao usa.",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "pattern",
+          "seen_in_count",
+          "why_works",
+          "how_to_apply"
+        ],
+        "properties": {
+          "pattern": {
+            "type": "string"
+          },
+          "seen_in_count": {
+            "type": "integer"
+          },
+          "seen_in_competitors": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "example_permalinks": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "why_works": {
+            "type": "string"
+          },
+          "how_to_apply": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "client_winning_patterns": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "pattern",
+          "seen_in_count",
+          "recommendation"
+        ],
+        "properties": {
+          "pattern": {
+            "type": "string"
+          },
+          "seen_in_count": {
+            "type": "integer"
+          },
+          "example_permalinks": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "recommendation": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "instagram_compliance": {
+      "type": "object",
+      "properties": {
+        "aspect_ratio_issues_count": {
+          "type": "integer"
+        },
+        "notes": {
+          "type": "string"
+        }
+      }
+    },
+    "next_actions": {
+      "type": "array",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "action",
+          "impact",
+          "effort",
+          "priority"
+        ],
+        "properties": {
+          "action": {
+            "type": "string"
+          },
+          "impact": {
+            "type": "string",
+            "enum": [
+              "alto",
+              "medio",
+              "baixo"
+            ]
+          },
+          "effort": {
+            "type": "string",
+            "enum": [
+              "baixo",
+              "medio",
+              "alto"
+            ]
+          },
+          "priority": {
+            "type": "integer",
+            "minimum": 1
+          }
+        }
+      }
+    },
+    "completed_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "definitions": {
+    "account": {
+      "type": "object",
+      "required": [
+        "username",
+        "name",
+        "followers_count",
+        "media_count_total",
+        "posts_90d"
+      ],
+      "properties": {
+        "username": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "biography": {
+          "type": "string"
+        },
+        "profile_picture_url": {
+          "type": "string"
+        },
+        "website": {
+          "type": "string"
+        },
+        "followers_count": {
+          "type": "integer"
+        },
+        "follows_count": {
+          "type": "integer"
+        },
+        "media_count_total": {
+          "type": "integer"
+        },
+        "posts_90d": {
+          "type": "integer"
+        },
+        "permalink": {
+          "type": "string"
+        }
+      }
+    },
+    "post": {
+      "type": "object",
+      "required": [
+        "username",
+        "permalink",
+        "embed_url",
+        "media_type",
+        "format",
+        "timestamp",
+        "caption",
+        "like_count",
+        "comments_count",
+        "engagement_proxy",
+        "diagnosis"
+      ],
+      "properties": {
+        "username": {
+          "type": "string"
+        },
+        "post_id": {
+          "type": "string"
+        },
+        "permalink": {
+          "type": "string"
+        },
+        "embed_url": {
+          "type": "string",
+          "description": "permalink + 'embed/' — o portal monta o iframe oficial do Instagram."
+        },
+        "media_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string",
+          "enum": [
+            "FEED_IMAGE",
+            "CAROUSEL",
+            "REELS",
+            "VIDEO"
+          ]
+        },
+        "thumbnail_url": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "caption": {
+          "type": "string"
+        },
+        "caption_length": {
+          "type": "integer"
+        },
+        "hashtags_count": {
+          "type": "integer"
+        },
+        "mentions_count": {
+          "type": "integer"
+        },
+        "has_cta": {
+          "type": "boolean"
+        },
+        "like_count": {
+          "type": "integer"
+        },
+        "comments_count": {
+          "type": "integer"
+        },
+        "engagement_proxy": {
+          "type": "number",
+          "description": "(likes + 3*comments) / followers * 100"
+        },
+        "diagnosis": {
+          "type": "string",
+          "description": "2 frases: o que funcionou (se top) ou o que quebrou (se bottom)."
+        },
+        "gap_para_cliente": {
+          "type": "boolean",
+          "description": "Se este eh um post de concorrente e o cliente nao tem padrao similar."
+        }
+      }
+    }
+  }
+}

--- a/.agents/skills/gt-diagnostico-organico-instagram/scripts/ig_organic_audit.py
+++ b/.agents/skills/gt-diagnostico-organico-instagram/scripts/ig_organic_audit.py
@@ -1,0 +1,474 @@
+#!/usr/bin/env python3
+"""
+ig_organic_audit.py — Coleta publica via Instagram Graph API + business_discovery.
+
+Uso:
+  python3 ig_organic_audit.py <client_dir>
+
+Le:
+  .credentials/meta-graph-api.json  (token longo + ig_business_account_v4)
+  <client_dir>/client.json          (briefing.instagram = @handle do cliente)
+  <client_dir>/outputs/geral-pesquisa-mercado.json  (escolhe top 2 concorrentes por digital_score)
+
+Grava:
+  <client_dir>/cache/ig_organic_audit-<ts>.json         (raw por conta)
+  <client_dir>/cache/ig_organic_audit-summary.json      (input direto para a skill)
+"""
+
+import json
+import os
+import re
+import sys
+import time
+import urllib.request
+import urllib.parse
+import urllib.error
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+
+GRAPH_BASE = "https://graph.facebook.com/v21.0"
+DAYS_WINDOW = 90
+TOP_N = 3
+BOTTOM_N = 3
+
+
+def log(msg):
+    print(f"[ig_audit] {msg}", flush=True)
+
+
+def die(msg, code=1):
+    print(f"[ig_audit] ERRO: {msg}", file=sys.stderr, flush=True)
+    sys.exit(code)
+
+
+def find_credentials(client_dir: Path) -> Path:
+    d = client_dir.resolve()
+    for _ in range(6):
+        candidate = d / ".credentials" / "meta-graph-api.json"
+        if candidate.exists():
+            return candidate
+        if d.parent == d:
+            break
+        d = d.parent
+    die("meta-graph-api.json nao encontrado subindo a partir de " + str(client_dir))
+
+
+def http_get(url: str, retries: int = 3, backoff: float = 1.5):
+    last_err = None
+    for i in range(retries):
+        try:
+            req = urllib.request.Request(url, headers={"User-Agent": "v4-ig-audit/1.0"})
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                data = resp.read().decode("utf-8")
+                return json.loads(data)
+        except urllib.error.HTTPError as e:
+            body = e.read().decode("utf-8", errors="ignore")
+            last_err = f"HTTP {e.code}: {body[:400]}"
+            if e.code in (500, 502, 503, 504):
+                time.sleep(backoff ** i)
+                continue
+            raise RuntimeError(last_err)
+        except Exception as e:
+            last_err = str(e)
+            time.sleep(backoff ** i)
+    raise RuntimeError(last_err or "http_get falhou")
+
+
+def clean_handle(h: str) -> str:
+    if not h:
+        return ""
+    h = h.strip()
+    m = re.search(r"instagram\.com/([^/?#]+)", h)
+    if m:
+        h = m.group(1)
+    return h.lstrip("@").strip("/").strip()
+
+
+def call_business_discovery(ig_user_id: str, target_username: str, token: str, since_iso: str):
+    """
+    Uma unica chamada retorna perfil + posts recentes (limit=50).
+    Inclui paginacao manual via next cursor.
+    """
+    fields = (
+        "business_discovery.username(" + target_username + "){"
+        "id,username,name,biography,profile_picture_url,website,followers_count,"
+        "follows_count,media_count,"
+        "media.limit(50){id,caption,media_type,media_product_type,media_url,"
+        "permalink,thumbnail_url,timestamp,like_count,comments_count,children{media_type,media_url}}"
+        "}"
+    )
+    url = f"{GRAPH_BASE}/{ig_user_id}?fields={urllib.parse.quote(fields)}&access_token={token}"
+    payload = http_get(url)
+    bd = payload.get("business_discovery")
+    if not bd:
+        raise RuntimeError(f"business_discovery vazio para @{target_username}: {json.dumps(payload)[:400]}")
+
+    # Paginacao: tentamos uma segunda pagina se tiver
+    posts = (bd.get("media") or {}).get("data") or []
+    after = ((bd.get("media") or {}).get("paging") or {}).get("cursors", {}).get("after")
+    pages = 1
+    # Filtro 90d — se a ultima ja eh mais antiga, nao precisa paginar
+    def oldest_ts(items):
+        if not items: return None
+        return min(p.get("timestamp","") for p in items)
+
+    while after and pages < 5:
+        last_old = oldest_ts(posts)
+        if last_old and last_old < since_iso:
+            break
+        fields2 = (
+            "business_discovery.username(" + target_username + "){"
+            "media.after(" + after + ").limit(50){id,caption,media_type,media_product_type,media_url,"
+            "permalink,thumbnail_url,timestamp,like_count,comments_count,children{media_type,media_url}}"
+            "}"
+        )
+        url2 = f"{GRAPH_BASE}/{ig_user_id}?fields={urllib.parse.quote(fields2)}&access_token={token}"
+        try:
+            nxt = http_get(url2)
+        except Exception as e:
+            log(f"paginacao parou: {e}")
+            break
+        nbd = nxt.get("business_discovery") or {}
+        nposts = (nbd.get("media") or {}).get("data") or []
+        if not nposts:
+            break
+        posts.extend(nposts)
+        after = ((nbd.get("media") or {}).get("paging") or {}).get("cursors", {}).get("after")
+        pages += 1
+
+    bd["_all_media"] = posts
+    return bd
+
+
+def classify_format(p: dict) -> str:
+    mt = (p.get("media_type") or "").upper()
+    mpt = (p.get("media_product_type") or "").upper()
+    if mpt == "REELS":
+        return "REELS"
+    if mt == "CAROUSEL_ALBUM":
+        return "CAROUSEL"
+    if mt == "VIDEO":
+        return "VIDEO"
+    if mt == "IMAGE":
+        return "FEED_IMAGE"
+    return mt or "UNKNOWN"
+
+
+def post_summary(p: dict, username: str, followers: int):
+    caption = p.get("caption") or ""
+    likes = p.get("like_count") or 0
+    comments = p.get("comments_count") or 0
+    eng = 0.0
+    if followers and followers > 0:
+        eng = round((likes + 3 * comments) / followers * 100, 3)
+    permalink = p.get("permalink") or ""
+    embed = permalink.rstrip("/") + "/embed/" if permalink else ""
+    caption_clean = caption.replace("\n", " ").strip()
+    hashtags = re.findall(r"#\w+", caption)
+    mentions = re.findall(r"@\w+", caption)
+    cta_markers = ["clique", "acesse", "agende", "whatsapp", "link", "bio", "chama", "reserve", "confira"]
+    has_cta = any(m in caption.lower() for m in cta_markers)
+    return {
+        "username": username,
+        "post_id": p.get("id"),
+        "permalink": permalink,
+        "embed_url": embed,
+        "media_type": p.get("media_type"),
+        "format": classify_format(p),
+        "thumbnail_url": p.get("thumbnail_url") or p.get("media_url"),
+        "media_url": p.get("media_url"),
+        "timestamp": p.get("timestamp"),
+        "caption": caption_clean[:1200],
+        "caption_length": len(caption),
+        "hashtags_count": len(hashtags),
+        "mentions_count": len(mentions),
+        "has_cta": has_cta,
+        "like_count": likes,
+        "comments_count": comments,
+        "engagement_proxy": eng,
+    }
+
+
+def weekday_name(ts: str) -> str:
+    try:
+        dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        return ["Mon","Tue","Wed","Thu","Fri","Sat","Sun"][dt.weekday()]
+    except Exception:
+        return ""
+
+
+def hour_bucket(ts: str) -> str:
+    try:
+        dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        return f"{dt.hour:02d}h"
+    except Exception:
+        return ""
+
+
+def aggregate_account(raw_bd: dict, handle: str, since_dt: datetime):
+    posts_all = raw_bd.get("_all_media") or []
+    since_iso = since_dt.isoformat()
+    posts_90d = [p for p in posts_all if (p.get("timestamp") or "") >= since_iso]
+    followers = raw_bd.get("followers_count") or 0
+    enriched = [post_summary(p, handle, followers) for p in posts_90d]
+
+    counts = {"FEED_IMAGE": 0, "CAROUSEL": 0, "REELS": 0, "VIDEO": 0}
+    for e in enriched:
+        counts[e["format"]] = counts.get(e["format"], 0) + 1
+
+    # Cadencia
+    weeks = max(1, round(DAYS_WINDOW / 7))
+    posts_per_week = round(len(enriched) / weeks, 2)
+
+    wd = {}
+    hr = {}
+    for e in enriched:
+        d = weekday_name(e.get("timestamp") or "")
+        h = hour_bucket(e.get("timestamp") or "")
+        if d: wd[d] = wd.get(d, 0) + 1
+        if h: hr[h] = hr.get(h, 0) + 1
+
+    preferred_weekday = max(wd.items(), key=lambda x: x[1])[0] if wd else None
+    preferred_hour = max(hr.items(), key=lambda x: x[1])[0] if hr else None
+
+    # Engajamento
+    likes_avg = round(sum(e["like_count"] for e in enriched) / len(enriched), 1) if enriched else 0
+    comm_avg = round(sum(e["comments_count"] for e in enriched) / len(enriched), 1) if enriched else 0
+    eng_avg = round(sum(e["engagement_proxy"] for e in enriched) / len(enriched), 3) if enriched else 0
+
+    # Melhor formato por engajamento
+    by_fmt = {}
+    for e in enriched:
+        by_fmt.setdefault(e["format"], []).append(e["engagement_proxy"])
+    best_format = None
+    if by_fmt:
+        best_format = max(
+            by_fmt.items(),
+            key=lambda kv: (sum(kv[1]) / len(kv[1])) if kv[1] else 0
+        )[0]
+
+    account = {
+        "username": handle,
+        "name": raw_bd.get("name"),
+        "biography": raw_bd.get("biography"),
+        "profile_picture_url": raw_bd.get("profile_picture_url"),
+        "website": raw_bd.get("website"),
+        "followers_count": followers,
+        "follows_count": raw_bd.get("follows_count"),
+        "media_count_total": raw_bd.get("media_count"),
+        "posts_90d": len(enriched),
+        "permalink": f"https://www.instagram.com/{handle}/",
+    }
+
+    top = sorted(enriched, key=lambda e: e["engagement_proxy"], reverse=True)[:TOP_N]
+    bottom = sorted(enriched, key=lambda e: e["engagement_proxy"])[:BOTTOM_N]
+
+    return {
+        "account": account,
+        "counts": counts,
+        "cadence": {
+            "posts_per_week": posts_per_week,
+            "preferred_weekday": preferred_weekday,
+            "preferred_hour": preferred_hour,
+        },
+        "engagement": {
+            "avg_likes": likes_avg,
+            "avg_comments": comm_avg,
+            "avg_engagement_proxy": eng_avg,
+            "best_format_by_engagement": best_format,
+        },
+        "top_posts": top,
+        "bottom_posts": bottom,
+        "all_posts_90d": enriched,
+    }
+
+
+def pick_competitors(pesquisa_path: Path, briefing_competitor_handles: dict, top_n: int = 2):
+    """
+    Le outputs/geral-pesquisa-mercado.json, ordena por digital_score DESC,
+    retorna lista de (nome, handle) dos top_n com handle conhecido.
+    handle pode vir de digital_details.instagram ou de briefing_competitor_handles (override).
+    """
+    if not pesquisa_path.exists():
+        die(f"Nao encontrei {pesquisa_path} — rode geral-pesquisa-mercado antes")
+    data = json.loads(pesquisa_path.read_text(encoding="utf-8"))
+    comps = data.get("competitors") or []
+    comps_sorted = sorted(comps, key=lambda c: c.get("digital_score") or 0, reverse=True)
+    picked = []
+    for c in comps_sorted:
+        name = c.get("name", "")
+        name_lc = name.lower()
+        handle_raw = ""
+        # 1) Override manual — substring match case-insensitive (a chave pode ser parte do nome)
+        for k, v in briefing_competitor_handles.items():
+            if not k:
+                continue
+            if k in name_lc or name_lc.startswith(k):
+                handle_raw = v
+                break
+        # 2) Extracao do campo instagram do digital_details
+        if not handle_raw:
+            ig_field = ((c.get("digital_details") or {}).get("instagram") or "")
+            m = re.search(r"@([A-Za-z0-9._]+)", ig_field)
+            if m:
+                handle_raw = m.group(1)
+        if handle_raw:
+            picked.append({"name": name, "handle": clean_handle(handle_raw), "digital_score": c.get("digital_score")})
+        if len(picked) >= top_n:
+            break
+    return picked
+
+
+def main():
+    if len(sys.argv) < 2:
+        die("Uso: ig_organic_audit.py <client_dir>")
+    client_dir = Path(sys.argv[1])
+    if not client_dir.exists():
+        die(f"client_dir {client_dir} nao existe")
+
+    cred_path = find_credentials(client_dir)
+    cred = json.loads(cred_path.read_text(encoding="utf-8"))
+    token = cred.get("access_token_long") or cred.get("access_token_short")
+    ig_user_id = cred.get("ig_business_account_v4")
+    if not token or not ig_user_id:
+        die("Credenciais incompletas: falta access_token ou ig_business_account_v4")
+
+    client_json_path = client_dir / "client.json"
+    if not client_json_path.exists():
+        die(f"{client_json_path} nao existe")
+    client_json = json.loads(client_json_path.read_text(encoding="utf-8"))
+
+    briefing = client_json.get("briefing") or {}
+    client_handle_raw = (
+        (briefing.get("identification") or {}).get("instagram")
+        or briefing.get("instagram")
+        or ""
+    )
+    if not client_handle_raw:
+        # procura recursivamente por chave "instagram"
+        def find_ig(obj):
+            if isinstance(obj, dict):
+                for k, v in obj.items():
+                    if k == "instagram" and isinstance(v, str) and v.strip():
+                        return v
+                    r = find_ig(v)
+                    if r: return r
+            elif isinstance(obj, list):
+                for x in obj:
+                    r = find_ig(x)
+                    if r: return r
+            return None
+        client_handle_raw = find_ig(briefing) or ""
+
+    client_handle = clean_handle(client_handle_raw)
+    if not client_handle:
+        die("Handle do Instagram do cliente nao encontrado em client.json (briefing.identification.instagram)")
+
+    # Override manual via env var CMP_HANDLES (formato: "Nome1=@handle1;Nome2=@handle2")
+    manual = {}
+    env = os.environ.get("CMP_HANDLES", "").strip()
+    if env:
+        for pair in env.split(";"):
+            if "=" in pair:
+                k, v = pair.split("=", 1)
+                manual[k.strip().lower()] = clean_handle(v)
+
+    # Concorrentes: top 2 por digital_score em geral-pesquisa-mercado
+    pesquisa_path = client_dir / "outputs" / "geral-pesquisa-mercado.json"
+    competitors = pick_competitors(pesquisa_path, manual, top_n=2)
+    if len(competitors) < 1:
+        die("Nao consegui identificar 2 concorrentes com handle de Instagram — use CMP_HANDLES para override")
+
+    log(f"Cliente: @{client_handle}")
+    for c in competitors:
+        log(f"Concorrente: @{c['handle']} (digital_score={c['digital_score']})")
+
+    since_dt = datetime.now(timezone.utc) - timedelta(days=DAYS_WINDOW)
+    since_iso = since_dt.isoformat()
+
+    accounts = []
+
+    # Cliente
+    log(f"Chamando business_discovery para @{client_handle}...")
+    client_bd = call_business_discovery(ig_user_id, client_handle, token, since_iso)
+    client_agg = aggregate_account(client_bd, client_handle, since_dt)
+    client_agg["_role"] = "client"
+    accounts.append(client_agg)
+
+    # Concorrentes
+    for c in competitors:
+        try:
+            log(f"Chamando business_discovery para @{c['handle']}...")
+            bd = call_business_discovery(ig_user_id, c["handle"], token, since_iso)
+            agg = aggregate_account(bd, c["handle"], since_dt)
+            agg["_role"] = "competitor"
+            agg["account"]["competitor_source_name"] = c["name"]
+            agg["account"]["digital_score"] = c["digital_score"]
+            accounts.append(agg)
+        except Exception as e:
+            log(f"Falha em @{c['handle']}: {e}")
+
+    # Raw
+    cache_dir = client_dir / "cache"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    raw_path = cache_dir / f"ig_organic_audit-{ts}.json"
+    raw_path.write_text(
+        json.dumps(
+            {
+                "fetched_at": datetime.now(timezone.utc).isoformat(),
+                "period": {
+                    "start": since_dt.date().isoformat(),
+                    "end": datetime.now(timezone.utc).date().isoformat(),
+                    "days": DAYS_WINDOW,
+                },
+                "client_handle": client_handle,
+                "accounts": accounts,
+            },
+            ensure_ascii=False,
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    log(f"Raw salvo em {raw_path}")
+
+    # Summary — insumo direto para a skill gerar o output
+    def acc_lite(a):
+        return {
+            "role": a["_role"],
+            "account": a["account"],
+            "counts": a["counts"],
+            "cadence": a["cadence"],
+            "engagement": a["engagement"],
+            "top_posts": a["top_posts"],
+            "bottom_posts": a["bottom_posts"],
+        }
+
+    summary = {
+        "fetched_at": datetime.now(timezone.utc).isoformat(),
+        "period": {
+            "start": since_dt.date().isoformat(),
+            "end": datetime.now(timezone.utc).date().isoformat(),
+            "days": DAYS_WINDOW,
+        },
+        "client": acc_lite(accounts[0]),
+        "competitors": [acc_lite(a) for a in accounts[1:]],
+        "raw_cache_file": str(raw_path.relative_to(client_dir.parent.parent)) if raw_path.is_absolute() else str(raw_path),
+    }
+
+    summary_path = cache_dir / "ig_organic_audit-summary.json"
+    summary_path.write_text(json.dumps(summary, ensure_ascii=False, indent=2), encoding="utf-8")
+    log(f"Summary salvo em {summary_path}")
+
+    # Breve resumo no stdout
+    print()
+    print("=== RESUMO ===")
+    for a in accounts:
+        acc = a["account"]
+        eng = a["engagement"]
+        print(f"@{acc['username']:<30} followers={acc.get('followers_count')} posts_90d={acc.get('posts_90d')} eng={eng['avg_engagement_proxy']}% best={eng['best_format_by_engagement']}")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/gt-diagnostico-organico-instagram/scripts/ig_organic_audit.sh
+++ b/.agents/skills/gt-diagnostico-organico-instagram/scripts/ig_organic_audit.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# ig_organic_audit.sh — Orquestra a auditoria de conteudo organico no Instagram
+# Uso:  ig_organic_audit.sh <client_dir>
+# Ex:   ig_organic_audit.sh squads/{squad}/clientes/{cliente}
+#
+# Opcional (override dos handles dos concorrentes):
+#   CMP_HANDLES="Concorrente 1=@concorrente1;Concorrente 2=@concorrente2" \
+#     ig_organic_audit.sh squads/{squad}/clientes/{cliente}
+
+set -euo pipefail
+
+CLIENT_DIR="${1:?Uso: ig_organic_audit.sh <client_dir>}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PY_SCRIPT="$SCRIPT_DIR/ig_organic_audit.py"
+
+if [ ! -f "$PY_SCRIPT" ]; then
+  echo "ERROR: ig_organic_audit.py nao encontrado em $PY_SCRIPT" >&2
+  exit 1
+fi
+
+if [ ! -d "$CLIENT_DIR" ]; then
+  echo "ERROR: client_dir $CLIENT_DIR nao existe" >&2
+  exit 1
+fi
+
+mkdir -p "$CLIENT_DIR/cache"
+
+echo ">> Rodando ig_organic_audit para $CLIENT_DIR ..."
+python3 "$PY_SCRIPT" "$CLIENT_DIR"
+
+echo
+echo ">> Summary pronto em: $CLIENT_DIR/cache/ig_organic_audit-summary.json"

--- a/.agents/skills/gt-diagnostico-organico-instagram/scripts/ig_profile_screenshot.py
+++ b/.agents/skills/gt-diagnostico-organico-instagram/scripts/ig_profile_screenshot.py
@@ -1,0 +1,135 @@
+"""
+ig_profile_screenshot.py — Captura print do header do perfil Instagram para embed no portal.
+
+Uso:
+    python3 ig_profile_screenshot.py <client_dir> --usernames user1,user2,user3
+    python3 ig_profile_screenshot.py <client_dir>   # le de outputs/gt-diagnostico-organico-instagram.json
+
+Saida:
+    <client_dir>/assets/instagram/<username>.png
+    Atualiza outputs/gt-diagnostico-organico-instagram.json com profile_screenshot_data_uri nos accounts.
+"""
+import asyncio
+import argparse
+import base64
+import json
+import sys
+from pathlib import Path
+
+from playwright.async_api import async_playwright
+
+
+async def snap(page, username, out_path):
+    url = f"https://www.instagram.com/{username}/"
+    await page.goto(url, wait_until="domcontentloaded", timeout=30000)
+    await asyncio.sleep(4)
+    for sel in [
+        'div[role="dialog"] button[aria-label="Close"]',
+        'svg[aria-label="Close"]',
+        'button[aria-label="Close"]',
+    ]:
+        try:
+            el = await page.query_selector(sel)
+            if el:
+                await el.click()
+                break
+        except Exception:
+            pass
+    await asyncio.sleep(1)
+    header = await page.query_selector("header")
+    if not header:
+        return False
+    await header.screenshot(path=str(out_path))
+    return True
+
+
+async def run(client_dir: Path, usernames: list[str]):
+    assets_dir = client_dir / "assets" / "instagram"
+    assets_dir.mkdir(parents=True, exist_ok=True)
+
+    results = {}
+    async with async_playwright() as p:
+        browser = await p.chromium.launch(headless=True)
+        ctx = await browser.new_context(
+            user_agent=(
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36"
+            ),
+            viewport={"width": 1280, "height": 900},
+            device_scale_factor=2,
+        )
+        page = await ctx.new_page()
+        for username in usernames:
+            username = username.strip().lstrip("@")
+            if not username:
+                continue
+            out = assets_dir / f"{username}.png"
+            try:
+                ok = await snap(page, username, out)
+                if ok and out.exists():
+                    data = out.read_bytes()
+                    uri = f"data:image/png;base64,{base64.b64encode(data).decode('ascii')}"
+                    results[username] = {"path": str(out.relative_to(client_dir)), "data_uri": uri, "bytes": len(data)}
+                    print(f"OK  @{username}: {len(data)} bytes -> {out}")
+                else:
+                    print(f"FAIL @{username}: header nao encontrado", file=sys.stderr)
+            except Exception as e:
+                print(f"FAIL @{username}: {e}", file=sys.stderr)
+        await browser.close()
+    return results
+
+
+def update_output(client_dir: Path, results: dict):
+    out_path = client_dir / "outputs" / "gt-diagnostico-organico-instagram.json"
+    if not out_path.exists():
+        return
+    with out_path.open() as f:
+        d = json.load(f)
+    accounts = [d.get("client_account") or {}] + list(d.get("competitor_accounts") or [])
+    for a in accounts:
+        if not a:
+            continue
+        u = (a.get("username") or "").lstrip("@")
+        if u in results:
+            a["profile_screenshot_data_uri"] = results[u]["data_uri"]
+            a["profile_screenshot_path"] = results[u]["path"]
+    with out_path.open("w") as f:
+        json.dump(d, f, ensure_ascii=False, indent=2)
+    print(f"Atualizado {out_path}")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("client_dir", type=Path)
+    ap.add_argument("--usernames", type=str, default="")
+    args = ap.parse_args()
+
+    if args.usernames:
+        usernames = [u.strip() for u in args.usernames.split(",") if u.strip()]
+    else:
+        out = args.client_dir / "outputs" / "gt-diagnostico-organico-instagram.json"
+        if not out.exists():
+            print("ERROR: --usernames nao fornecido e nao ha gt-diagnostico-organico-instagram.json", file=sys.stderr)
+            sys.exit(1)
+        with out.open() as f:
+            d = json.load(f)
+        usernames = []
+        c = d.get("client_account")
+        if c and c.get("username"):
+            usernames.append(c["username"])
+        for comp in d.get("competitor_accounts") or []:
+            if comp.get("username"):
+                usernames.append(comp["username"])
+
+    if not usernames:
+        print("ERROR: nenhum username para capturar", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Capturando {len(usernames)} perfis: {', '.join('@'+u for u in usernames)}")
+    results = asyncio.run(run(args.client_dir, usernames))
+    if results:
+        update_output(args.client_dir, results)
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/gt-diagnostico-organico-instagram/scripts/requirements-meta.txt
+++ b/.agents/skills/gt-diagnostico-organico-instagram/scripts/requirements-meta.txt
@@ -1,0 +1,2 @@
+playwright==1.48.0
+requests==2.32.3

--- a/.agents/skills/gt-forecast-midia/SKILL.md
+++ b/.agents/skills/gt-forecast-midia/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: gt-forecast-midia
+description: "Cria o forecast e plano de mídia de 6 meses: modelagem financeira evolutiva, distribuição por plataforma/funil, campanhas detalhadas (TECR), cronograma e assumptions explícitas. Output exportado para Google Sheets. Use quando disser /gt-forecast-midia ou 'planejamento de mídia' ou 'forecast' ou 'budget de anúncios'."
+area: gt
+author: luizfreitasv4
+version: 1.0.0
+dependencies:
+  - gt-diagnostico-midia-paga
+inputs:
+  - client.json (briefing)
+  - gt-diagnostico-midia-paga.json
+  - geral-persona-icp.json
+  - geral-posicionamento-estrategico.json
+output: gt-forecast-midia.json
+export: google-sheets
+week: 4
+type: automated
+estimated_time: "2h"
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta versao foi portada do sistema de Estruturacao Estrategica. As regras abaixo tem precedencia sobre caminhos e persistencia citados no fluxo original:
+
+- Trabalhe somente em `squads/{squad}/clientes/{cliente}/`, nunca em um diretorio `clientes/` solto na raiz.
+- Leia primeiro o `CLAUDE.md` ou `AGENTS.md` da KB, `mission-control/`, `calls/`, `docs/` e `campanhas/`.
+- Se `client.json` existir, use-o como fonte complementar. Se nao existir, derive o contexto da KB e do Mission Control; nao exija nem invente esse arquivo.
+- Salve entregaveis em `squads/{squad}/clientes/{cliente}/outputs/`, em JSON e Markdown quando o fluxo pedir ambos.
+- Registre decisoes e progresso no `mission-control/historico-checkins.md` ou no arquivo de historico equivalente encontrado na KB.
+- Resolva recursos empacotados a partir do proprio diretorio desta skill. Se uma integracao externa nao estiver configurada, declare o gap e continue apenas com os dados reais disponiveis.
+
+
+# Forecast e Plano de Mídia — 6 Meses (POP 3.12)
+
+> **Posição no fluxo:** Semana 4 — Identidade de Comunicação e Plano de Mídia (**comum** a todos os modelos) (e-commerce / inside-sales / pdv) — entregável final que amarra toda a estratégia. Horizonte de **6 meses** com curva evolutiva (não linear) e **assumptions explícitas**. Se mudar a premissa, refaz o forecast.
+
+Você é um especialista em planejamento de mídia paga para PMEs brasileiras. Vai criar o forecast completo de 6 meses: budget recomendado, distribuição por plataforma e funil, campanhas detalhadas, metas de resultado evolutivas e critérios de alerta.
+
+## Dados necessários
+
+1. `client.json` (seção `briefing`) — nome, segmento, budget disponível, ticket médio, objetivo
+2. `outputs/gt-diagnostico-midia-paga.json` — análise de mídia atual, CPL/ROAS atual, problemas, benchmarks
+3. `outputs/geral-persona-icp.json` — ICP, canais preferidos
+4. `outputs/geral-posicionamento-estrategico.json` — PUV, diferenciais
+5. `client.json` (seção `history`) — decisões anteriores
+
+Consulte `references/benchmarks-forecast.md` para benchmarks de CPL/ROAS por segmento.
+
+---
+
+## Geração
+
+Gere o output COMPLETO de uma vez: modelagem + distribuição + cronograma + alertas. Use os dados de `client.json` (briefing) e outputs de skills dependentes em `outputs/`.
+
+### Premissas (explicitar todas)
+
+CPL estimado (com fonte), taxa de conversão, ROAS esperado, ramp-up (Mês 1 tem CPL 20-30% maior), sazonalidade.
+
+### Modelagem financeira de 6 meses (evolutiva, não linear)
+
+Fases: **M1 setup/aprendizado** · **M2–M3 otimização** · **M4–M6 escala**.
+
+| Métrica | M1 (setup) | M2 | M3 | M4 | M5 | M6 |
+|---|---|---|---|---|---|---|
+| Budget, CPL, Leads, Taxa conversão, Vendas, Faturamento, ROAS |
+
+A curva evolui: M1 com CPL 20-30% maior (aprendizado), ganho gradual de eficiência em M2-M3, escala em M4-M6. NÃO modele crescimento linear ("+10%/mês").
+
+**Cenários:** Otimista (CPL -20%, conversão +20%), Realista (benchmarks), Pessimista (CPL +30%, conversão -20%).
+
+### Campanhas detalhadas (TECR)
+
+Para cada campanha: **T**ópico, **E**stratégia, **C**onjunto (segmentação/criativos), **R**esultado esperado — com objetivo, verba e fase de funil.
+
+### Distribuição por plataforma
+
+| Plataforma | % do budget | R$/mês | Objetivo principal |
+Lógica: ICP busca no Google? → Google Search. ICP impactado visual? → Meta. Budget < R$3k? → 1 plataforma só.
+
+### Distribuição por fase do funil
+
+| Fase | % do budget | Objetivo |
+Regras: Marca nova → mais topo (40-50%). Marca conhecida → mais fundo (40-50%). Remarketing sempre 10-15%.
+
+### Cronograma de 6 meses (180 dias)
+
+*M1 (Setup/Aprendizado):* configuração, lançamento, primeiras otimizações. Meta e ações semanais.
+*M2–M3 (Otimização):* eliminar piores, escalar melhores, novos hooks, calibrar segmentação. Metas e ações.
+*M4–M6 (Escala):* dobrar budget nos melhores, expandir lookalike/novas praças, sustentar eficiência. Metas e ações.
+
+Cada fase com `assumptions` e `dependencies` explícitas (criativo pronto, LP no ar, SDR treinado).
+
+### Alertas e critérios de pausa
+
+| Métrica | Limite de alerta | Ação imediata |
+CPL, CTR, ROAS, CPC, Frequência, Budget diário.
+
+### Critérios de escala
+
+| Métrica | Limite para escalar | Ação |
+
+### Disclaimer
+
+Variáveis que podem impactar: qualidade dos criativos, velocidade de aprovação, sazonalidade, tempo de resposta aos leads, mudanças de algoritmo, concorrência, qualidade da LP.
+
+### Exportação para Google Sheets
+
+```bash
+gog sheets create --title "Forecast Mídia - {NOME_CLIENTE}" --no-input
+```
+5 abas: Modelagem Financeira (6 meses), Distribuição, Cronograma 6 Meses, Alertas/Critérios, Assumptions/Premissas.
+
+## Auto-validação
+
+Antes de mostrar ao operador, verifique:
+
+- [ ] Mencionou o cliente pelo nome?
+- [ ] Usou dados reais do client.json (não inventou)?
+- [ ] Nenhum item genérico (ex: "quer crescer", "qualidade e compromisso")?
+- [ ] Schema da skill validou?
+- [ ] Todos os campos do schema preenchidos (ou com `null` + `unavailable_reason` no pai)?
+- [ ] Nenhuma string vazia (`""`) — substituí por `null` + reason quando o dado não existe?
+- [ ] Estimativas marcadas com `estimated: true` ou `[E]`?
+- [ ] Consistente com outputs anteriores (diagnóstico de mídia)?
+- [ ] Premissas têm fonte (não "números mágicos")?
+- [ ] Cenário pessimista é realista (não assustador demais)?
+- [ ] Disclaimer é honesto sobre variáveis de risco?
+
+Se falhou → regenere silenciosamente. Não avise o operador.
+
+## Apresentação e decisões
+
+Apresente o output COMPLETO ao operador.
+
+Revise o output. O que está errado, exagerado ou faltando?
+
+- "O budget mensal de R$ {BUDGET_MENSAL} está confirmado?"
+- "O ticket médio de R$ {TICKET_MEDIO} está correto?"
+- "A taxa de conversão é realista para o processo comercial atual?"
+- "O cronograma é factível com os recursos disponíveis?"
+- "Os limites de alerta são adequados?"
+- "O disclaimer é honesto? O cliente vai entender que forecast não é garantia?"
+
+## Finalização
+
+Operador aprova (com ou sem ajustes).
+1. Salve em `squads/{squad}/clientes/{cliente}/outputs/gt-forecast-midia.json` (com campo `summary` no topo, incluindo link Sheets)
+2. Atualize `client.json`: progress.skills → completed, version++, append em history[]
+3. Salve também uma versão Markdown do entregável na mesma pasta de outputs.
+4. Sugira próxima skill do dependency_graph
+
+## Formato do output (gt-forecast-midia.json)
+
+```json
+{
+  "financial_model": [{ "month": 1, "label": "Ramp-up", "budget": 0, "cpl": 0, "leads": 0, "conversion_rate": 0, "sales": 0, "revenue": 0, "roas": 0 }],
+  "assumptions": ["string"],
+  "scenarios": { "optimistic": {}, "realistic": {}, "pessimistic": {} },
+  "platform_distribution": [{ "platform": "Meta Ads", "percentage": 0, "monthly_value": 0, "objective": "string" }],
+  "funnel_distribution": [{ "phase": "Topo", "percentage": 0, "objective": "string" }],
+  "timeline": [{ "month": 1, "focus": "Ramp-up", "weekly_actions": ["string"], "goal": "string" }],
+  "alerts": [{ "metric": "CPL", "threshold": "> R$ X", "action": "string" }],
+  "scale_criteria": [{ "metric": "ROAS", "threshold": "> Xx", "action": "string" }],
+  "disclaimer": ["string"],
+  "sheets_url": "string"
+}
+```
+
+
+## Campo obrigatório: summary
+
+Sempre inclua no JSON de saída:
+```json
+"summary": "Resumo de 1-2 frases do forecast de mídia: investimento total, leads projetados e ROAS esperado. Seja específico — mencione o cliente, números reais e a conclusão principal."
+```
+
+Este campo alimenta o Resumo Executivo do portal de entregas. Deve ser objetivo, com dados reais, sem genéricos.

--- a/.agents/skills/gt-forecast-midia/references/benchmarks-forecast.md
+++ b/.agents/skills/gt-forecast-midia/references/benchmarks-forecast.md
@@ -1,0 +1,280 @@
+# Benchmarks de CPL, ROAS e Métricas por Segmento — Brasil 2025-2026
+
+Referência para calibrar premissas do forecast de mídia. Dados compilados de benchmarks públicos, relatórios de mercado e médias operacionais da V4 Company.
+
+**IMPORTANTE:** Benchmarks são referência, não garantia. O CPL real depende de qualidade dos criativos, LP, processo comercial e mercado local. Sempre use dados históricos do próprio cliente quando disponíveis.
+
+---
+
+## Metodologia
+
+- CPL = custo por lead (formulário, WhatsApp, ligação)
+- ROAS = faturamento gerado / budget de mídia investido
+- CAC = custo de aquisição de cliente (budget + operação)
+- CTR = taxa de clique (cliques / impressões)
+- CVR = taxa de conversão (leads / cliques)
+- Ticket = valor médio de uma venda
+
+Faixas: Baixo (bottom 25%) | Médio (mediana) | Alto (top 25%)
+
+---
+
+## Saúde e Bem-Estar (Clínicas, Estéticas, Academias)
+
+### Meta Ads
+| Métrica | Baixo | Médio | Alto |
+|---------|-------|-------|------|
+| CPL | R$ 25 | R$ 45 | R$ 80 |
+| CTR | 0.8% | 1.5% | 2.5% |
+| CVR LP | 8% | 15% | 25% |
+| CPC | R$ 1.50 | R$ 3.00 | R$ 6.00 |
+
+### Google Ads (Search)
+| Métrica | Baixo | Médio | Alto |
+|---------|-------|-------|------|
+| CPL | R$ 35 | R$ 70 | R$ 150 |
+| CTR | 3% | 6% | 12% |
+| CPC | R$ 2.00 | R$ 5.00 | R$ 12.00 |
+
+### Métricas de negócio
+| Métrica | Valor típico |
+|---------|-------------|
+| Ticket médio | R$ 200-800 (procedimento) / R$ 100-250 (mensalidade) |
+| Conversão lead→venda | 15-30% |
+| ROAS esperado | 3x-8x |
+| Ciclo de venda | 3-14 dias |
+
+### Notas do segmento
+- Procedimentos estéticos: CPL mais alto, ticket mais alto, compensação por ROAS
+- Academias: CPL mais baixo, ticket menor, foco em volume
+- Clínicas médicas: restrições de anúncio (CFM), CPL alto em Search
+- Sazonalidade: janeiro (promessas de ano novo), março-abril (pré-inverno estético)
+
+---
+
+## Alimentação e Gastronomia (Restaurantes, Delivery, Food)
+
+### Meta Ads
+| Métrica | Baixo | Médio | Alto |
+|---------|-------|-------|------|
+| CPL | R$ 5 | R$ 15 | R$ 30 |
+| CTR | 1.5% | 3.0% | 5.0% |
+| CVR LP | 12% | 20% | 35% |
+| CPC | R$ 0.50 | R$ 1.50 | R$ 3.00 |
+
+### Google Ads (Search)
+| Métrica | Baixo | Médio | Alto |
+|---------|-------|-------|------|
+| CPL | R$ 10 | R$ 25 | R$ 50 |
+| CTR | 4% | 8% | 15% |
+| CPC | R$ 1.00 | R$ 3.00 | R$ 7.00 |
+
+### Métricas de negócio
+| Métrica | Valor típico |
+|---------|-------------|
+| Ticket médio | R$ 40-120 (delivery) / R$ 80-300 (presencial) |
+| Conversão lead→pedido | 20-40% |
+| ROAS esperado | 5x-15x |
+| Ciclo de decisão | Imediato a 3 dias |
+
+### Notas do segmento
+- CPL baixo mas ticket baixo — precisa de volume
+- Instagram Stories performa muito bem (comida é visual)
+- Google Maps/GMB é essencial (busca local)
+- Sazonalidade: datas comemorativas, feriados, finais de semana
+
+---
+
+## Tecnologia e SaaS (Software, Plataformas, Tools)
+
+### Meta Ads
+| Métrica | Baixo | Médio | Alto |
+|---------|-------|-------|------|
+| CPL | R$ 30 | R$ 80 | R$ 200 |
+| CTR | 0.5% | 1.2% | 2.0% |
+| CVR LP | 5% | 12% | 20% |
+| CPC | R$ 2.00 | R$ 5.00 | R$ 15.00 |
+
+### Google Ads (Search)
+| Métrica | Baixo | Médio | Alto |
+|---------|-------|-------|------|
+| CPL | R$ 50 | R$ 120 | R$ 300 |
+| CTR | 2% | 5% | 10% |
+| CPC | R$ 3.00 | R$ 8.00 | R$ 25.00 |
+
+### Métricas de negócio
+| Métrica | Valor típico |
+|---------|-------------|
+| Ticket médio | R$ 99-999/mês (SaaS) / R$ 5K-50K (projeto) |
+| Conversão lead→trial | 20-35% |
+| Conversão trial→paying | 10-25% |
+| ROAS esperado | 3x-10x (depende muito do LTV) |
+| Ciclo de venda | 14-90 dias |
+
+### Notas do segmento
+- CPL alto mas LTV alto — avaliar por CAC/LTV, não ROAS imediato
+- Google Search é rei (intenção de compra)
+- LinkedIn Ads pode ser mais eficiente para B2B tech (não coberto aqui)
+- Free trial / freemium reduz CPL mas dilui conversão
+
+---
+
+## Educação e Cursos (Infoprodutos, Mentorias, Escolas)
+
+### Meta Ads
+| Métrica | Baixo | Médio | Alto |
+|---------|-------|-------|------|
+| CPL | R$ 5 | R$ 20 | R$ 60 |
+| CTR | 1.0% | 2.5% | 4.0% |
+| CVR LP | 10% | 22% | 40% |
+| CPC | R$ 0.50 | R$ 2.00 | R$ 5.00 |
+
+### Google Ads (Search)
+| Métrica | Baixo | Médio | Alto |
+|---------|-------|-------|------|
+| CPL | R$ 15 | R$ 40 | R$ 100 |
+| CTR | 3% | 7% | 14% |
+| CPC | R$ 1.50 | R$ 4.00 | R$ 10.00 |
+
+### Métricas de negócio
+| Métrica | Valor típico |
+|---------|-------------|
+| Ticket médio | R$ 97-997 (curso) / R$ 3K-15K (mentoria) |
+| Conversão lead→venda | 2-8% (lançamento) / 5-15% (perpétuo) |
+| ROAS esperado | 3x-12x |
+| Ciclo de venda | 7-30 dias (lançamento) / imediato (perpétuo low-ticket) |
+
+### Notas do segmento
+- Lançamentos: budget concentrado em janela curta, CPL cai durante campanha
+- Perpétuo: budget constante, otimização contínua
+- YouTube Ads pode ter CPL 40% menor que Meta para educação
+- Webinar como funil intermediário reduz CPL mas adiciona etapa
+
+---
+
+## Serviços B2B / Consultoria (Contabilidade, Jurídico, Marketing)
+
+### Meta Ads
+| Métrica | Baixo | Médio | Alto |
+|---------|-------|-------|------|
+| CPL | R$ 40 | R$ 90 | R$ 200 |
+| CTR | 0.5% | 1.0% | 1.8% |
+| CVR LP | 5% | 10% | 18% |
+| CPC | R$ 3.00 | R$ 8.00 | R$ 20.00 |
+
+### Google Ads (Search)
+| Métrica | Baixo | Médio | Alto |
+|---------|-------|-------|------|
+| CPL | R$ 60 | R$ 150 | R$ 350 |
+| CTR | 2% | 5% | 9% |
+| CPC | R$ 5.00 | R$ 15.00 | R$ 40.00 |
+
+### Métricas de negócio
+| Métrica | Valor típico |
+|---------|-------------|
+| Ticket médio | R$ 500-5K/mês (recorrente) / R$ 5K-50K (projeto) |
+| Conversão lead→reunião | 20-40% |
+| Conversão reunião→venda | 15-35% |
+| ROAS esperado | 5x-20x (por causa do LTV alto) |
+| Ciclo de venda | 15-60 dias |
+
+### Notas do segmento
+- CPL alto mas ticket alto — ROAS compensatório
+- Google Search > Meta para serviços de necessidade (contabilidade, jurídico)
+- Meta > Google para serviços de oportunidade (consultoria, coaching)
+- Material rico (ebook, diagnóstico gratuito) reduz CPL em 30-50%
+
+---
+
+## Beleza e Estética (Salões, Clínicas, E-commerce de Cosméticos)
+
+### Meta Ads
+| Métrica | Baixo | Médio | Alto |
+|---------|-------|-------|------|
+| CPL | R$ 8 | R$ 25 | R$ 50 |
+| CTR | 1.2% | 2.5% | 4.0% |
+| CVR LP | 10% | 18% | 30% |
+| CPC | R$ 0.80 | R$ 2.50 | R$ 5.00 |
+
+### Métricas de negócio
+| Métrica | Valor típico |
+|---------|-------------|
+| Ticket médio | R$ 80-400 (serviço) / R$ 50-200 (produto) |
+| Conversão lead→agendamento | 25-45% |
+| ROAS esperado | 4x-10x |
+| Ciclo de decisão | 1-7 dias |
+
+---
+
+## Imóveis e Construção
+
+### Meta Ads
+| Métrica | Baixo | Médio | Alto |
+|---------|-------|-------|------|
+| CPL | R$ 30 | R$ 80 | R$ 200 |
+| CTR | 0.5% | 1.2% | 2.2% |
+| CPC | R$ 2.00 | R$ 6.00 | R$ 15.00 |
+
+### Google Ads (Search)
+| Métrica | Baixo | Médio | Alto |
+|---------|-------|-------|------|
+| CPL | R$ 50 | R$ 130 | R$ 300 |
+| CTR | 2% | 5% | 9% |
+| CPC | R$ 4.00 | R$ 12.00 | R$ 30.00 |
+
+### Métricas de negócio
+| Métrica | Valor típico |
+|---------|-------------|
+| Ticket médio | R$ 200K-2M (imóvel) / R$ 50K-500K (reforma) |
+| Conversão lead→visita | 10-25% |
+| Conversão visita→venda | 5-15% |
+| ROAS esperado | 20x-100x (ticket altíssimo compensa CPL alto) |
+| Ciclo de venda | 30-180 dias |
+
+---
+
+## Fitness e Esportes
+
+### Meta Ads
+| Métrica | Baixo | Médio | Alto |
+|---------|-------|-------|------|
+| CPL | R$ 10 | R$ 30 | R$ 60 |
+| CTR | 1.0% | 2.2% | 3.5% |
+| CVR LP | 8% | 15% | 28% |
+
+### Métricas de negócio
+| Métrica | Valor típico |
+|---------|-------------|
+| Ticket médio | R$ 100-300/mês (academia) / R$ 200-500/mês (personal) |
+| Conversão lead→matrícula | 15-30% |
+| ROAS esperado | 3x-8x |
+| Churn mensal | 5-15% |
+
+---
+
+## Tabela Resumo — CPL Médio por Segmento (Meta Ads)
+
+| Segmento | CPL Médio | Ticket Médio | ROAS Típico |
+|----------|----------|-------------|-------------|
+| Alimentação | R$ 15 | R$ 80 | 8x |
+| Educação | R$ 20 | R$ 400 | 6x |
+| Beleza | R$ 25 | R$ 200 | 6x |
+| Fitness | R$ 30 | R$ 200 | 5x |
+| Saúde | R$ 45 | R$ 400 | 5x |
+| Tecnologia | R$ 80 | R$ 500 | 5x |
+| Imóveis | R$ 80 | R$ 500K | 50x |
+| B2B | R$ 90 | R$ 2K | 10x |
+
+---
+
+## Regras para Usar Benchmarks no Forecast
+
+1. **Sempre use dados do próprio cliente quando disponíveis** — benchmark é fallback
+2. **Mês 1 = CPL 20-30% acima do benchmark** — fase de aprendizado do algoritmo
+3. **Mês 2 = benchmark** — otimizações começam a fazer efeito
+4. **Mês 3 = CPL 10-15% abaixo do benchmark** — anúncios otimizados, público refinado
+5. **Budget < R$ 2K/mês = CPL 30-50% acima** — pouco volume para otimizar
+6. **Budget > R$ 10K/mês = CPL pode ser 10-20% abaixo** — mais dados = mais otimização
+7. **Cidades pequenas = CPL geralmente menor** (menos concorrência) mas menos volume
+8. **Capitais / SP+RJ = CPL geralmente maior** (mais concorrência) mas mais volume
+9. **Nunca use benchmarks como garantia para o cliente** — sempre apresente como estimativa com disclaimer

--- a/.agents/skills/gt-forecast-midia/schema.json
+++ b/.agents/skills/gt-forecast-midia/schema.json
@@ -1,0 +1,405 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Forecast de Mídia",
+  "description": "Forecast operacional de 6 meses com split de canais, plano de campanhas, métricas de tracking e evolução mensal projetada. Baseline conservador — não modela ROAS/receita financeira.",
+  "type": "object",
+  "required": [
+    "client_name",
+    "summary",
+    "summary_headline",
+    "horizon",
+    "currency",
+    "scenario_stance",
+    "channel_split",
+    "campaigns",
+    "tracking_metrics",
+    "forecast_6_months",
+    "assumptions_and_dependencies",
+    "summary_highlights",
+    "summary_key_findings"
+  ],
+  "properties": {
+    "client_name": {
+      "type": "string",
+      "description": "Nome do cliente — sempre presente em todo output."
+    },
+    "summary": {
+      "type": "string",
+      "description": "Resumo em 1-2 parágrafos com o veredito do forecast. Específico, com números reais."
+    },
+    "summary_headline": {
+      "type": "string",
+      "description": "Manchete em 1 linha (~120 chars) com o veredito principal."
+    },
+    "summary_highlights": {
+      "type": "array",
+      "description": "KPIs em destaque (4-6 itens). Categorias: maturidade | janela | oportunidade | risco | competicao | posicao.",
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "label",
+          "value",
+          "tone"
+        ],
+        "properties": {
+          "category": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "subtext": {
+            "type": "string"
+          },
+          "tone": {
+            "type": "string",
+            "enum": [
+              "green",
+              "yellow",
+              "red",
+              "blue",
+              "gray"
+            ]
+          }
+        }
+      }
+    },
+    "summary_key_findings": {
+      "type": "array",
+      "description": "3-5 achados categorizados (vantagem | contexto | ameaca | acao).",
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "text"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "vantagem",
+              "contexto",
+              "ameaca",
+              "acao"
+            ]
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "horizon": {
+      "type": "string",
+      "description": "Janela temporal coberta (ex: 'Maio/2026 — Outubro/2026 (6 meses)')."
+    },
+    "currency": {
+      "type": "string",
+      "description": "Moeda base — normalmente 'BRL'."
+    },
+    "scenario_stance": {
+      "type": "string",
+      "description": "Postura do cenário (ULTRA conservador / Conservador / Realista / Otimista) com justificativa."
+    },
+    "channel_split": {
+      "type": "object",
+      "required": [
+        "total_monthly_budget",
+        "rationale",
+        "channels"
+      ],
+      "properties": {
+        "total_monthly_budget": {
+          "type": "number"
+        },
+        "rationale": {
+          "type": "string"
+        },
+        "channels": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": [
+              "channel",
+              "percentage",
+              "monthly_value",
+              "primary_intent"
+            ],
+            "properties": {
+              "channel": {
+                "type": "string"
+              },
+              "percentage": {
+                "type": "number"
+              },
+              "monthly_value": {
+                "type": "number"
+              },
+              "primary_intent": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "campaigns": {
+      "type": "object",
+      "description": "Plano de campanhas concentradas por canal. Estrutura aberta — varia conforme split.",
+      "required": [
+        "concentration_note"
+      ],
+      "properties": {
+        "concentration_note": {
+          "type": "string"
+        }
+      }
+    },
+    "tracking_metrics": {
+      "type": "object",
+      "required": [
+        "description",
+        "metrics"
+      ],
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "metrics": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": [
+              "id",
+              "metric",
+              "definition",
+              "source",
+              "frequency"
+            ],
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "metric": {
+                "type": "string"
+              },
+              "definition": {
+                "type": "string"
+              },
+              "source": {
+                "type": "string"
+              },
+              "frequency": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "forecast_6_months": {
+      "type": "object",
+      "required": [
+        "description",
+        "evolution_logic",
+        "monthly_evolution",
+        "totals_6_months"
+      ],
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "evolution_logic": {
+          "type": "string"
+        },
+        "monthly_evolution": {
+          "type": "array",
+          "minItems": 6,
+          "maxItems": 6,
+          "items": {
+            "type": "object",
+            "required": [
+              "month",
+              "label",
+              "phase",
+              "impressions",
+              "clicks",
+              "leads",
+              "cpl"
+            ],
+            "properties": {
+              "month": {
+                "type": "integer"
+              },
+              "label": {
+                "type": "string"
+              },
+              "phase": {
+                "type": "string"
+              },
+              "impressions": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "clicks": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "ctr_pct": {
+                "type": "number"
+              },
+              "cpc": {
+                "type": "number"
+              },
+              "leads": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "cpl": {
+                "type": "number"
+              },
+              "mql_rate_pct": {
+                "type": "number"
+              },
+              "mqls": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "appointments": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "show_rate_pct": {
+                "type": "number"
+              },
+              "served_clients": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "cac_media": {
+                "type": "number"
+              }
+            }
+          }
+        },
+        "totals_6_months": {
+          "type": "object",
+          "properties": {
+            "total_investment": {
+              "type": "number"
+            },
+            "total_impressions": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "total_clicks": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "avg_ctr_pct": {
+              "type": "number"
+            },
+            "avg_cpc": {
+              "type": "number"
+            },
+            "total_leads": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "avg_cpl": {
+              "type": "number"
+            },
+            "avg_mql_rate_pct": {
+              "type": "number"
+            },
+            "total_mqls": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "total_appointments": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "avg_show_rate_pct": {
+              "type": "number"
+            },
+            "total_served_clients": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "avg_cac_media": {
+              "type": "number"
+            }
+          }
+        }
+      }
+    },
+    "assumptions_and_dependencies": {
+      "type": "array",
+      "description": "Premissas, dependências e disclaimers explícitos do forecast.",
+      "minItems": 3,
+      "items": {
+        "type": "string"
+      }
+    },
+    "_metadata": {
+      "type": "object",
+      "properties": {
+        "skill": {
+          "type": "string"
+        },
+        "version": {
+          "type": [
+            "integer",
+            "number"
+          ]
+        },
+        "generated_at": {
+          "type": "string"
+        },
+        "version_notes": {
+          "type": "string"
+        },
+        "depends_on": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "next_iteration": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/.claude/skills/gt-diagnostico-criativos/SKILL.md
+++ b/.claude/skills/gt-diagnostico-criativos/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: gt-diagnostico-criativos
+description: "Diagnostico de criativos com analise multimodal: matriz de avaliacao, padroes, analise de concorrentes e briefing de producao. Use quando o operador disser /gt-diagnostico-criativos ou 'analisar criativos' ou 'avaliar anuncios' ou 'como estao os criativos'."
+area: gt
+author: luizfreitasv4
+version: 1.0.0
+dependencies:
+  - geral-persona-icp
+tools: []
+week: 2
+estimated_time: "2h"
+output_file: "gt-diagnostico-criativos.json"
+multimodal: true
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta versao foi portada do sistema de Estruturacao Estrategica. As regras abaixo tem precedencia sobre caminhos e persistencia citados no fluxo original:
+
+- Trabalhe somente em `squads/{squad}/clientes/{cliente}/`, nunca em um diretorio `clientes/` solto na raiz.
+- Leia primeiro o `CLAUDE.md` ou `AGENTS.md` da KB, `mission-control/`, `calls/`, `docs/` e `campanhas/`.
+- Se `client.json` existir, use-o como fonte complementar. Se nao existir, derive o contexto da KB e do Mission Control; nao exija nem invente esse arquivo.
+- Salve entregaveis em `squads/{squad}/clientes/{cliente}/outputs/`, em JSON e Markdown quando o fluxo pedir ambos.
+- Registre decisoes e progresso no `mission-control/historico-checkins.md` ou no arquivo de historico equivalente encontrado na KB.
+- Resolva recursos empacotados a partir do proprio diretorio desta skill. Se uma integracao externa nao estiver configurada, declare o gap e continue apenas com os dados reais disponiveis.
+
+
+# Diagnostico de Criativos (POP 2.3)
+
+> **Posição no fluxo:** Semana 2 — comum a todos os modelos. O briefing de produção gerado aqui alimenta `designer-criativos-anuncios` (POP 3.11) na cauda da Semana 3.
+
+Voce e um diretor criativo especializado em performance marketing para PMEs brasileiras. Vai analisar os criativos atuais do cliente — anuncios, posts, stories, banners — usando analise VISUAL (multimodal) e de copy para identificar por que nao estao performando e gerar um briefing para a producao da Semana 3.
+
+**CAPACIDADE MULTIMODAL:** Voce pode analisar imagens diretamente. O operador vai compartilhar screenshots/prints dos criativos e voce vai avaliar cada um visualmente.
+
+## Dados necessários
+
+1. Leia `client.json` (seção `briefing`) — extraia: NOME_CLIENTE, SEGMENTO, TOM_DE_VOZ, identidade visual atual
+2. Leia `outputs/geral-persona-icp.json` — extraia: RESUMO_ICP, linguagem do ICP, canais preferenciais, dores principais
+3. Se houver `outputs/geral-posicionamento-estrategico.json`, extraia: PUV, tagline, tom de voz aprovado
+4. Se houver `outputs/gt-diagnostico-midia-paga.json`, **automaticamente** cruze `campaigns[]` e `creatives[]` (se existir) para trazer CTR, CPL, impressions, spend por criativo — nao pergunte ao operador sobre performance se esse output ja tem os dados.
+5. Se houver `outputs/gt-diagnostico-organico-instagram.json`, extraia `top_posts` e `client_winning_patterns` do cliente — padroes que ja funcionam no organico devem ser considerados no briefing de producao pago.
+
+### Cross-reference automatico com diagnostico de midia
+
+Ao popular cada item de `creative_matrix[].performance_data`, prefira PUXAR de `gt-diagnostico-midia-paga.json` em vez de perguntar. O operador deve precisar fornecer apenas:
+- Os screenshots/criativos em si (visual)
+- Quais concorrentes analisar na Meta Ads Library
+
+### Pedido ao operador (unico)
+
+Peca os criativos ao operador de UMA vez:
+
+> Preciso dos criativos visuais para analisar. Pode enviar:
+> - **Screenshots/prints dos anuncios** ativos (10-15 idealmente, vertical + quadrado + video)
+> - **Links da Meta Ads Library** do {NOME_CLIENTE} (se souber quais campanhas estao ativas)
+> - **Posts boosteados** se forem parte da midia paga
+>
+> Performance (CTR, CPL, impressions) eu ja vou puxar automaticamente do gt-diagnostico-midia-paga.
+>
+> Tambem: quais concorrentes analisar na Meta Ads Library? Minha sugestao e pegar os 2-3 de maior `digital_score` em geral-pesquisa-mercado.json — posso validar uma lista antes.
+
+Aguarde o operador enviar os criativos antes de iniciar a analise.
+
+---
+
+## Geração
+
+Gere o output COMPLETO de uma vez após receber os criativos do operador. Use os dados de `client.json` (briefing) e outputs de skills dependentes em `outputs/`.
+
+Consulte `references/boas-praticas-criativos.md` para os criterios de avaliacao.
+
+### Catálogo de criativos recebidos
+
+Total, ICP target, tom de voz, objetivo, dados de performance disponíveis.
+
+### Matriz de avaliação
+
+Para CADA criativo, analise visual e de copy com score 1-5 em 5 dimensões:
+
+| # | Tipo | Hook | Clareza | ICP Coer. | CTA | Visual | Total | Veredicto |
+|---|------|------|---------|-----------|-----|--------|-------|-----------|
+| 1 | {tipo} | {1-5} | {1-5} | {1-5} | {1-5} | {1-5} | {/25} | {M/O/E} |
+
+Legenda: M = Manter | O = Otimizar | E = Eliminar
+Score: 20-25 = Manter | 13-19 = Otimizar | <13 = Eliminar
+
+Para cada criativo, inclua comentário específico por dimensão (não genérico).
+
+### Padrões identificados
+
+Problemas que se repetem na maioria dos criativos (com referência a quais criativos). Elementos que estão funcionando e devem ser preservados/replicados.
+
+### Análise de criativos de concorrentes
+
+Se o operador fornecer prints ou links, analise. Senão, instrua como acessar Meta Ads Library (`https://www.facebook.com/ads/library/?active_status=active&ad_type=all&country=BR&q={nome_concorrente}`).
+
+Para cada concorrente:
+- `active_ads_count` — nº de anúncios ativos na Library
+- `ads_library_url` — link direto para a página do concorrente na Library
+- `creative_pattern` — padrão observado (formato, hook recorrente, ângulo)
+- `what_works`, `what_to_avoid`
+- `gap_para_cliente: true/false` — se o padrão NÃO aparece nos criativos do cliente e deveria ser testado
+- `replication_idea` (se gap=true) — ideia concreta para o cliente replicar
+
+### Padrões de concorrentes NÃO usados pelo cliente (`competitor_patterns_missing`)
+
+Esta é a parte mais acionável — alinha com `gt-diagnostico-organico-instagram.competitor_patterns_missing`. Liste 3-6 padrões recorrentes que aparecem nos concorrentes e **não** aparecem nos criativos do cliente. Para cada:
+
+- `pattern` — descrição (ex: "vídeo vertical com caso real + depoimento em texto sobreposto")
+- `seen_in_competitors` — lista dos concorrentes
+- `ads_count` — quantos anúncios dos concorrentes usam o padrão
+- `why_it_works` — por que provavelmente funciona para o ICP do cliente
+- `how_client_could_implement` — ação concreta (não "melhorar conteúdo")
+- `priority` — alta/media/baixa
+
+### Briefing de produção para Semana 3
+
+**HOOK:** Direção recomendada + 3 exemplos
+**FORMATO PRIORITÁRIO:** formato + justificativa para o ICP
+**ELEMENTOS VISUAIS:** a incluir + a evitar (com exemplos)
+**COPY — Diretrizes:** comprimento, tom, estrutura recomendada (hook → dor → solução → prova → CTA), palavras-chave do ICP
+**QUANTIDADE:** criativos novos + variações sugeridas
+
+### Estrutura visual (obrigatória)
+
+Siga o padrão canônico de `references/padrao-output.md`. Além dos campos específicos da skill, SEMPRE inclua:
+
+- **`summary_headline`** (max 200 char) — manchete com o veredito. Ex: "[Cliente] tem 10 criativos mas 7 falham no hook — eliminar 3, redesenhar 4 antes de escalar mídia."
+- **`summary_highlights`** (4-6 itens, `{category, label, value, subtext, tone}`) — para criativos sugestões:
+  - `maturidade`: score médio (ex: "13,2/25")
+  - `posicao`: distribuição M/O/E (ex: "3M · 4O · 3E")
+  - `competicao`: volume de anúncios ativos dos concorrentes (ex: "18 ads ativos vs 0 do cliente")
+  - `oportunidade`: padrão missing mais impactante
+  - `risco`: problema criativo mais recorrente (ex: "Copy genérica em 7/10")
+- **`summary_key_findings`** (3-5 itens, `{category, text}`) — `vantagem|contexto|ameaca|acao` — cubra pelo menos 3 dos 4.
+
+### Ponto de alavancagem (`key_insight`)
+
+Para criativos, o ponto de alavancagem é o **padrão criativo recorrente mais impactante** — um problema sistêmico a corrigir OU um sucesso específico a amplificar. Estruture:
+
+```json
+"key_insight": {
+  "headline": "Frase-manchete em 1 linha (pode virar quote)",
+  "context": "2-3 linhas sobre por que este padrão está dominando",
+  "numbered_reasons": ["(1) padrão afeta X de Y criativos...", "(2) impacto em performance...", "(3) comparativo com concorrentes..."],
+  "discussion_anchor": "Por que o stakeholder precisa validar a direção de produção"
+}
+```
+
+Se o diagnóstico revelou fragilidade estrutural (cliente não tem criativos pagos ativos, base insuficiente, concorrentes com volume incomparável), inclua `honesty_alert`.
+
+## Auto-validação
+
+Antes de mostrar ao operador, verifique:
+
+- [ ] Mencionou o cliente pelo nome?
+- [ ] Usou dados reais do client.json (não inventou)?
+- [ ] Performance por criativo foi puxada de `gt-diagnostico-midia-paga.json` (não pedida ao operador se já existe)?
+- [ ] Nenhum item genérico (ex: "quer crescer", "qualidade e compromisso")?
+- [ ] Schema da skill validou?
+- [ ] Todos os campos do schema preenchidos (ou com `null` + `unavailable_reason` no pai)?
+- [ ] Nenhuma string vazia (`""`) — substituí por `null` + reason quando o dado não existe?
+- [ ] Estimativas marcadas com `estimated: true` ou `[E]`?
+- [ ] Consistente com outputs anteriores (ICP, posicionamento, orgânico IG)?
+- [ ] Cada criativo tem comentário específico (não "poderia melhorar")?
+- [ ] Padrões são baseados em evidência (referência a criativos específicos)?
+- [ ] `competitor_patterns_missing` tem ao menos 3 itens acionáveis (não "melhorar conteúdo")?
+- [ ] Cada item de `competitor_analysis` tem `gap_para_cliente` marcado corretamente?
+- [ ] Briefing de produção é acionável (um criativo conseguiria executar)?
+- [ ] Tem `summary_headline` específico (não "análise concluída")?
+- [ ] `summary_highlights` tem 4-6 itens com categorias e tons válidos?
+- [ ] `summary_key_findings` cobre pelo menos 3 dos 4 tipos?
+- [ ] Identificou `key_insight` (padrão recorrente ou gap mais impactante) para stakeholder?
+- [ ] Se há fragilidade, incluiu `honesty_alert`?
+
+Se falhou → regenere silenciosamente. Não avise o operador.
+
+## Apresentação e decisões
+
+Apresente o output COMPLETO ao operador.
+
+Revise o output. O que está errado, exagerado ou faltando?
+
+- "A avaliacao faz sentido? Algum criativo que voce acha que merece nota diferente?"
+- "Algum contexto que eu perdi? (ex: 'o #3 foi feito as pressas', 'o #7 teve o melhor CPL')"
+- "O briefing de produção está acionável? Alguma restrição de marca?"
+
+## Finalização
+
+Operador aprova (com ou sem ajustes).
+1. Salve em `squads/{squad}/clientes/{cliente}/outputs/gt-diagnostico-criativos.json` (com campo `summary` no topo)
+2. Atualize `client.json`: progress.skills → completed, version++, append em history[]
+3. Salve também uma versão Markdown do entregável na mesma pasta de outputs.
+4. Sugira próxima skill do dependency_graph
+   - "Diagnóstico concluído. Criativos analisados: {numero}. Manter: {n} | Otimizar: {n} | Eliminar: {n}."
+   - "Este diagnostico alimenta: /designer-criativos-anuncios, /copy-anuncios"
+   - "Proximo passo recomendado: /gt-diagnostico-cro"
+
+
+## Campo obrigatório: summary
+
+Sempre inclua no JSON de saída:
+```json
+"summary": "Resumo de 1-2 frases do diagnóstico de criativos: principais padrões encontrados e ação prioritária. Seja específico — mencione o cliente, números reais e a conclusão principal."
+```
+
+Este campo alimenta o Resumo Executivo do portal de entregas. Deve ser objetivo, com dados reais, sem genéricos.

--- a/.claude/skills/gt-diagnostico-criativos/references/boas-praticas-criativos.md
+++ b/.claude/skills/gt-diagnostico-criativos/references/boas-praticas-criativos.md
@@ -1,0 +1,174 @@
+# Boas Praticas para Criativos de Performance Marketing
+
+Guia para avaliar e produzir criativos de anuncios pagos para PMEs brasileiras, focado em Meta Ads (Instagram/Facebook) e Google Ads.
+
+## Principio #1: O criativo e o anuncio
+
+Em performance marketing, o criativo nao e "a arte". E o anuncio inteiro. Se o criativo nao funciona, nada funciona — segmentacao perfeita + budget alto + LP otimizada = zero resultado se o criativo nao para o scroll.
+
+## Anatomia de um criativo de performance
+
+### Hook (primeiros 1-3 segundos)
+
+O hook e o elemento mais importante. 80% da decisao de engajar ou pular acontece aqui.
+
+**Tipos de hook que funcionam:**
+
+| Tipo | Descricao | Exemplo | Melhor para |
+|---|---|---|---|
+| Pergunta-dor | Pergunta que ativa a dor do ICP | "Cansou de gastar com anuncio sem retorno?" | Servicos B2B |
+| Dado chocante | Numero que surpreende | "87% das clinicas perdem R$ 3K/mes em ads mal feitos" | Autoridade |
+| Antes/depois | Transformacao visual | Foto split antes → depois | Estetica, fitness, reformas |
+| Depoimento | Cliente real falando | "Eu gastava R$ 5K e nao via resultado..." | Prova social |
+| Demonstracao | Mostra o produto/servico em acao | Video mostrando o dashboard | SaaS, produto fisico |
+| Contra-intuitivo | Afirmacao que desafia crenca | "Nao poste todo dia. Poste menos, melhor." | Educacao, consultoria |
+| Resultado | Numero concreto de resultado | "De 5 para 47 leads/mes em 60 dias" | Performance, resultado |
+
+**Hooks que NAO funcionam:**
+- Logo da empresa (ninguem conhece sua marca)
+- "Ola, tudo bem?" (nao para o scroll)
+- Texto generico ("Descubra como...")
+- Musica sem contexto
+- Fundo colorido sem informacao
+
+### Clareza da mensagem
+
+Em 5 segundos, o espectador precisa entender:
+1. Para QUEM e isto
+2. O que RESOLVE
+3. O que FAZER (CTA)
+
+**Teste de clareza:** Mostre o criativo para alguem de fora por 5 segundos. Pergunte: "O que estao vendendo?" Se a resposta for vaga, a mensagem nao esta clara.
+
+**Erros comuns de clareza:**
+- Tentar comunicar 3 beneficios ao mesmo tempo (escolha 1)
+- Copy longa demais na imagem (regra Meta: <20% de texto)
+- Jargao tecnico que o ICP nao entende
+- Metaforas abstratas em vez de beneficio direto
+
+### Coerencia com ICP
+
+O criativo precisa parecer feito PARA aquele ICP especifico. Sinais de coerencia:
+
+- **Visual:** Pessoas que se parecem com o ICP (idade, contexto, estilo)
+- **Linguagem:** Palavras que o ICP usa no dia a dia
+- **Cenario:** Contexto real do ICP (escritorio, clinica, casa, academia)
+- **Dor:** A dor mencionada e a dor REAL do ICP, nao a que a empresa acha que e
+- **Formato:** O formato e o que o ICP consome (stories para jovens, feed para 40+)
+
+**Red flags de incoerencia:**
+- Foto de stock americana para ICP brasileiro
+- Linguagem formal para ICP jovem informal
+- Foco em features tecnicas para ICP que quer resultado
+- Video longo para ICP que consome reels de 15s
+
+### CTA (Call to Action)
+
+**Regras de CTA em criativos:**
+1. Um CTA por criativo (nao dois, nao tres)
+2. O CTA deve ser visivel sem esforco
+3. Deve dizer O QUE acontece ao clicar ("Agendar consulta gratis", nao "Saiba mais")
+4. Deve gerar baixo atrito ("Simulacao em 30 segundos" > "Preencha o formulario")
+
+**Hierarquia de CTAs por conversao (do mais forte ao mais fraco):**
+1. "Agendar [coisa] gratis" / "Teste gratis"
+2. "Receber orcamento em X minutos"
+3. "Ver precos" / "Ver planos"
+4. "Baixar [material]"
+5. "Falar com especialista"
+6. "Saiba mais" (o mais fraco — evite)
+
+### Qualidade visual
+
+**Criterios de avaliacao:**
+
+| Score | Descricao |
+|---|---|
+| 1 | Amador: foto borrada, design feio, sem identidade, parece spam |
+| 2 | Basico: foto ok mas sem tratamento, design generico de Canva template |
+| 3 | Aceitavel: foto boa, design limpo, mas nada que destaque |
+| 4 | Bom: foto profissional ou muito boa, design alinhado com marca, destaca no feed |
+| 5 | Excelente: foto/video de alta qualidade, design proprio, para o scroll, transmite profissionalismo |
+
+**O que melhora visual rapidamente:**
+- Fotos reais (mesmo de celular) > stock
+- Contraste alto (se destaca no feed)
+- Rostos humanos (geram mais conexao)
+- Menos texto na imagem (mais limpo + melhor entrega Meta)
+- Cores consistentes com a marca
+
+---
+
+## Formatos por plataforma
+
+### Meta Ads (Instagram/Facebook)
+
+| Formato | Dimensao | Quando usar | Performance tipica |
+|---|---|---|---|
+| Feed quadrado | 1:1 (1080x1080) | Imagem unica, oferta clara | CTR medio |
+| Stories/Reels | 9:16 (1080x1920) | Video, imersivo, urgencia | CTR alto (ocupa tela toda) |
+| Carrossel | 1:1 (multiplos) | Educativo, lista, antes/depois | Engajamento alto |
+| Video feed | 1:1 ou 4:5 | Demonstracao, depoimento | Melhor custo por view |
+| Collection | Mix | E-commerce, catalogo | ROAS alto |
+
+**Regras gerais Meta:**
+- Video: primeiros 3 segundos sao tudo. Nao use intro/logo
+- Imagem: texto <20% da area (senao entrega cai)
+- Carrossel: primeiro slide e o hook, ultimo e o CTA
+- Stories: use elementos nativos (stickers, polls) para parecer organico
+- Legenda: curta (1-2 linhas) para performance, longa para conteudo educativo
+
+### Google Ads
+
+| Formato | Quando usar |
+|---|---|
+| Search (texto) | Busca ativa, intencao alta |
+| Display (banner) | Retargeting, awareness |
+| YouTube (video) | Pre-roll, educacao, demonstracao |
+| Performance Max | Mix automatico, escala |
+
+**Regras gerais Google:**
+- Display: banner clean, CTA grande, pouco texto
+- YouTube: hook em 5 segundos (antes do "pular anuncio")
+- Search: headline com palavra-chave + beneficio + CTA
+
+---
+
+## Checklist de avaliacao rapida
+
+Para cada criativo, passe por este checklist:
+
+```
+[ ] HOOK: Para o scroll em 1-3 segundos?
+[ ] CLAREZA: Em 5 segundos, sabe o que e e para quem?
+[ ] ICP: Parece feito para o ICP (visual, linguagem, contexto)?
+[ ] CTA: Tem 1 CTA claro e visivel?
+[ ] VISUAL: Qualidade profissional? Destaca no feed?
+[ ] MOBILE-FIRST: Funciona em tela pequena? Texto legivel?
+[ ] TEXTO: <20% da area (regra Meta)?
+[ ] CONFIANCA: Transmite profissionalismo?
+[ ] DIFERENCIACAO: E diferente dos concorrentes?
+[ ] ACAO: Quem ve sabe o que fazer?
+```
+
+## Erros fatais (eliminam o criativo)
+
+1. **Logo como hook** — Ninguem para o scroll por um logo que nao conhece
+2. **Texto ilegivel em mobile** — Se nao da pra ler no celular, nao existe
+3. **Sem CTA** — Bonito mas nao converte
+4. **Foto de stock obvia** — Perde confianca instantaneamente
+5. **Informacao errada** — Preco, telefone, oferta expirada
+6. **Muito texto na imagem** — Meta penaliza a entrega
+7. **Audio ruim em video** — Melhor sem audio do que com audio estourado
+8. **Duracao longa sem hook** — Video >30s que so fica bom a partir dos 15s
+
+## Tendencias 2025-2026 em criativos de performance
+
+1. **UGC (User Generated Content)** — Conteudo que parece organico performa melhor que producao polida
+2. **Video vertical curto** — 15-30 segundos, formato reels/stories
+3. **Hooks de texto na tela** — Texto grande + imagem de fundo, estilo meme
+4. **Antes/depois** — Continua sendo o formato mais poderoso para transformacao
+5. **Depoimento em video** — Cliente real falando direto pra camera
+6. **Static creative revival** — Imagens estaticas com copy forte voltando a competir com video
+7. **AI-generated variations** — Multiplas variacoes de hook/copy para teste rapido
+8. **Dark post testing** — Testar criativos sem publicar no perfil

--- a/.claude/skills/gt-diagnostico-criativos/references/padrao-output.md
+++ b/.claude/skills/gt-diagnostico-criativos/references/padrao-output.md
@@ -1,0 +1,202 @@
+# Padrão de Output das Skills — V4 Estruturação IA
+
+Este documento define a **estrutura canônica** que todos os outputs de skill devem seguir para renderizar no portal com hierarquia visual consistente. O objetivo é que o operador e o stakeholder final abram qualquer entregável e encontrem o mesmo ritmo: manchete → KPIs → achados categorizados → ponto de alavancagem destacado → detalhes expansíveis.
+
+---
+
+## Princípios
+
+1. **Manchete antes de texto.** Toda skill abre com uma frase única e específica que resume a conclusão. Não é parágrafo, é headline.
+2. **Números em destaque, não escondidos no corpo do texto.** KPIs que importam viram cards. Texto corrido é para contexto, não para fato quantitativo.
+3. **Achados categorizados por intenção.** Cada insight é classificado como `vantagem | contexto | ameaca | acao` — o leitor identifica o tom antes de ler.
+4. **Ponto de alavancagem visualmente isolado.** Toda skill tem UM ponto onde a conversa com o stakeholder precisa acontecer. Esse ponto ganha hero visual (border, gradient, quote destacada).
+5. **Detalhe denso → colapsável.** Listas longas (concorrentes, itens de checklist, fontes) ficam em `<details>` para não afogar a leitura.
+
+---
+
+## Campos obrigatórios no JSON
+
+Todo output de skill DEVE ter estes campos no topo (antes dos campos específicos da skill):
+
+```json
+{
+  "client_name": "Nome do Cliente",
+  "summary": "Resumo em 1-2 frases. Específico, com dados reais. Alimenta o resumo executivo do portal.",
+
+  "summary_headline": "Manchete em 1 linha (max 120 caracteres). A frase que o stakeholder lê primeiro.",
+
+  "summary_highlights": [
+    {
+      "category": "posicao | competicao | janela | maturidade | oportunidade | risco",
+      "label": "Rótulo curto (max 30 char)",
+      "value": "Valor em destaque (número, %, status)",
+      "subtext": "Contexto em 1 linha (max 60 char)",
+      "tone": "green | yellow | red | blue | gray"
+    }
+  ],
+
+  "summary_key_findings": [
+    {
+      "category": "vantagem | contexto | ameaca | acao",
+      "text": "Achado em 1-2 linhas. Específico, acionável."
+    }
+  ]
+}
+```
+
+### Regras dos campos de summary
+
+**`summary_headline`**: É a ÚNICA frase que o stakeholder precisa ler se só tiver 5 segundos. Deve conter o veredito da skill. Exemplos bons:
+- ✓ "[Cliente] é o ÚNICO player premium da microrregião com [diferencial declarado] — janela competitiva de 12-18 meses."
+- ✗ "Análise de mercado concluída com sucesso."
+
+**`summary_highlights`** (4-6 itens): KPIs visuais. Categorias sugeridas:
+- `posicao` — onde o cliente está hoje vs potencial
+- `competicao` — quem disputa o mesmo espaço
+- `janela` — tempo/urgência
+- `maturidade` — estágio atual em algum eixo
+- `oportunidade` — tamanho do ganho possível
+- `risco` — tamanho da ameaça
+
+Agrupar de 2 em 2 por categoria no renderer (dá layout balanceado 3x2 ou 2x2).
+
+**`summary_key_findings`** (3-5 itens): Achados que embasam a manchete. Categorias:
+- `vantagem` (✓ verde) — o que o cliente tem a favor
+- `contexto` (i azul) — o que é fato do mercado, neutro
+- `ameaca` (! vermelho) — o que pode dar errado
+- `acao` (▸ laranja) — o que precisa ser feito
+
+---
+
+## Ponto de Alavancagem (hero block)
+
+Toda skill deve identificar **UM bloco que merece destaque visual especial** — o ponto onde a conversa estratégica precisa acontecer. O nome do campo varia por skill, mas a estrutura é consistente:
+
+```json
+{
+  "key_leverage_point": {
+    "headline": "Frase-manchete do ponto (pode ir como quote)",
+    "context": "Contexto em 2-3 linhas explicando o cenário",
+    "numbered_reasons": [
+      "Razão 1 (parse-friendly, pode começar com texto direto)",
+      "Razão 2",
+      "Razão 3"
+    ],
+    "discussion_anchor": "Frase curta sobre POR QUE este é o ponto de conversa com o stakeholder"
+  }
+}
+```
+
+Exemplos por skill:
+- `pesquisa-mercado` → `unexploited_opportunity` (whitespace estratégico)
+- `persona-icp` → persona principal + dor mais ignorada
+- `swot` → combinação força × oportunidade mais assimétrica
+- `posicionamento` → PUV vs alternativas descartadas
+- `diagnostico-midia` → canal mais subotimizado + upside estimado
+- `diagnostico-maturidade` → pilar mais fraco com maior impacto
+
+O renderer aplica:
+- Border verde 2px + gradient sutil
+- Selo "Whitespace Estratégico · Discussão com Stakeholder" no topo
+- Pill de viabilidade/urgência à direita
+- Quote/headline em card branco isolado
+- Razões numeradas em 3 círculos
+- Footer "💬 Momento de validar com a stakeholder"
+
+---
+
+## Alerta de honestidade
+
+Se a pesquisa/análise revelou fragilidade do cliente (não há diferencial real, ICP mal definido, mercado saturado, etc.), inclua:
+
+```json
+{
+  "honesty_alert": "Texto explicando a fragilidade encontrada e o que precisa ser feito antes de seguir."
+}
+```
+
+Esse campo renderiza em box amarelo/vermelho após os achados. **Nunca omita** se a realidade justifica. O valor do sistema depende de não vender aspiracional como real.
+
+---
+
+## Instrução para a IA da skill
+
+Em cada `SKILL.md`, incluir esta seção na geração:
+
+> ### Estrutura visual (obrigatória)
+>
+> Além dos campos específicos desta skill, gere SEMPRE:
+>
+> - `summary_headline` — manchete em 1 linha com o veredito
+> - `summary_highlights` — 4-6 KPIs categorizados (`posicao|competicao|janela|maturidade|oportunidade|risco`) com `{label, value, subtext, tone}`
+> - `summary_key_findings` — 3-5 achados categorizados (`vantagem|contexto|ameaca|acao`)
+> - `honesty_alert` se houver fragilidade
+>
+> Identifique o **ponto de alavancagem** desta skill (o bloco que merece hero visual) e estruture-o com headline + contexto + razões numeradas + discussion anchor.
+>
+> Consulte `references/padrao-output.md` para especificação completa.
+
+E na auto-validação:
+
+> - [ ] Tem `summary_headline` específico (não "análise concluída")?
+> - [ ] `summary_highlights` tem 4-6 itens com categorias válidas?
+> - [ ] `summary_key_findings` cobre pelo menos 3 dos 4 tipos (vantagem/contexto/ameaça/ação)?
+> - [ ] Identificou o ponto de alavancagem para discussão com stakeholder?
+> - [ ] Se há fragilidade, incluiu `honesty_alert`?
+
+---
+
+## Completude (regra crítica)
+
+**Todo campo definido no schema da skill é obrigatório no output.** Não omitir campos — o renderer assume que os campos do schema existem e quebra/fica vazio silenciosamente quando faltam.
+
+Se um dado **não pode ser obtido** (GA4 não instalado, conector não conectado, cliente não sabe, etc.), preencher com `null` E adicionar `unavailable_reason` no objeto pai:
+
+```json
+{
+  "current_conversion_rate": null,
+  "current_bounce_rate": null,
+  "avg_time_on_page": null,
+  "unavailable_reason": "GA4 não instalado no site — métricas de analytics não coletadas nesta auditoria"
+}
+```
+
+Para arrays vazios legitimamente (ex: nenhum competidor identificado), preencher com `[]` e adicionar uma nota no campo irmão `{campo}_note`:
+
+```json
+{
+  "competitors": [],
+  "competitors_note": "Nenhum concorrente direto identificado na microrregião após busca em Google Maps + Instagram."
+}
+```
+
+Para valores **estimados** (sem fonte pública), adicionar flag `[E]` no texto OU campo `estimated: true` no objeto:
+
+```json
+{ "tam_brl": 450000000, "estimated": true, "estimation_basis": "IBGE população × SEBRAE ticket médio" }
+```
+
+**Nunca** deixar string vazia (`""`), zero falso (`0` quando não é zero real), ou omitir o campo. Essas três formas são invisíveis para o renderer e geram o bug "coluna vazia".
+
+Valide o JSON contra o `schema.json` empacotado na skill e corrija campos ausentes ou `null` sem `unavailable_reason`.
+
+### Checklist adicional de auto-validação
+
+> - [ ] Todos os campos do schema estão presentes (preenchidos ou com `null` + `unavailable_reason`)?
+> - [ ] Nenhuma string vazia (`""`) — substituí por `null` + reason quando o dado não existe?
+> - [ ] Arrays vazios legítimos têm `{campo}_note` explicando por quê?
+> - [ ] Estimativas marcadas com `estimated: true` ou `[E]`?
+
+---
+
+## Tons de voz
+
+- `green` — oportunidade/vantagem/confirmado
+- `yellow` — atenção/potencial/médio
+- `red` — risco/ameaça/fraco
+- `blue` — contexto/informativo/neutro
+- `gray` — desativado/aspiracional/ausente
+
+Usar tons consistentemente: nunca pintar ameaça de verde ou vantagem de vermelho para "chamar atenção". O tom é semântico.
+
+---

--- a/.claude/skills/gt-diagnostico-criativos/schema.json
+++ b/.claude/skills/gt-diagnostico-criativos/schema.json
@@ -1,0 +1,608 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DiagnosticoCriativos",
+  "description": "Output estruturado do diagnostico de criativos: matriz de avaliacao, padroes, analise de concorrentes e briefing de producao.",
+  "type": "object",
+  "required": [
+    "summary",
+    "summary_headline",
+    "summary_highlights",
+    "summary_key_findings",
+    "client_name",
+    "segment",
+    "creative_matrix",
+    "patterns_identified",
+    "what_works",
+    "production_briefing"
+  ],
+  "properties": {
+    "client_name": {
+      "type": "string",
+      "description": "Nome do cliente"
+    },
+    "segment": {
+      "type": "string",
+      "description": "Segmento de atuacao"
+    },
+    "icp_summary": {
+      "type": "string",
+      "description": "Resumo do ICP para referencia"
+    },
+    "total_creatives_analyzed": {
+      "type": "integer",
+      "description": "Total de criativos analisados"
+    },
+    "average_score": {
+      "type": "number",
+      "description": "Score medio dos criativos (de 25)"
+    },
+    "creative_matrix": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "number",
+          "type",
+          "hook_score",
+          "clarity_score",
+          "icp_coherence_score",
+          "cta_score",
+          "visual_score",
+          "total_score",
+          "verdict"
+        ],
+        "properties": {
+          "number": {
+            "type": "integer",
+            "description": "Numero sequencial do criativo"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "feed",
+              "story",
+              "carrossel",
+              "video_curto",
+              "video_longo",
+              "banner",
+              "reels",
+              "outro"
+            ],
+            "description": "Tipo/formato do criativo"
+          },
+          "description": {
+            "type": "string",
+            "description": "Descricao curta do criativo"
+          },
+          "hook_score": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 5,
+            "description": "Score do hook — capacidade de parar o scroll (1-5)"
+          },
+          "hook_comment": {
+            "type": "string",
+            "description": "Comentario especifico sobre o hook"
+          },
+          "clarity_score": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 5,
+            "description": "Score de clareza da mensagem (1-5)"
+          },
+          "clarity_comment": {
+            "type": "string",
+            "description": "Comentario especifico sobre a clareza"
+          },
+          "icp_coherence_score": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 5,
+            "description": "Score de coerencia com o ICP (1-5)"
+          },
+          "icp_coherence_comment": {
+            "type": "string",
+            "description": "Comentario especifico sobre coerencia com ICP"
+          },
+          "cta_score": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 5,
+            "description": "Score do CTA — clareza e visibilidade (1-5)"
+          },
+          "cta_comment": {
+            "type": "string",
+            "description": "Comentario especifico sobre o CTA"
+          },
+          "visual_score": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 5,
+            "description": "Score de qualidade visual (1-5)"
+          },
+          "visual_comment": {
+            "type": "string",
+            "description": "Comentario especifico sobre a qualidade visual"
+          },
+          "total_score": {
+            "type": "integer",
+            "minimum": 5,
+            "maximum": 25,
+            "description": "Score total (soma dos 5 criterios)"
+          },
+          "verdict": {
+            "type": "string",
+            "enum": [
+              "manter",
+              "otimizar",
+              "eliminar"
+            ],
+            "description": "Veredicto: manter (20-25), otimizar (13-19), eliminar (<13)"
+          },
+          "verdict_reason": {
+            "type": "string",
+            "description": "Motivo do veredicto em 1 frase"
+          },
+          "performance_data": {
+            "type": "object",
+            "description": "Dados de performance se disponiveis",
+            "properties": {
+              "ctr": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "cpl": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "impressions": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "clicks": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              }
+            }
+          },
+          "preview": {
+            "type": "object",
+            "description": "Midia do criativo para embed no portal. Populado automaticamente pelo meta_ads_fetch.sh ou manualmente pelo operador.",
+            "properties": {
+              "image_url": {
+                "type": ["string", "null"],
+                "description": "Path relativo (ex: 'assets/creatives/meta/{slug}/{ad_id}/image.jpg') ou URL absoluta"
+              },
+              "thumbnail_url": {
+                "type": ["string", "null"],
+                "description": "Miniatura otimizada para grid"
+              },
+              "video_url": {
+                "type": ["string", "null"],
+                "description": "URL do CDN Meta (se for video) — renderer embeda direto via <video>"
+              },
+              "ads_library_id": {
+                "type": ["string", "null"],
+                "description": "ID do anuncio na Meta Ads Library"
+              },
+              "ads_library_url": {
+                "type": ["string", "null"],
+                "description": "Link direto para a pagina do anuncio no Meta Ads Library"
+              },
+              "start_date": {
+                "type": ["string", "null"],
+                "description": "Data de inicio da veiculacao (ISO)"
+              },
+              "platforms": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Plataformas onde o anuncio foi veiculado (facebook, instagram, messenger, audience_network)"
+              },
+              "cta_type": {
+                "type": ["string", "null"],
+                "description": "Tipo de CTA (LEARN_MORE, MESSAGE_PAGE, SHOP_NOW, etc.)"
+              },
+              "source": {
+                "type": "string",
+                "enum": ["meta_ads_library", "uploaded", "unavailable"],
+                "description": "De onde veio a midia"
+              },
+              "fetched_at": {
+                "type": ["string", "null"],
+                "format": "date-time"
+              }
+            }
+          }
+        }
+      },
+      "description": "Matriz de avaliacao de cada criativo"
+    },
+    "patterns_identified": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "pattern",
+          "affected_creatives",
+          "example"
+        ],
+        "properties": {
+          "pattern": {
+            "type": "string",
+            "description": "Descricao do padrao/problema"
+          },
+          "affected_creatives": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            },
+            "description": "Numeros dos criativos afetados"
+          },
+          "example": {
+            "type": "string",
+            "description": "Exemplo concreto do padrao"
+          }
+        }
+      },
+      "description": "Padroes de problema que se repetem"
+    },
+    "what_works": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "element",
+          "seen_in",
+          "reason"
+        ],
+        "properties": {
+          "element": {
+            "type": "string",
+            "description": "Elemento que funciona"
+          },
+          "seen_in": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            },
+            "description": "Numeros dos criativos onde aparece"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Por que funciona"
+          }
+        }
+      },
+      "description": "Elementos que devem ser preservados ou replicados"
+    },
+    "competitor_analysis": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "competitor",
+          "creative_pattern"
+        ],
+        "properties": {
+          "competitor": {
+            "type": "string",
+            "description": "Nome do concorrente"
+          },
+          "active_ads_count": {
+            "type": "integer",
+            "description": "Numero de anuncios ativos (Meta Ads Library)"
+          },
+          "ads_library_url": {
+            "type": "string",
+            "description": "Link direto para a Meta Ads Library do concorrente"
+          },
+          "creative_pattern": {
+            "type": "string",
+            "description": "Padrao criativo observado"
+          },
+          "what_works": {
+            "type": "string",
+            "description": "O que pode inspirar"
+          },
+          "what_to_avoid": {
+            "type": "string",
+            "description": "O que nao copiar"
+          },
+          "gap_para_cliente": {
+            "type": "boolean",
+            "description": "True se o concorrente usa um padrao que o cliente NAO usa e deveria testar."
+          },
+          "replication_idea": {
+            "type": ["string", "null"],
+            "description": "Se gap_para_cliente=true, ideia concreta para o cliente replicar (formato, hook, angulo). null quando gap=false."
+          },
+          "sample_ads": {
+            "type": "array",
+            "description": "Ate 6 anuncios de exemplo do concorrente para embed no portal. Populado pelo meta_ads_fetch.sh.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "ads_library_id": {"type": ["string", "null"]},
+                "ads_library_url": {"type": ["string", "null"]},
+                "image_url": {"type": ["string", "null"]},
+                "thumbnail_url": {"type": ["string", "null"]},
+                "video_url": {"type": ["string", "null"]},
+                "copy_excerpt": {"type": ["string", "null"], "description": "Primeiros 150 caracteres do copy"},
+                "start_date": {"type": ["string", "null"]},
+                "platforms": {"type": "array", "items": {"type": "string"}},
+                "cta_type": {"type": ["string", "null"]}
+              }
+            }
+          }
+        }
+      },
+      "description": "Analise de criativos de concorrentes na Meta Ads Library"
+    },
+    "competitor_patterns_missing": {
+      "type": "array",
+      "description": "Padroes recorrentes dos concorrentes que o cliente NAO usa — lista priorizada de gaps acionaveis. Mesma logica do gt-diagnostico-organico-instagram para coerencia cross-outputs.",
+      "items": {
+        "type": "object",
+        "required": [
+          "pattern",
+          "seen_in_competitors",
+          "why_it_works",
+          "how_client_could_implement"
+        ],
+        "properties": {
+          "pattern": {
+            "type": "string",
+            "description": "Descricao do padrao (ex: 'video vertical com case real + depoimento em texto sobreposto')"
+          },
+          "seen_in_competitors": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Nomes dos concorrentes que usam o padrao"
+          },
+          "ads_count": {
+            "type": "integer",
+            "description": "Quantos anuncios dos concorrentes usam esse padrao"
+          },
+          "why_it_works": {
+            "type": "string",
+            "description": "Por que provavelmente funciona para o ICP do cliente"
+          },
+          "how_client_could_implement": {
+            "type": "string",
+            "description": "Como o cliente poderia implementar (acionavel, nao generico)"
+          },
+          "priority": {
+            "type": "string",
+            "enum": ["alta", "media", "baixa"]
+          }
+        }
+      }
+    },
+    "production_briefing": {
+      "type": "object",
+      "required": [
+        "hook_direction",
+        "priority_format",
+        "visual_elements",
+        "avoid_elements",
+        "copy_guidelines"
+      ],
+      "properties": {
+        "hook_direction": {
+          "type": "string",
+          "description": "Direcao recomendada para hooks"
+        },
+        "hook_examples": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Exemplos de hooks recomendados"
+        },
+        "priority_format": {
+          "type": "string",
+          "enum": [
+            "stories_vertical",
+            "feed_quadrado",
+            "carrossel",
+            "video_curto",
+            "video_longo",
+            "reels"
+          ],
+          "description": "Formato prioritario para novos criativos"
+        },
+        "format_justification": {
+          "type": "string",
+          "description": "Por que este formato para este ICP"
+        },
+        "visual_elements": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Elementos visuais a incluir nos novos criativos"
+        },
+        "avoid_elements": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Elementos a evitar nos novos criativos"
+        },
+        "copy_guidelines": {
+          "type": "object",
+          "properties": {
+            "length": {
+              "type": "string",
+              "enum": [
+                "short_15_words",
+                "medium_30_words",
+                "long_50_plus"
+              ],
+              "description": "Comprimento recomendado"
+            },
+            "tone": {
+              "type": "string",
+              "description": "Tom recomendado"
+            },
+            "structure": {
+              "type": "string",
+              "description": "Estrutura recomendada (ex: hook-dor-solucao-prova-CTA)"
+            },
+            "icp_keywords": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Palavras-chave que o ICP usa"
+            }
+          },
+          "description": "Diretrizes de copy para novos criativos"
+        },
+        "recommended_quantity": {
+          "type": "integer",
+          "description": "Quantidade recomendada de novos criativos"
+        },
+        "variation_plan": {
+          "type": "string",
+          "description": "Plano de variacoes (ex: 3 hooks x 2 formatos x 2 CTAs)"
+        }
+      },
+      "description": "Briefing para producao de novos criativos na Semana 3"
+    },
+    "completed_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Data/hora de conclusao"
+    },
+    "counts": {
+      "type": "object",
+      "description": "Resumo da avaliacao",
+      "properties": {
+        "keep_count": {
+          "type": "integer",
+          "description": "Quantidade de criativos para manter"
+        },
+        "optimize_count": {
+          "type": "integer",
+          "description": "Quantidade de criativos para otimizar"
+        },
+        "eliminate_count": {
+          "type": "integer",
+          "description": "Quantidade de criativos para eliminar"
+        }
+      }
+    },
+    "summary": {
+      "type": "string",
+      "description": "Resumo de 1-2 frases do diagnóstico de criativos. Inclui principais padrões encontrados e ação prioritária."
+    },
+    "summary_headline": {
+      "type": "string",
+      "maxLength": 200,
+      "description": "Manchete em 1 linha com o veredito da analise. Ex: '[Cliente]: 7 de 10 criativos falham no hook — oportunidade de redesenho antes de escalar midia'. Ver PADRAO-OUTPUT.md."
+    },
+    "summary_highlights": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 8,
+      "description": "KPIs visuais categorizados para o resumo executivo. Ex: {category:'maturidade', label:'Score medio', value:'13,2/25', tone:'yellow'}.",
+      "items": {
+        "type": "object",
+        "required": ["category", "label", "value"],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": ["posicao", "competicao", "janela", "maturidade", "oportunidade", "risco"]
+          },
+          "label": {
+            "type": "string",
+            "maxLength": 40
+          },
+          "value": {
+            "type": "string"
+          },
+          "subtext": {
+            "type": "string",
+            "maxLength": 80
+          },
+          "tone": {
+            "type": "string",
+            "enum": ["green", "yellow", "red", "blue", "gray"]
+          }
+        }
+      }
+    },
+    "summary_key_findings": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 6,
+      "description": "Achados categorizados. Cobrir pelo menos 3 dos 4 tipos (vantagem/contexto/ameaca/acao).",
+      "items": {
+        "type": "object",
+        "required": ["category", "text"],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": ["vantagem", "contexto", "ameaca", "acao"]
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "key_insight": {
+      "type": "object",
+      "description": "Ponto de alavancagem desta skill — para diagnostico de criativos, e o padrao criativo mais impactante (problema recorrente ou sucesso a amplificar) OU o gap mais assimetrico vs concorrente. Ver PADRAO-OUTPUT.md.",
+      "properties": {
+        "headline": {
+          "type": "string",
+          "description": "Frase-manchete do ponto (pode virar quote destacada)"
+        },
+        "context": {
+          "type": "string",
+          "description": "Contexto em 2-3 linhas explicando o cenario"
+        },
+        "numbered_reasons": {
+          "type": "array",
+          "items": {"type": "string"},
+          "description": "Razoes numeradas (renderer vira 3 cards)"
+        },
+        "discussion_anchor": {
+          "type": "string",
+          "description": "Por que este e o ponto para stakeholder decidir/validar"
+        }
+      }
+    },
+    "honesty_alert": {
+      "type": "string",
+      "description": "Alerta se o diagnostico revelou fragilidade critica (ex: cliente nao tem criativos pagos ativos, base insuficiente para analise, concorrentes dominam com volume que o cliente nao consegue acompanhar). Nunca omitir se justificado."
+    },
+    "source_outputs": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Outputs consultados para cross-referencia (ex: 'gt-diagnostico-midia-paga.json' para performance por criativo, 'geral-persona-icp.json' para ICP)."
+    },
+    "period": {
+      "type": "object",
+      "description": "Periodo coberto pelos criativos analisados (se aplicavel).",
+      "properties": {
+        "start": {"type": "string", "format": "date"},
+        "end": {"type": "string", "format": "date"}
+      }
+    }
+  }
+}

--- a/.claude/skills/gt-diagnostico-cro/SKILL.md
+++ b/.claude/skills/gt-diagnostico-cro/SKILL.md
@@ -1,0 +1,283 @@
+---
+name: gt-diagnostico-cro
+description: "Diagnostico de CRO (Conversion Rate Optimization): analise tecnica, auditoria de copy, hipoteses de teste e wireframe de melhorias para a landing page. Use quando o operador disser /gt-diagnostico-cro ou 'analisar conversao' ou 'diagnostico da landing page' ou 'por que a LP nao converte' ou 'analise de CRO'."
+area: gt
+author: luizfreitasv4
+version: 1.0.0
+dependencies:
+  - geral-persona-icp
+  - geral-posicionamento-estrategico
+tools: []
+week: 3
+modelo_venda: inside-sales
+estimated_time: "2.5h"
+output_file: "gt-diagnostico-cro.json"
+multimodal: true
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta versao foi portada do sistema de Estruturacao Estrategica. As regras abaixo tem precedencia sobre caminhos e persistencia citados no fluxo original:
+
+- Trabalhe somente em `squads/{squad}/clientes/{cliente}/`, nunca em um diretorio `clientes/` solto na raiz.
+- Leia primeiro o `CLAUDE.md` ou `AGENTS.md` da KB, `mission-control/`, `calls/`, `docs/` e `campanhas/`.
+- Se `client.json` existir, use-o como fonte complementar. Se nao existir, derive o contexto da KB e do Mission Control; nao exija nem invente esse arquivo.
+- Salve entregaveis em `squads/{squad}/clientes/{cliente}/outputs/`, em JSON e Markdown quando o fluxo pedir ambos.
+- Registre decisoes e progresso no `mission-control/historico-checkins.md` ou no arquivo de historico equivalente encontrado na KB.
+- Resolva recursos empacotados a partir do proprio diretorio desta skill. Se uma integracao externa nao estiver configurada, declare o gap e continue apenas com os dados reais disponiveis.
+
+
+# Diagnóstico de CRO — Site/LP (POP 3.1 — Inside Sales)
+
+> **Posição no fluxo:** etapa de CRO para operações de Inside Sales. Cobre Core Web Vitals, SEO on-page, copy vs. PUV, sinais de confiança, tracking e LGPD, com hipóteses A/B priorizadas por ICE. Para e-commerce, adapte a análise para PDP, carrinho e checkout.
+
+Voce e um especialista em CRO com experiencia em PMEs brasileiras. Vai analisar o site ou landing page do cliente sob a otica de conversao: onde os visitantes saem, o que impede o clique no CTA, e quais mudancas tem maior impacto. O output final inclui um wireframe de melhorias que alimenta diretamente a skill de landing page da Semana 3.
+
+**CAPACIDADE MULTIMODAL:** Voce pode analisar screenshots da pagina visualmente. O operador vai compartilhar prints da pagina (mobile e desktop) e voce faz a auditoria visual.
+
+## Dados necessários
+
+1. Leia `client.json` (seção `briefing`) — extraia: NOME_CLIENTE, SEGMENTO, URL_SITE, OBJETIVO_PAGINA
+2. Leia `outputs/geral-persona-icp.json` — extraia: RESUMO_ICP, dores, linguagem, canal preferencial
+3. Leia `outputs/geral-posicionamento-estrategico.json` — extraia: PUV, mensagem topo/fundo de funil, tom de comunicacao
+4. Se houver `outputs/gt-diagnostico-midia-paga.json`, carregue taxa de conversao e bounce rate
+
+## Fluxo obrigatório (ordem fixa, sem pular etapas)
+
+Todo diagnóstico de CRO é composto por 3 etapas automatizadas + análise visual. **Nenhuma etapa é opcional** — o schema exige os blocos preenchidos.
+
+1. **Audit técnico PSI** (`page_audit.sh`) → preenche `technical_audit`, `onpage_seo`, `security_headers`
+2. **Audit profundo Playwright** (`page_audit_deep.sh`) → preenche `tracking_stack`, `events_fired`, `quality_flags`, `cro_elements_deep`, `compliance_lgpd`
+3. **Análise visual** (screenshots + copy audit + hipóteses + wireframe) → preenche `copy_audit`, `trust_analysis`, `test_hypotheses`, `wireframe_improvements`
+
+Cache: se `client.json.page_audit.fetched_at` e `client.json.page_audit_deep.fetched_at` forem ambos < 7 dias, reaproveitar. Senão rodar novamente.
+
+### Passo 1 — Audit técnico automatizado (PSI)
+
+Ele alimenta os blocos `technical_audit`, `onpage_seo` e `security_headers` do output com dados reais de PageSpeed Insights + parser HTML + headers de segurança.
+
+Verifique `client.json.page_audit.fetched_at`:
+- Se ausente OU mais de 7 dias → rode novo audit
+- Se dentro de 7 dias → reaproveite os dados do `client.json.page_audit`
+
+**Comando:**
+```bash
+bash .claude/skills/gt-diagnostico-cro/scripts/page_audit.sh squads/{squad}/clientes/{cliente} {URL}
+```
+
+O script:
+1. Lê `.credentials/google.json` (campo `pagespeed_api_key`)
+2. Roda em paralelo: PSI mobile + PSI desktop + on-page mobile UA + on-page desktop UA + headers
+3. Salva raw em `squads/{squad}/clientes/{cliente}/cache/page_audit-{timestamp}.json`
+4. Condensa summary em `client.json.page_audit`
+
+**Setup inicial (uma vez por ambiente):**
+- Criar projeto no Google Cloud Console → habilitar PageSpeed Insights API → gerar API Key
+- Copiar `.credentials/google.json.example` → `.credentials/google.json` → colar a key
+- 1 key serve para todos os clientes (cota 25k queries/dia, 2 queries por audit)
+- `pip3 install --user -r .claude/skills/gt-diagnostico-cro/scripts/requirements.txt` (requests, beautifulsoup4, lxml)
+
+### Passo 2 — Audit PROFUNDO (Playwright)
+
+**SEMPRE depois do Passo 1.** Rode o audit profundo com Playwright. Ele renderiza a página como um usuário real (Chromium headless), intercepta requests de rede, inspeciona `dataLayer`, simula interações e gera 5 blocos adicionais:
+
+1. `tracking_stack` — GTM/GA4/Meta Pixel/Clarity/Hotjar/Chat detectados (com IDs reais AW-XXX, GTM-XXX, G-XXX)
+2. `events_fired` — eventos GA4 (`page_view`, `scroll`, `generate_lead`) e Meta Pixel (`PageView`, `Lead`, `Purchase`) realmente disparados
+3. `quality_flags` — red flags: UA legacy, Pixel duplicado, GTM sem analytics, sem Consent Mode v2
+4. `cro_elements_deep` — CTAs visíveis, forms (campos, required, consent checkbox), WhatsApp, prova social, urgência, confiança
+5. `compliance_lgpd` — 2-pass (pre-consent) para detectar scripts que vazam dados antes do usuário aceitar cookies
+
+Verifique `client.json.page_audit_deep.fetched_at`:
+- Se ausente OU mais de 7 dias → rode novo deep audit
+- Se dentro de 7 dias → reaproveite
+
+**Comando:**
+```bash
+bash .claude/skills/gt-diagnostico-cro/scripts/page_audit_deep.sh squads/{squad}/clientes/{cliente} {URL}
+```
+
+O script:
+1. Lança Chromium headless (user-agent pt-BR, timezone SP)
+2. Faz 3 passes: desktop completo, mobile completo, compliance pre-consent
+3. Captura todo o network (GA4 `/collect`, Meta `/tr`, GTM, doubleclick, etc.)
+4. Dump do `window.dataLayer` e globals relevantes
+5. Screenshot full-page de desktop + mobile
+6. Salva raw em `squads/{squad}/clientes/{cliente}/cache/page_audit_deep-{timestamp}.json`
+7. Condensa summary em `client.json.page_audit_deep`
+
+**Setup inicial (uma vez por ambiente):**
+- `pip3 install --user -r .claude/skills/gt-diagnostico-cro/scripts/requirements-deep.txt` (playwright, pyyaml)
+- `python3 -m playwright install chromium` (~200MB, uma vez por máquina)
+- Tempo total: ~60-90s por URL
+
+### Pedido ao operador
+
+Peca ao operador de uma vez:
+
+> Para o diagnostico de CRO, preciso de:
+> 1. **URL do site/landing page** do cliente (vou rodar o audit tecnico automatico)
+> 2. **Screenshots da pagina** — mobile E desktop, scroll completo (para analise visual multimodal)
+> 3. **Taxa de conversao atual** (se tiver)
+> 4. **Bounce rate** (se tiver)
+> 5. **Tempo medio na pagina** (se tiver)
+
+Aguarde o operador fornecer os dados. Com a URL, rode `page_audit.sh` E `page_audit_deep.sh` em sequência ANTES de pedir os screenshots — os dados técnicos + tagueamento + compliance já orientam onde olhar na análise visual.
+
+### Passo 3 — Análise visual + geração do output
+
+Só depois dos Passos 1 e 2 concluídos (client.json populado com `page_audit` + `page_audit_deep`), proceda para a análise visual dos screenshots e geração do output JSON completo conforme schema.
+
+---
+
+## Geração
+
+Gere o output COMPLETO de uma vez usando os dados de `client.json` (briefing, connectors) e outputs de skills dependentes em `outputs/`.
+
+Consulte `references/checklist-cro.md` para os criterios de avaliacao.
+
+### Diagnóstico técnico (3 camadas automáticas)
+
+Com o audit já rodado (passo anterior), leia `client.json.page_audit` e preencha 3 blocos estruturados:
+
+**1. `technical_audit`** — Core Web Vitals + Lighthouse (copie exatamente do page_audit.pagespeed):
+- `mobile_scores` e `desktop_scores` (performance, accessibility, best_practices, seo)
+- `mobile_cwv_lab` e `desktop_cwv_lab` (LCP, FCP, TBT, CLS, Speed Index, TTI, TTFB)
+- `mobile_cwv_field` e `desktop_cwv_field` (CrUX, se disponível)
+- `mobile_top_opportunities` e `desktop_top_opportunities` (Top 10 por savings_ms)
+
+**2. `onpage_seo`** — parser HTML (copie de page_audit.onpage):
+- `mobile` e `desktop` com: title, meta_description, canonical, lang, viewport, favicon, og, twitter, schema_types, h1/h2/h3_count, images_total/images_without_alt, links_internal/external/nofollow, html_size_kb, response_time_ms
+- `divergences` — diferenças entre mobile e desktop (rendering inconsistente, cloaking acidental)
+
+**3. `security_headers`** — headers HTTP (copie de page_audit.security):
+- https, hsts, csp, x_frame_options, x_content_type_options, referrer_policy, permissions_policy
+- `score` 0-10 e `issues` (lista de headers ausentes ou fracos)
+
+### Diagnóstico profundo (5 blocos do page_audit_deep)
+
+Com o audit profundo rodado, leia `client.json.page_audit_deep` e preencha 5 novos blocos:
+
+**5. `tracking_stack`** — ferramentas detectadas (copie de page_audit_deep.tracking_stack):
+- `tools_detected`, `ids_found`, `categories_summary`, `total_tools`
+- `setup_diagnosis` — narrativa obrigatória. Exemplos de interpretação:
+  - "GTM presente (GTM-XXXXX) mas sem GA4 — cliente opera cego. Investimento em mídia não tem atribuição."
+  - "Google Ads tag presente (AW-XXXXX) mas sem Meta Pixel — perde possibilidade de remarketing no Facebook/Instagram."
+  - "Hotjar detectado — cliente já investe em UX research. Aproveitar para validar hipóteses de teste com gravações."
+  - "Plataforma: WordPress + Elementor + LiteSpeed — site estático. Qualquer mudança pode ser feita sem dev."
+
+**6. `events_fired`** — eventos reais (copie de page_audit_deep.events_fired):
+- `ga4_event_count`, `meta_event_count`, `ga4_event_names`, `meta_event_names`
+- `events_diagnosis` — cheque completude esperada: `page_view` (GA4) e `PageView` (Pixel) são obrigatórios. Formulários devem gerar `generate_lead` (GA4) e `Lead` (Pixel). Se faltarem, listar em `expected_events_missing`.
+
+**7. `quality_flags`** — copie de page_audit_deep.quality_flags (array de red flags com severity).
+
+**8. `cro_elements_deep`** — copie de page_audit_deep.cro_elements (mobile + desktop). Adicione narrativas:
+- `cta_diagnosis` — interprete `cta_count`, `cta_above_fold`, consistência de texto entre CTAs
+- `form_diagnosis` — regra: formulário com > 5 campos cai conversão >50% (baseline Hubspot). Sempre checar `has_consent_checkbox` para LGPD.
+- `social_proof_diagnosis` — baseado em `social_proof.*` (has_testimonials, has_ratings, has_numbers, has_certifications, has_logos_clients)
+- `trust_diagnosis` — baseado em `trust.*` (has_cnpj, has_phone, has_email, has_privacy_link, has_terms_link)
+
+**9. `compliance_lgpd`** — copie de page_audit_deep.compliance_lgpd. Sempre adicione `recommendation`:
+- Se `non_compliant` → "URGENTE: Instalar CMP (Cookiebot R$0/mês até 500k pageviews ou OneTrust). Configurar gtag consent default denied + Consent Mode v2. Risco de multa ANPD até R$50M."
+- Se `partial` (CMP mas trackers pré-consent) → "Ajustar CMP para bloquear tags até opt-in. Verificar GTM: triggers devem checar consent state."
+- Se `compliant` → "Manter. Checar anualmente se novas tags adicionadas respeitam consent."
+
+**4. `technical_diagnosis`** — narrativa sobre os números:
+- `pagespeed_mobile` e `pagespeed_desktop` (score de performance)
+- `lcp`, `cls`, `inp` (lab mobile, em segundos para LCP/INP)
+- `critical_issues` — **interprete** os top opportunities e o on-page: se `render-blocking-resources` > 1000ms, cite; se `images_without_alt` > 50% do total, cite; se falta HSTS/CSP e o site transaciona dados, cite
+- `estimated_conversion_loss` — correlacione com benchmarks: cada 100ms de LCP > 2500ms custa ~7% de conversão (estudo Google/Deloitte). Se LCP mobile > 4s, diga "queda estimada de 20-30%"
+- `tested: true`
+
+### Auditoria de copy (above the fold + seção a seção)
+
+**Above the fold (hero):**
+- Proposta de valor clara em < 5 segundos?
+- Headline responde "o que + para quem + qual benefício"?
+- Headline atual vs headline sugerida (baseada na PUV)
+- CTA visível sem rolar? CTA atual vs sugerido
+- O que um visitante do ICP pensa ao chegar
+
+**Estrutura da página (seção a seção):**
+
+| Secao | Existe? | Avaliacao | Problema principal |
+|-------|---------|-----------|-------------------|
+| Hero com PUV | {S/N} | {1-5} | {descricao} |
+| Problema/dor | {S/N} | {1-5} | {descricao} |
+| Solucao | {S/N} | {1-5} | {descricao} |
+| Como funciona | {S/N} | {1-5} | {descricao} |
+| Prova social | {S/N} | {1-5} | {descricao} |
+| FAQ | {S/N} | {1-5} | {descricao} |
+| CTA final | {S/N} | {1-5} | {descricao} |
+
+Seções faltando (críticas) + seções desnecessárias.
+
+**Análise de confiança:**
+Checklist de sinais de confiança (CNPJ, endereço, fotos reais, depoimentos, selos, SSL, etc.). Score de confiança X/10. Maior gap.
+
+### Hipóteses de teste priorizadas por impacto
+
+| # | Hipotese | Elemento | Impacto | Dificuldade | Prioridade |
+|---|----------|----------|---------|-------------|------------|
+
+Para cada hipótese P1, detalhe: versão atual, versão proposta, métrica de sucesso, impacto estimado.
+
+### Wireframe de melhorias
+
+Estrutura recomendada para a nova LP (seção por seção): Hero, Problema/Dor, Solução, Como Funciona, Prova Social, FAQ, CTA Final. Para cada: conteúdo, copy sugerida, formato. Elementos transversais: barra de confiança, WhatsApp flutuante, exit intent popup.
+
+## Auto-validação
+
+Antes de mostrar ao operador, verifique:
+
+- [ ] Mencionou o cliente pelo nome?
+- [ ] Usou dados reais do client.json (não inventou)?
+- [ ] Nenhum item genérico (ex: "quer crescer", "qualidade e compromisso")?
+- [ ] Schema da skill validou?
+- [ ] Todos os campos do schema preenchidos (ou com `null` + `unavailable_reason` no pai)?
+- [ ] Nenhuma string vazia (`""`) — substituí por `null` + reason quando o dado não existe?
+- [ ] Estimativas marcadas com `estimated: true` ou `[E]`?
+- [ ] Consistente com outputs anteriores (ICP, posicionamento)?
+- [ ] Headlines sugeridas são baseadas na PUV aprovada?
+- [ ] Hipóteses têm impacto estimado (não apenas "melhorar")?
+- [ ] Wireframe é suficiente para construir a LP na Semana 3?
+- [ ] `technical_audit`, `onpage_seo`, `security_headers` preenchidos com dados reais do page_audit (não zerados)?
+- [ ] `critical_issues` em `technical_diagnosis` cita opportunities específicas (não "otimizar velocidade" genérico)?
+- [ ] Hipóteses de teste incluem pelo menos 1 ligada a achado técnico (LCP alto → otimizar hero, imagens sem alt → adicionar alt, etc.)?
+- [ ] `tracking_stack`, `events_fired`, `quality_flags`, `cro_elements_deep`, `compliance_lgpd` preenchidos do page_audit_deep?
+- [ ] `setup_diagnosis` é específico (cita os IDs reais GTM-/AW-/G-, não genérico)?
+- [ ] Hipóteses P1 incluem pelo menos 1 ligada a tagueamento/compliance se houver red flags críticos (ex: "Instalar GA4", "Adicionar CMP")?
+
+Se falhou → regenere silenciosamente. Não avise o operador.
+
+## Apresentação e decisões
+
+Apresente o output COMPLETO ao operador.
+
+Revise o output. O que está errado, exagerado ou faltando?
+
+- "A auditoria reflete o que voce ve na pagina? Algum elemento que eu nao consegui ver nos screenshots?"
+- "As hipoteses de teste fazem sentido na prioridade? Alguma que voce ja testou?"
+- "O wireframe seria suficiente para construir a LP na Semana 3?"
+- "Alguma restricao tecnica? (ex: 'usamos WordPress e nao Vercel', 'formulario precisa integrar com Kommo')"
+
+## Finalização
+
+Operador aprova (com ou sem ajustes).
+1. Salve em `squads/{squad}/clientes/{cliente}/outputs/gt-diagnostico-cro.json` (com campo `summary` no topo)
+2. Atualize `client.json`: progress.skills → completed, version++, append em history[]
+3. Salve também uma versão Markdown do entregável na mesma pasta de outputs.
+4. Sugira próxima skill do dependency_graph
+   - "Diagnóstico CRO concluído. PageSpeed mobile: {score}/100. Score de confiança: {X}/10. Hipóteses: {numero}."
+   - "Este diagnostico (CRO Site/LP, POP 3.1) alimenta a Landing Page (POP 3.8) e o Pipeline consultivo."
+   - "Cabeça do Inside Sales: próximo passo é o Cliente Oculto (/account-cliente-oculto, POP 3.2)."
+
+
+## Campo obrigatório: summary
+
+Sempre inclua no JSON de saída:
+```json
+"summary": "Resumo de 1-2 frases do diagnóstico de CRO: principal gap de conversão identificado e ação prioritária. Seja específico — mencione o cliente, números reais e a conclusão principal."
+```
+
+Este campo alimenta o Resumo Executivo do portal de entregas. Deve ser objetivo, com dados reais, sem genéricos.

--- a/.claude/skills/gt-diagnostico-cro/references/checklist-cro.md
+++ b/.claude/skills/gt-diagnostico-cro/references/checklist-cro.md
@@ -1,0 +1,281 @@
+# Checklist Completo de CRO para Landing Pages de PMEs Brasileiras
+
+## Como usar este checklist
+
+Use este checklist como referencia ao auditar landing pages. Nem todos os itens se aplicam a todos os casos — priorize os que tem maior impacto para o segmento e ICP do cliente.
+
+A auditoria segue 5 dimensoes:
+1. Performance tecnica
+2. Above the fold (hero)
+3. Estrutura e conteudo
+4. Confianca e credibilidade
+5. Mobile e UX
+
+---
+
+## 1. Performance Tecnica
+
+### Core Web Vitals
+
+| Metrica | Bom | Medio | Ruim | Impacto |
+|---------|-----|-------|------|---------|
+| LCP (Largest Contentful Paint) | <2.5s | 2.5-4s | >4s | Cada segundo extra = -7% conversao |
+| CLS (Cumulative Layout Shift) | <0.1 | 0.1-0.25 | >0.25 | Layout pulando = visitante sai |
+| INP (Interaction to Next Paint) | <200ms | 200-500ms | >500ms | Clique sem resposta = frustracao |
+
+### PageSpeed Score
+
+| Score | Classificacao | Acao |
+|-------|--------------|------|
+| 90-100 | Excelente | Manter e monitorar |
+| 50-89 | Medio | Otimizar (imagens, JS, CSS) |
+| 0-49 | Ruim | Refazer ou otimizacao urgente |
+
+### Checklist tecnico
+
+```
+[ ] PageSpeed mobile >= 50 (idealmente >= 70)
+[ ] PageSpeed desktop >= 70 (idealmente >= 90)
+[ ] LCP < 2.5 segundos
+[ ] CLS < 0.1
+[ ] SSL (HTTPS) ativo
+[ ] Sem erros 404 ou redirects desnecessarios
+[ ] Imagens otimizadas (WebP, lazy loading)
+[ ] Sem JavaScript blocante na renderizacao
+[ ] Fonts carregando rapido (preload ou system fonts)
+[ ] Meta tags basicas (title, description, og:image)
+[ ] Mobile responsive (nao apenas "funciona" — "fica bom")
+[ ] Formulario funcional (testado — envia de verdade)
+[ ] Tracking instalado (GA4, Pixel Meta, Tag Manager)
+```
+
+### Causas comuns de lentidao em LPs de PMEs
+
+1. **Imagens nao otimizadas** — JPGs de 3MB direto da camera. Solucao: WebP, max 200KB, lazy load
+2. **Slider/carrossel pesado** — Plugins de carrossel com JS pesado. Solucao: imagem estatica ou CSS puro
+3. **Fonts externas** — Google Fonts sem preload. Solucao: preload ou hospedar localmente
+4. **WordPress com 30 plugins** — Cada plugin adiciona JS/CSS. Solucao: remover nao essenciais
+5. **Video autoplay** — Video pesado carregando no hero. Solucao: thumbnail + play on click
+6. **Hosting ruim** — Shared hosting lento. Solucao: Vercel, Netlify, ou VPS
+7. **Chat widgets** — Tawk.to, Intercom carregando JS pesado. Solucao: lazy load ou remover
+8. **Animations pesadas** — CSS/JS animations que causam repaints. Solucao: transform/opacity only
+
+---
+
+## 2. Above the Fold (Hero)
+
+O hero e responsavel por 80% da decisao de ficar ou sair. A regra e: em 5 segundos, o visitante precisa saber O QUE e, PARA QUEM e, e O QUE FAZER.
+
+### Checklist do hero
+
+```
+[ ] Headline clara (responde "o que + para quem + beneficio")
+[ ] Sub-headline que complementa (nao repete)
+[ ] CTA visivel sem rolar (botao, nao link)
+[ ] CTA com texto acionavel ("Agendar consulta gratis" > "Saiba mais")
+[ ] Elemento visual relevante (foto real, nao stock generico)
+[ ] Prova social rapida (estrelas, numero de clientes, selo)
+[ ] Sem excesso de informacao (max 3 elementos de texto)
+[ ] Contraste suficiente entre texto e fundo
+[ ] Mobile: tudo acima da dobra em tela de 375px
+```
+
+### Erros fatais no hero
+
+| Erro | Por que e fatal | Solucao |
+|------|----------------|---------|
+| Headline generica ("Bem-vindo") | Nao diz o que faz nem para quem | PUV como headline |
+| Slider/carrossel no hero | Ninguem le alem do primeiro slide | Imagem unica com mensagem clara |
+| Video autoplay com som | Irrita e faz o visitante fechar | Video mudo ou thumbnail |
+| CTA abaixo da dobra | Quem nao rola nunca ve | CTA no hero, sempre |
+| Formulario longo no hero | Gera atrito antes de gerar interesse | Formulario curto (nome + telefone) ou CTA para WhatsApp |
+
+### Headlines que convertem (formulas)
+
+1. **Resultado direto:** "[Resultado] para [ICP] em [prazo]"
+   Ex: "30+ leads qualificados por mes para clinicas de estetica"
+
+2. **Dor → Solucao:** "Cansou de [dor]? [Solucao] sem [objecao]"
+   Ex: "Cansou de gastar com anuncio sem retorno? Performance real sem contrato de fidelidade"
+
+3. **PUV direta:** "[O que faz] de um jeito [como ninguem faz]"
+   Ex: "Implante dental em sessao unica com sedacao — sem medo, sem espera"
+
+4. **Especializacao:** "[Servico] para [nicho especifico]"
+   Ex: "Contabilidade exclusiva para e-commerces que faturam R$ 50K-2M/mes"
+
+---
+
+## 3. Estrutura e Conteudo
+
+### Ordem recomendada de secoes
+
+A ordem importa. Cada secao leva o visitante um passo mais perto da conversao.
+
+| # | Secao | Objetivo | Se nao tiver |
+|---|-------|----------|--------------|
+| 1 | Hero (PUV + CTA) | Captar atencao, dizer o que e | Visitante sai em 5s |
+| 2 | Problema/dor | Gerar identificacao ("voce tambem?") | Visitante nao se conecta |
+| 3 | Solucao | Mostrar como resolve | Visitante nao entende o valor |
+| 4 | Como funciona | Reduzir incerteza (passo a passo) | Visitante tem medo de contratar |
+| 5 | Prova social | Gerar confianca (outros ja fizeram) | Visitante nao acredita |
+| 6 | Beneficios / diferenciais | Reforcar por que voce e diferente | Visitante compara com concorrente |
+| 7 | FAQ | Eliminar objecoes | Visitante sai com dúvida |
+| 8 | CTA final | Fechar a conversao | Visitante nao converte |
+
+### Checklist por secao
+
+**Secao Problema/Dor:**
+```
+[ ] Descreve a dor com palavras do ICP (nao jargao)
+[ ] Gera identificacao ("voce ja passou por isso?")
+[ ] Nao e exagerada (nao parece manipulacao)
+[ ] Conecta com a solucao que vem a seguir
+```
+
+**Secao Solucao:**
+```
+[ ] Mostra o "o que" e o "como" (nao so features)
+[ ] Foca em transformacao (antes → depois)
+[ ] Usa imagem/video do produto/servico real
+[ ] Conecta com a PUV
+```
+
+**Secao Como Funciona:**
+```
+[ ] 3-5 passos simples (nao 10)
+[ ] Cada passo cabe em 1 frase
+[ ] Mostra que e facil comecar
+[ ] Ultimo passo = resultado positivo
+```
+
+**Secao Prova Social:**
+```
+[ ] Depoimentos com nome + foto + cargo/empresa (nao anonimo)
+[ ] Depoimentos especificos (mencionam resultado, nao "otimo servico")
+[ ] Numero de clientes/projetos/avaliacoes
+[ ] Se possivel, video de depoimento
+[ ] Se tiver logos de clientes, sao reconheciveis pelo ICP
+```
+
+**FAQ:**
+```
+[ ] 3-5 perguntas (nao 20)
+[ ] Inclui objecoes de venda (preco, prazo, garantia)
+[ ] Respostas curtas e diretas
+[ ] Usa linguagem do ICP
+```
+
+---
+
+## 4. Confianca e Credibilidade
+
+Para PMEs, confianca e o maior obstaculo de conversao. O visitante nao conhece a marca e precisa de sinais de que e seguro.
+
+### Hierarquia de sinais de confianca (do mais forte ao mais fraco)
+
+1. **Depoimentos com video** — Mais dificil de falsificar
+2. **Avaliacoes Google (link para Google Meu Negocio)** — Verificavel
+3. **Depoimentos com nome + foto + empresa** — Crivel
+4. **Logos de clientes conhecidos** — Transferencia de confianca
+5. **Selos e certificacoes** (ISO, CRO, OAB, etc.) — Autoridade
+6. **Numero de clientes / projetos** — Prova de volume
+7. **CNPJ e endereco** — Empresa real
+8. **Politica de privacidade** — Profissionalismo
+9. **Garantia explicita** — Reduz risco percebido
+10. **SSL (cadeado)** — Basico, mas ausencia e fatal
+
+### Score de confianca
+
+| Score | Descricao | Conversao tipica |
+|-------|-----------|-----------------|
+| 1-3 | Sem sinais de confianca. Parece golpe. | <1% |
+| 4-5 | Sinais basicos (CNPJ, SSL). Pouco profissional. | 1-3% |
+| 6-7 | Profissional. Depoimentos e prova social. | 3-8% |
+| 8-9 | Forte confianca. Video, reviews, garantia. | 8-15% |
+| 10 | Confianca maxima. Marca conhecida, prova abundante. | 15%+ |
+
+---
+
+## 5. Mobile e UX
+
+### Estatisticas que importam
+- 75-85% do trafego de Meta Ads em PMEs brasileiras e mobile
+- Se a LP nao funciona em mobile, voce perde 3/4 do investimento
+- Visitante mobile tem menos paciencia (thumb scroll rapido)
+
+### Checklist mobile
+
+```
+[ ] Layout 100% responsivo (nao apenas "encolhido")
+[ ] Texto legivel sem zoom (min 16px)
+[ ] Botoes grandes o suficiente para polegar (min 44x44px)
+[ ] CTA fixo na tela (sticky button) ou facilmente acessivel
+[ ] Formulario simples (max 3 campos em mobile)
+[ ] Nao tem popup que bloqueia a tela inteira em mobile
+[ ] Imagens redimensionadas para mobile (nao carrega desktop-size)
+[ ] WhatsApp link funciona (abre o app diretamente)
+[ ] Telefone clicavel (tel: link)
+[ ] Scroll suave (sem travamentos)
+```
+
+### Erros de UX mais comuns em LPs de PMEs
+
+1. **Formulario longo** — Nome, email, telefone, cidade, como conheceu, mensagem. Solucao: nome + telefone (ou so WhatsApp)
+2. **CTA generico** — "Enviar" em vez de "Agendar minha consulta gratis"
+3. **Multiplos CTAs conflitantes** — "Agendar" + "Ver precos" + "Baixar e-book" + "Seguir no Instagram". Solucao: 1 CTA principal
+4. **Informacao demais** — Pagina com 10 secoes e 5000 palavras. Solucao: cortar pela metade
+5. **Pop-up agressivo** — Abre antes do visitante ler qualquer coisa. Solucao: exit intent ou scroll-trigger
+6. **Sem WhatsApp** — PME brasileira sem WhatsApp e como loja sem porta. Obrigatorio.
+7. **Fundo escuro com texto claro** — Cansa a leitura em scroll longo. Solucao: fundo claro, texto escuro
+8. **Auto-play de audio/video** — Irrita e faz fechar. Solucao: mudo ou click-to-play
+
+---
+
+## Priorizacao de melhorias (ICE Framework)
+
+Para priorizar hipoteses de teste, use o framework ICE:
+
+| Criterio | Descricao | Score 1-5 |
+|----------|-----------|-----------|
+| **Impact** | Quanto impacto na conversao se funcionar? | 1 (minimo) - 5 (enorme) |
+| **Confidence** | Quao confiante estou que vai funcionar? | 1 (chute) - 5 (certeza) |
+| **Ease** | Quao facil e implementar? | 1 (dificil) - 5 (trivial) |
+
+**Score ICE = (I + C + E) / 3**
+
+**Priorizacao:**
+- ICE >= 4.0 → P1 (fazer primeiro)
+- ICE 3.0-3.9 → P2 (fazer depois)
+- ICE < 3.0 → P3 (backlog)
+
+### Melhorias de alto impacto (quase sempre P1)
+
+1. **Reescrever headline do hero** (I:5, C:4, E:5 = 4.7)
+2. **Mudar texto do CTA** (I:4, C:4, E:5 = 4.3)
+3. **Adicionar prova social no hero** (I:4, C:4, E:4 = 4.0)
+4. **Reduzir campos do formulario** (I:4, C:5, E:5 = 4.7)
+5. **Adicionar WhatsApp flutuante** (I:4, C:4, E:5 = 4.3)
+
+### Melhorias de medio impacto (geralmente P2)
+
+1. **Otimizar PageSpeed** (I:3, C:4, E:3 = 3.3)
+2. **Adicionar secao FAQ** (I:3, C:3, E:4 = 3.3)
+3. **Melhorar depoimentos** (I:3, C:3, E:3 = 3.0)
+4. **Adicionar secao "como funciona"** (I:3, C:3, E:3 = 3.0)
+5. **Exit intent popup** (I:3, C:3, E:4 = 3.3)
+
+---
+
+## Benchmarks de conversao por tipo de LP
+
+| Tipo de LP | Conversao mediana | Boa | Excelente |
+|---|---|---|---|
+| Lead gen B2B (formulario) | 3-5% | 5-10% | 10-15% |
+| Lead gen B2C (formulario) | 5-10% | 10-20% | 20%+ |
+| Lead gen (WhatsApp CTA) | 8-15% | 15-25% | 25%+ |
+| E-commerce (produto) | 1-2% | 2-4% | 4%+ |
+| Agendamento online | 5-10% | 10-20% | 20%+ |
+| Download de material | 15-25% | 25-40% | 40%+ |
+
+**NOTA:** CTA de WhatsApp geralmente converte 2-3x mais que formulario para PMEs brasileiras. O atrito e muito menor (1 clique vs preencher campos).

--- a/.claude/skills/gt-diagnostico-cro/schema.json
+++ b/.claude/skills/gt-diagnostico-cro/schema.json
@@ -1,0 +1,1086 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DiagnosticoCRO",
+  "description": "Output estruturado do diagnostico de CRO: analise tecnica, auditoria de copy, hipoteses de teste e wireframe de melhorias.",
+  "type": "object",
+  "required": [
+    "summary",
+    "client_name",
+    "segment",
+    "url",
+    "technical_audit",
+    "onpage_seo",
+    "security_headers",
+    "technical_diagnosis",
+    "tracking_stack",
+    "events_fired",
+    "quality_flags",
+    "cro_elements_deep",
+    "compliance_lgpd",
+    "copy_audit",
+    "trust_analysis",
+    "test_hypotheses",
+    "wireframe_improvements",
+    "summary_headline",
+    "summary_highlights",
+    "summary_key_findings"
+  ],
+  "properties": {
+    "client_name": {
+      "type": "string",
+      "description": "Nome do cliente"
+    },
+    "summary": {
+      "type": "string",
+      "description": "Resumo de 1-2 frases do diagnóstico de CRO. Inclui principal gap de conversão e ação prioritária."
+    },
+    "summary_headline": {
+      "type": "string",
+      "description": "Manchete em 1 linha (~120 caracteres) com o veredito da skill."
+    },
+    "summary_highlights": {
+      "type": "array",
+      "description": "KPIs em destaque (4-6 itens). Categorias: posicao | competicao | janela | maturidade | oportunidade | risco.",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "label",
+          "value",
+          "tone"
+        ],
+        "properties": {
+          "category": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "subtext": {
+            "type": "string"
+          },
+          "tone": {
+            "type": "string",
+            "enum": [
+              "green",
+              "yellow",
+              "red",
+              "blue",
+              "gray"
+            ]
+          }
+        }
+      }
+    },
+    "summary_key_findings": {
+      "type": "array",
+      "description": "3-5 achados categorizados (vantagem | contexto | ameaca | acao).",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "text"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "vantagem",
+              "contexto",
+              "ameaca",
+              "acao"
+            ]
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "segment": {
+      "type": "string",
+      "description": "Segmento de atuacao"
+    },
+    "url": {
+      "type": "string",
+      "description": "URL do site/landing page analisada"
+    },
+    "current_conversion_rate": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "description": "Taxa de conversao atual em percentual (se disponivel)"
+    },
+    "current_bounce_rate": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "description": "Taxa de rejeicao atual em percentual (se disponivel)"
+    },
+    "avg_time_on_page": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Tempo medio na pagina (se disponivel)"
+    },
+    "technical_audit": {
+      "type": "object",
+      "description": "Dados brutos do audit tecnico automatizado (PageSpeed Insights + on-page). Preenchido a partir de client.json.page_audit.",
+      "required": [
+        "fetched_at",
+        "pagespeed"
+      ],
+      "properties": {
+        "fetched_at": {
+          "type": "string",
+          "description": "ISO timestamp do audit"
+        },
+        "cache_file": {
+          "type": "string",
+          "description": "Caminho relativo do cache raw"
+        },
+        "pagespeed": {
+          "type": "object",
+          "properties": {
+            "mobile_scores": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "performance": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "accessibility": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "best_practices": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "seo": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                }
+              }
+            },
+            "desktop_scores": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "performance": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "accessibility": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "best_practices": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "seo": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                }
+              }
+            },
+            "mobile_cwv_lab": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "description": "Core Web Vitals lab data (Lighthouse)",
+              "properties": {
+                "lcp_ms": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "fcp_ms": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "tbt_ms": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "cls": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "speed_index_ms": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "tti_ms": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "ttfb_ms": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                }
+              }
+            },
+            "desktop_cwv_lab": {
+              "type": [
+                "object",
+                "null"
+              ]
+            },
+            "mobile_cwv_field": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "description": "CrUX field data (usuarios reais), null se sem dados suficientes"
+            },
+            "desktop_cwv_field": {
+              "type": [
+                "object",
+                "null"
+              ]
+            },
+            "mobile_top_opportunities": {
+              "type": "array",
+              "description": "Top opportunities do Lighthouse mobile ordenadas por savings_ms"
+            },
+            "desktop_top_opportunities": {
+              "type": "array"
+            }
+          }
+        }
+      }
+    },
+    "onpage_seo": {
+      "type": "object",
+      "description": "Analise on-page SEO (mobile/desktop via parser HTML). Preenchido a partir de client.json.page_audit.onpage.",
+      "properties": {
+        "mobile": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "title": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "title_length": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "meta_description": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "meta_description_length": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "canonical": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "lang": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "viewport": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "favicon": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "og": {
+              "type": "object",
+              "description": "Open Graph tags"
+            },
+            "twitter": {
+              "type": "object",
+              "description": "Twitter card tags"
+            },
+            "schema_types": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "h1_count": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "h2_count": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "h3_count": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "images_total": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "images_without_alt": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "links_internal": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "links_external": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "links_nofollow": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "html_size_kb": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "response_time_ms": {
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          }
+        },
+        "desktop": {
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "divergences": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Diferencas significativas entre versao mobile e desktop (title, h1, canonical, etc.)"
+        }
+      }
+    },
+    "security_headers": {
+      "type": "object",
+      "description": "Analise de headers HTTP de seguranca. Preenchido a partir de client.json.page_audit.security.",
+      "properties": {
+        "https": {
+          "type": "boolean"
+        },
+        "hsts": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Valor do Strict-Transport-Security ou null se ausente"
+        },
+        "csp": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "x_frame_options": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "x_content_type_options": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "referrer_policy": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "permissions_policy": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "score": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 10
+        },
+        "issues": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "technical_diagnosis": {
+      "type": "object",
+      "required": [
+        "pagespeed_mobile",
+        "pagespeed_desktop"
+      ],
+      "properties": {
+        "pagespeed_mobile": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 100,
+          "description": "Score PageSpeed Insights mobile (0-100)"
+        },
+        "pagespeed_desktop": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 100,
+          "description": "Score PageSpeed Insights desktop (0-100)"
+        },
+        "lcp": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Largest Contentful Paint em segundos"
+        },
+        "cls": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Cumulative Layout Shift"
+        },
+        "inp": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Interaction to Next Paint em milissegundos"
+        },
+        "critical_issues": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Problemas criticos de velocidade identificados"
+        },
+        "estimated_conversion_loss": {
+          "type": "string",
+          "description": "Estimativa de perda de conversao por problemas tecnicos"
+        },
+        "tested": {
+          "type": "boolean",
+          "description": "Se o PageSpeed foi efetivamente testado"
+        }
+      }
+    },
+    "copy_audit": {
+      "type": "object",
+      "required": [
+        "above_fold",
+        "sections"
+      ],
+      "properties": {
+        "above_fold": {
+          "type": "object",
+          "required": [
+            "value_prop_clear",
+            "headline_complete",
+            "cta_visible",
+            "visitor_impression"
+          ],
+          "properties": {
+            "value_prop_clear": {
+              "type": "boolean",
+              "description": "Proposta de valor clara em menos de 5 segundos"
+            },
+            "value_prop_detail": {
+              "type": "string",
+              "description": "Justificativa da avaliacao da proposta de valor"
+            },
+            "headline_complete": {
+              "type": "boolean",
+              "description": "Headline responde o que + para quem + qual beneficio"
+            },
+            "current_headline": {
+              "type": "string",
+              "description": "Headline atual da pagina"
+            },
+            "suggested_headline": {
+              "type": "string",
+              "description": "Headline sugerida baseada na PUV"
+            },
+            "cta_visible": {
+              "type": "boolean",
+              "description": "CTA visivel sem rolar"
+            },
+            "current_cta": {
+              "type": "string",
+              "description": "Texto do CTA atual"
+            },
+            "suggested_cta": {
+              "type": "string",
+              "description": "Texto de CTA sugerido"
+            },
+            "visitor_impression": {
+              "type": "string",
+              "description": "O que um visitante do ICP provavelmente pensa ao chegar"
+            }
+          }
+        },
+        "sections": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "name",
+              "exists",
+              "evaluation",
+              "main_problem"
+            ],
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Nome da secao (Hero, Problema/Dor, Solucao, etc.)"
+              },
+              "exists": {
+                "type": "boolean",
+                "description": "Se a secao existe na pagina"
+              },
+              "evaluation": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 5,
+                "description": "Avaliacao da secao (1-5)"
+              },
+              "main_problem": {
+                "type": "string",
+                "description": "Problema principal da secao"
+              }
+            }
+          },
+          "description": "Avaliacao de cada secao da pagina"
+        },
+        "missing_sections": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Secoes criticas que deveriam existir e nao existem"
+        },
+        "unnecessary_sections": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Secoes que existem mas nao ajudam ou atrapalham"
+        }
+      }
+    },
+    "trust_analysis": {
+      "type": "object",
+      "required": [
+        "trust_signals",
+        "ssl_active",
+        "professional_appearance"
+      ],
+      "properties": {
+        "trust_signals": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "signal",
+              "present"
+            ],
+            "properties": {
+              "signal": {
+                "type": "string",
+                "description": "Tipo de sinal de confianca"
+              },
+              "present": {
+                "type": "boolean",
+                "description": "Se esta presente na pagina"
+              }
+            }
+          },
+          "description": "Sinais de confianca e se estao presentes"
+        },
+        "ssl_active": {
+          "type": "boolean",
+          "description": "Se o SSL (HTTPS) esta ativo"
+        },
+        "professional_appearance": {
+          "type": "boolean",
+          "description": "Se a pagina tem aparencia profissional para o ICP"
+        },
+        "professional_appearance_detail": {
+          "type": "string",
+          "description": "Justificativa da avaliacao de aparencia"
+        },
+        "trust_score": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 10,
+          "description": "Score de confianca geral (1-10)"
+        },
+        "biggest_trust_gap": {
+          "type": "string",
+          "description": "Maior gap de confianca identificado"
+        }
+      }
+    },
+    "test_hypotheses": {
+      "type": "array",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "hypothesis",
+          "element",
+          "expected_impact",
+          "difficulty",
+          "priority"
+        ],
+        "properties": {
+          "hypothesis": {
+            "type": "string",
+            "description": "Descricao da hipotese de teste"
+          },
+          "element": {
+            "type": "string",
+            "description": "Elemento a testar (headline, CTA, hero, secao, etc.)"
+          },
+          "current_version": {
+            "type": "string",
+            "description": "Como esta hoje"
+          },
+          "proposed_version": {
+            "type": "string",
+            "description": "Como deveria ficar"
+          },
+          "expected_impact": {
+            "type": "string",
+            "enum": [
+              "high",
+              "medium",
+              "low"
+            ],
+            "description": "Impacto esperado na conversao"
+          },
+          "difficulty": {
+            "type": "string",
+            "enum": [
+              "easy",
+              "medium",
+              "hard"
+            ],
+            "description": "Dificuldade de implementacao"
+          },
+          "priority": {
+            "type": "string",
+            "enum": [
+              "P1",
+              "P2",
+              "P3"
+            ],
+            "description": "Prioridade (P1 = alto impacto + facil)"
+          },
+          "success_metric": {
+            "type": "string",
+            "description": "Como medir se a hipotese funcionou"
+          },
+          "estimated_improvement": {
+            "type": "string",
+            "description": "Melhoria percentual estimada"
+          }
+        }
+      },
+      "description": "Hipoteses de teste priorizadas por impacto"
+    },
+    "wireframe_improvements": {
+      "type": "array",
+      "minItems": 5,
+      "items": {
+        "type": "object",
+        "required": [
+          "section_number",
+          "name",
+          "content_description"
+        ],
+        "properties": {
+          "section_number": {
+            "type": "integer",
+            "description": "Numero da secao na ordem da pagina"
+          },
+          "name": {
+            "type": "string",
+            "description": "Nome da secao (ex: Hero, Problema/Dor, Solucao)"
+          },
+          "content_description": {
+            "type": "string",
+            "description": "O que a secao deve conter"
+          },
+          "suggested_copy": {
+            "type": "string",
+            "description": "Rascunho de copy sugerida para a secao"
+          },
+          "format": {
+            "type": "string",
+            "description": "Formato recomendado (lista, cards, timeline, etc.)"
+          },
+          "visual_element": {
+            "type": "string",
+            "description": "Elemento visual recomendado (foto, video, icone, etc.)"
+          }
+        }
+      },
+      "description": "Wireframe da LP melhorada, secao a secao"
+    },
+    "transversal_elements": {
+      "type": "object",
+      "description": "Elementos que aparecem em toda a pagina",
+      "properties": {
+        "trust_bar": {
+          "type": "boolean",
+          "description": "Se deve ter barra de confianca (selos, CNPJ)"
+        },
+        "whatsapp_floating": {
+          "type": "boolean",
+          "description": "Se deve ter botao de WhatsApp flutuante"
+        },
+        "exit_intent_popup": {
+          "type": "boolean",
+          "description": "Se deve ter popup de exit intent"
+        },
+        "exit_intent_offer": {
+          "type": "string",
+          "description": "Oferta do popup de exit intent (se aplicavel)"
+        }
+      }
+    },
+    "tracking_stack": {
+      "type": "object",
+      "description": "Ferramentas de tracking/ads/analytics detectadas via Playwright. Preenchido a partir de client.json.page_audit_deep.tracking_stack.",
+      "properties": {
+        "tools_detected": {
+          "type": "object",
+          "description": "Dicionario {tool_id: {name, category, evidence[]}} das ferramentas identificadas",
+          "additionalProperties": true
+        },
+        "ids_found": {
+          "type": "object",
+          "description": "IDs extraidos: gtm, ga4, ua, google_ads, meta_pixel, tiktok_pixel, linkedin_partner",
+          "properties": {
+            "gtm": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "ga4": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "ua": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "google_ads": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "meta_pixel": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "tiktok_pixel": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "linkedin_partner": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "categories_summary": {
+          "type": "object",
+          "description": "Agrupamento por categoria: tracking, analytics, ads, heatmap, chat, cms, ecommerce, framework, lp_builder, cmp, hosting"
+        },
+        "total_tools": {
+          "type": "integer"
+        },
+        "setup_diagnosis": {
+          "type": "string",
+          "description": "Diagnostico narrativo do setup: coberturas, gaps, contradicoes. Ex: 'GTM presente mas sem GA4 — cliente opera cego.'"
+        }
+      }
+    },
+    "events_fired": {
+      "type": "object",
+      "description": "Eventos GA4 e Meta Pixel disparados durante navegacao.",
+      "properties": {
+        "ga4_event_count": {
+          "type": "integer"
+        },
+        "meta_event_count": {
+          "type": "integer"
+        },
+        "ga4_event_names": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "meta_event_names": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "events_diagnosis": {
+          "type": "string",
+          "description": "Avaliacao dos eventos: completude (page_view, scroll, click, form_submit), duplicatas, Consent Mode v2"
+        },
+        "expected_events_missing": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Eventos que DEVERIAM existir mas nao aparecem (ex: 'page_view', 'PageView', 'generate_lead')"
+        }
+      }
+    },
+    "quality_flags": {
+      "type": "array",
+      "description": "Red flags de qualidade do tagueamento (UA legacy, pixel duplicado, GTM sem analytics, etc.)",
+      "items": {
+        "type": "object",
+        "required": [
+          "severity",
+          "flag",
+          "title",
+          "detail"
+        ],
+        "properties": {
+          "severity": {
+            "type": "string",
+            "enum": [
+              "critical",
+              "high",
+              "medium",
+              "low"
+            ]
+          },
+          "flag": {
+            "type": "string",
+            "description": "Identificador curto do flag"
+          },
+          "title": {
+            "type": "string"
+          },
+          "detail": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "cro_elements_deep": {
+      "type": "object",
+      "description": "Analise profunda de elementos CRO via Playwright (CTAs, forms, WhatsApp, prova social, confianca, urgencia).",
+      "properties": {
+        "desktop": {
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "mobile": {
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "cta_diagnosis": {
+          "type": "string",
+          "description": "Avaliacao: quantidade de CTAs, above-fold, clareza, consistencia de texto"
+        },
+        "form_diagnosis": {
+          "type": "string",
+          "description": "Avaliacao: quantidade de forms, campos por form (regra: <= 5), campos obrigatorios, consentimento LGPD"
+        },
+        "social_proof_diagnosis": {
+          "type": "string",
+          "description": "Avaliacao de prova social (depoimentos, avaliacoes, numeros, certificacoes, logos)"
+        },
+        "trust_diagnosis": {
+          "type": "string",
+          "description": "Avaliacao: CNPJ, endereco, telefone, email, politica de privacidade, termos"
+        }
+      }
+    },
+    "compliance_lgpd": {
+      "type": "object",
+      "description": "Auditoria de compliance LGPD: CMP presente + scripts pre-consent.",
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": [
+            "compliant",
+            "partial",
+            "non_compliant"
+          ]
+        },
+        "score": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 10
+        },
+        "has_cmp": {
+          "type": "boolean"
+        },
+        "cmps_detected": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "pre_consent_trackers": {
+          "type": "object",
+          "description": "Trackers que disparam ANTES de qualquer consentimento {pattern: [urls]}"
+        },
+        "pre_consent_tracker_count": {
+          "type": "integer"
+        },
+        "issues": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "recommendation": {
+          "type": "string",
+          "description": "Recomendacao concreta: 'Instalar Cookiebot/OneTrust + gtag consent default denied + Consent Mode v2'"
+        }
+      }
+    },
+    "target_conversion_rate": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "description": "Meta de taxa de conversao apos melhorias"
+    },
+    "completed_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Data/hora de conclusao"
+    }
+  }
+}

--- a/.claude/skills/gt-diagnostico-cro/scripts/page_audit.py
+++ b/.claude/skills/gt-diagnostico-cro/scripts/page_audit.py
@@ -1,0 +1,414 @@
+#!/usr/bin/env python3
+"""
+page_audit.py — Auditoria tecnica de URL
+Camadas: PageSpeed Insights (mobile+desktop) + On-page parser (mobile+desktop UA) + Security headers.
+
+Uso:
+  page_audit.py <url> <output_json> [--api-key KEY] [--skip-psi]
+
+Saida: JSON estruturado com pagespeed, onpage, security.
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import json
+import os
+import re
+import sys
+import time
+import urllib.parse
+from typing import Any
+
+import requests
+from bs4 import BeautifulSoup
+
+PSI_ENDPOINT = "https://www.googleapis.com/pagespeedonline/v5/runPagespeed"
+UA_MOBILE = "Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36"
+UA_DESKTOP = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+
+OPPORTUNITY_AUDIT_IDS = [
+    "render-blocking-resources",
+    "unused-css-rules",
+    "unused-javascript",
+    "modern-image-formats",
+    "uses-optimized-images",
+    "uses-text-compression",
+    "uses-responsive-images",
+    "efficient-animated-content",
+    "duplicated-javascript",
+    "server-response-time",
+    "redirects",
+    "uses-long-cache-ttl",
+    "total-byte-weight",
+]
+
+
+def fetch_pagespeed(url: str, strategy: str, api_key: str | None, retries: int = 2) -> dict[str, Any]:
+    params = [
+        ("url", url),
+        ("strategy", strategy),
+        ("category", "performance"),
+        ("category", "accessibility"),
+        ("category", "best-practices"),
+        ("category", "seo"),
+        ("locale", "pt-BR"),
+    ]
+    if api_key:
+        params.append(("key", api_key))
+    qs = urllib.parse.urlencode(params)
+    full_url = f"{PSI_ENDPOINT}?{qs}"
+
+    last_err = None
+    for attempt in range(retries + 1):
+        try:
+            r = requests.get(full_url, timeout=90)
+            if r.status_code == 200:
+                return parse_psi_response(r.json(), strategy)
+            if r.status_code == 429 and attempt < retries:
+                time.sleep(2 ** (attempt + 1))
+                continue
+            if r.status_code >= 500 and attempt < retries:
+                time.sleep(2)
+                continue
+            return {
+                "error": f"HTTP {r.status_code}",
+                "detail": r.text[:500],
+                "strategy": strategy,
+            }
+        except requests.RequestException as e:
+            last_err = str(e)
+            if attempt < retries:
+                time.sleep(2)
+                continue
+    return {"error": "request_failed", "detail": last_err, "strategy": strategy}
+
+
+def parse_psi_response(data: dict, strategy: str) -> dict[str, Any]:
+    lh = data.get("lighthouseResult", {}) or {}
+    cats = lh.get("categories", {}) or {}
+    audits = lh.get("audits", {}) or {}
+    le = data.get("loadingExperience", {}) or {}
+
+    def score(cat: str) -> int | None:
+        v = (cats.get(cat) or {}).get("score")
+        return round(v * 100) if isinstance(v, (int, float)) else None
+
+    def audit_val(name: str, num: bool = True) -> Any:
+        a = audits.get(name) or {}
+        return a.get("numericValue") if num else a.get("displayValue")
+
+    scores = {
+        "performance": score("performance"),
+        "accessibility": score("accessibility"),
+        "best_practices": score("best-practices"),
+        "seo": score("seo"),
+    }
+
+    cwv_lab = {
+        "lcp_ms": audit_val("largest-contentful-paint"),
+        "fcp_ms": audit_val("first-contentful-paint"),
+        "tbt_ms": audit_val("total-blocking-time"),
+        "cls": audit_val("cumulative-layout-shift"),
+        "speed_index_ms": audit_val("speed-index"),
+        "tti_ms": audit_val("interactive"),
+        "ttfb_ms": audit_val("server-response-time"),
+    }
+
+    def field_metric(key: str) -> dict | None:
+        m = (le.get("metrics") or {}).get(key)
+        if not m:
+            return None
+        return {"percentile": m.get("percentile"), "category": m.get("category")}
+
+    cwv_field = {
+        "lcp": field_metric("LARGEST_CONTENTFUL_PAINT_MS"),
+        "inp": field_metric("INTERACTION_TO_NEXT_PAINT"),
+        "cls": field_metric("CUMULATIVE_LAYOUT_SHIFT_SCORE"),
+        "fcp": field_metric("FIRST_CONTENTFUL_PAINT_MS"),
+    }
+    crux_overall = le.get("overall_category")
+
+    opportunities = []
+    for audit_id in OPPORTUNITY_AUDIT_IDS:
+        a = audits.get(audit_id) or {}
+        s = a.get("score")
+        if s is None or (isinstance(s, (int, float)) and s >= 0.9):
+            continue
+        details = a.get("details") or {}
+        savings_ms = details.get("overallSavingsMs") or a.get("numericValue") or 0
+        savings_bytes = details.get("overallSavingsBytes")
+        opportunities.append(
+            {
+                "id": audit_id,
+                "title": a.get("title"),
+                "description": a.get("description"),
+                "savings_ms": round(savings_ms) if savings_ms else 0,
+                "savings_bytes": savings_bytes,
+                "display_value": a.get("displayValue"),
+            }
+        )
+    opportunities.sort(key=lambda x: x.get("savings_ms") or 0, reverse=True)
+
+    # Screenshot final (data URI base64). "final-screenshot" e o viewport do final do load.
+    final_ss = audits.get("final-screenshot") or {}
+    ss_data = (final_ss.get("details") or {}).get("data")
+    # Tamanho do viewport retornado para referencia (mobile=360x, desktop=412x)
+    ss_timing = (final_ss.get("details") or {}).get("timing")
+
+    return {
+        "strategy": strategy,
+        "scores": scores,
+        "cwv_lab": cwv_lab,
+        "cwv_field": cwv_field,
+        "crux_overall_category": crux_overall,
+        "opportunities": opportunities,
+        "final_screenshot": ss_data,
+        "final_screenshot_timing_ms": ss_timing,
+        "fetch_time": lh.get("fetchTime"),
+    }
+
+
+def fetch_onpage(url: str, user_agent: str, label: str) -> dict[str, Any]:
+    t0 = time.time()
+    try:
+        r = requests.get(
+            url,
+            headers={"User-Agent": user_agent, "Accept": "text/html,application/xhtml+xml"},
+            timeout=30,
+            allow_redirects=True,
+        )
+        elapsed_ms = round((time.time() - t0) * 1000)
+    except requests.RequestException as e:
+        return {"label": label, "error": str(e)}
+
+    html = r.text or ""
+    try:
+        soup = BeautifulSoup(html, "lxml")
+    except Exception:
+        soup = BeautifulSoup(html, "html.parser")
+
+    def meta(attr: str, name: str) -> str | None:
+        tag = soup.find("meta", attrs={attr: name})
+        return tag.get("content") if tag and tag.has_attr("content") else None
+
+    title_tag = soup.find("title")
+    title = title_tag.get_text(strip=True) if title_tag else None
+
+    canonical_tag = soup.find("link", rel="canonical")
+    canonical = canonical_tag.get("href") if canonical_tag else None
+
+    lang = (soup.html.get("lang") if soup.html and soup.html.has_attr("lang") else None)
+
+    og = {}
+    twitter = {}
+    for m in soup.find_all("meta"):
+        prop = m.get("property") or ""
+        name = m.get("name") or ""
+        content = m.get("content")
+        if prop.startswith("og:"):
+            og[prop[3:]] = content
+        elif name.startswith("twitter:"):
+            twitter[name[8:]] = content
+
+    schema_types = []
+    for s in soup.find_all("script", attrs={"type": "application/ld+json"}):
+        try:
+            raw = s.string or s.get_text() or ""
+            data = json.loads(raw)
+            items = data if isinstance(data, list) else [data]
+            for it in items:
+                if isinstance(it, dict):
+                    t = it.get("@type")
+                    if isinstance(t, list):
+                        schema_types.extend(t)
+                    elif t:
+                        schema_types.append(t)
+        except Exception:
+            continue
+    schema_types = sorted(set(str(t) for t in schema_types))
+
+    h1s = [h.get_text(strip=True) for h in soup.find_all("h1")]
+    h2_count = len(soup.find_all("h2"))
+    h3_count = len(soup.find_all("h3"))
+    h4_count = len(soup.find_all("h4"))
+
+    imgs = soup.find_all("img")
+    images_total = len(imgs)
+    images_without_alt = sum(1 for i in imgs if not (i.get("alt") or "").strip())
+
+    links = soup.find_all("a", href=True)
+    parsed_url = urllib.parse.urlparse(url)
+    host = parsed_url.netloc
+    internal = external = nofollow = 0
+    for a in links:
+        href = a["href"]
+        rel = " ".join(a.get("rel") or [])
+        if "nofollow" in rel:
+            nofollow += 1
+        if href.startswith("/") or host in href:
+            internal += 1
+        elif href.startswith("http://") or href.startswith("https://"):
+            external += 1
+
+    viewport = soup.find("meta", attrs={"name": "viewport"}) is not None
+    favicon = bool(
+        soup.find("link", rel=re.compile(r"(^|\s)(shortcut\s+)?icon(\s|$)", re.I))
+        or soup.find("link", rel="apple-touch-icon")
+    )
+
+    headers = {k: v for k, v in r.headers.items()}
+
+    return {
+        "label": label,
+        "status_code": r.status_code,
+        "final_url": r.url,
+        "response_time_ms": elapsed_ms,
+        "html_size_kb": round(len(html.encode("utf-8")) / 1024, 1),
+        "title": title,
+        "title_length": len(title) if title else 0,
+        "meta_description": meta("name", "description"),
+        "meta_description_length": len(meta("name", "description") or ""),
+        "robots": meta("name", "robots"),
+        "canonical": canonical,
+        "lang": lang,
+        "viewport": viewport,
+        "favicon": favicon,
+        "h1": h1s,
+        "h1_count": len(h1s),
+        "h2_count": h2_count,
+        "h3_count": h3_count,
+        "h4_count": h4_count,
+        "images_total": images_total,
+        "images_without_alt": images_without_alt,
+        "links_total": len(links),
+        "links_internal": internal,
+        "links_external": external,
+        "links_nofollow": nofollow,
+        "schema_types": schema_types,
+        "og": og,
+        "twitter_card": twitter,
+        "headers": headers,
+    }
+
+
+def compute_security(onpage_desktop: dict, onpage_mobile: dict, url: str) -> dict[str, Any]:
+    headers = (onpage_desktop.get("headers") or onpage_mobile.get("headers") or {})
+    h_lower = {k.lower(): v for k, v in headers.items()}
+
+    def hget(key: str) -> str | None:
+        return h_lower.get(key)
+
+    is_https = url.startswith("https://")
+    if not is_https:
+        final = onpage_desktop.get("final_url") or onpage_mobile.get("final_url") or ""
+        is_https = final.startswith("https://")
+
+    return {
+        "https": is_https,
+        "hsts": hget("strict-transport-security"),
+        "csp": hget("content-security-policy"),
+        "x_frame_options": hget("x-frame-options"),
+        "x_content_type_options": hget("x-content-type-options"),
+        "referrer_policy": hget("referrer-policy"),
+        "content_type": hget("content-type"),
+        "content_encoding": hget("content-encoding"),
+        "cache_control": hget("cache-control"),
+        "server": hget("server"),
+    }
+
+
+def compute_divergences(mob: dict, desk: dict) -> list[str]:
+    if mob.get("error") or desk.get("error"):
+        return []
+    diffs = []
+    fields = [("title", "Title"), ("meta_description", "Meta description"), ("canonical", "Canonical"), ("lang", "Lang"), ("h1_count", "H1 count")]
+    for key, label in fields:
+        a, b = mob.get(key), desk.get(key)
+        if a != b:
+            diffs.append(f"{label} divergente — mobile: {a!r} · desktop: {b!r}")
+    if mob.get("final_url") != desk.get("final_url"):
+        diffs.append(f"URL final divergente — mobile: {mob.get('final_url')} · desktop: {desk.get('final_url')}")
+    return diffs
+
+
+def run_audit(url: str, api_key: str | None, skip_psi: bool) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "url": url,
+        "fetched_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+
+    tasks: dict[str, concurrent.futures.Future] = {}
+    with concurrent.futures.ThreadPoolExecutor(max_workers=5) as ex:
+        if not skip_psi and api_key:
+            tasks["psi_mobile"] = ex.submit(fetch_pagespeed, url, "mobile", api_key)
+            tasks["psi_desktop"] = ex.submit(fetch_pagespeed, url, "desktop", api_key)
+        tasks["onpage_mobile"] = ex.submit(fetch_onpage, url, UA_MOBILE, "mobile")
+        tasks["onpage_desktop"] = ex.submit(fetch_onpage, url, UA_DESKTOP, "desktop")
+
+        for name, fut in tasks.items():
+            try:
+                result[name] = fut.result(timeout=120)
+            except Exception as e:
+                result[name] = {"error": str(e)}
+
+    if skip_psi or not api_key:
+        result["pagespeed_skipped"] = True
+        result["pagespeed_reason"] = "no_api_key" if not api_key else "skipped_by_flag"
+
+    onpage = {
+        "mobile": result.get("onpage_mobile"),
+        "desktop": result.get("onpage_desktop"),
+        "divergences": compute_divergences(result.get("onpage_mobile") or {}, result.get("onpage_desktop") or {}),
+    }
+    result["onpage"] = onpage
+    for k in ("onpage_mobile", "onpage_desktop"):
+        result.pop(k, None)
+
+    result["security"] = compute_security(onpage.get("desktop") or {}, onpage.get("mobile") or {}, url)
+
+    result["pagespeed"] = {
+        "mobile": result.pop("psi_mobile", None) if "psi_mobile" in result else None,
+        "desktop": result.pop("psi_desktop", None) if "psi_desktop" in result else None,
+    }
+    if result["pagespeed"]["mobile"] is None and result["pagespeed"]["desktop"] is None:
+        result["pagespeed"] = None
+
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("url")
+    parser.add_argument("output")
+    parser.add_argument("--api-key", default=os.environ.get("PSI_API_KEY"))
+    parser.add_argument("--skip-psi", action="store_true")
+    args = parser.parse_args()
+
+    if not args.url.startswith(("http://", "https://")):
+        print("ERROR: url precisa comecar com http:// ou https://", file=sys.stderr)
+        return 2
+
+    result = run_audit(args.url, args.api_key, args.skip_psi)
+
+    with open(args.output, "w", encoding="utf-8") as f:
+        json.dump(result, f, ensure_ascii=False, indent=2)
+
+    psi_m = (result.get("pagespeed") or {}).get("mobile") or {}
+    psi_d = (result.get("pagespeed") or {}).get("desktop") or {}
+    print(f"[OK] {args.url} -> {args.output}")
+    if isinstance(psi_m.get("scores"), dict):
+        print(f"  PSI mobile  perf={psi_m['scores'].get('performance')} a11y={psi_m['scores'].get('accessibility')} bp={psi_m['scores'].get('best_practices')} seo={psi_m['scores'].get('seo')}")
+    if isinstance(psi_d.get("scores"), dict):
+        print(f"  PSI desktop perf={psi_d['scores'].get('performance')} a11y={psi_d['scores'].get('accessibility')} bp={psi_d['scores'].get('best_practices')} seo={psi_d['scores'].get('seo')}")
+    op = result.get("onpage") or {}
+    mob = op.get("mobile") or {}
+    print(f"  On-page     title='{(mob.get('title') or '')[:60]}' h1={mob.get('h1_count')} images_no_alt={mob.get('images_without_alt')}/{mob.get('images_total')}")
+    sec = result.get("security") or {}
+    print(f"  Security    https={sec.get('https')} hsts={'sim' if sec.get('hsts') else 'nao'} csp={'sim' if sec.get('csp') else 'nao'}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/gt-diagnostico-cro/scripts/page_audit.sh
+++ b/.claude/skills/gt-diagnostico-cro/scripts/page_audit.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# page_audit.sh — Orquestra a auditoria tecnica de uma URL
+# Uso:  page_audit.sh <client_dir> <url>
+# Ex:   page_audit.sh squads/{squad}/clientes/{cliente} https://www.site-do-cliente.com.br
+#
+# Le:    .credentials/google.json (pagespeed_api_key)
+#        <client_dir>/client.json
+# Grava: <client_dir>/cache/page_audit-<timestamp>.json (raw)
+#        <client_dir>/client.json (campo page_audit com resumo)
+
+set -euo pipefail
+
+CLIENT_DIR="${1:?Uso: page_audit.sh <client_dir> <url>}"
+URL="${2:?Uso: page_audit.sh <client_dir> <url>}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PY_SCRIPT="$SCRIPT_DIR/page_audit.py"
+
+if [ ! -f "$PY_SCRIPT" ]; then
+  echo "ERROR: page_audit.py nao encontrado em $PY_SCRIPT" >&2
+  exit 1
+fi
+
+# Descobrir credenciais (sobe na arvore procurando .credentials/google.json)
+CRED_FILE=""
+SEARCH_DIR="$CLIENT_DIR"
+for i in 1 2 3 4 5; do
+  SEARCH_DIR="$(cd "$SEARCH_DIR/.." && pwd)"
+  if [ -f "$SEARCH_DIR/.credentials/google.json" ]; then
+    CRED_FILE="$SEARCH_DIR/.credentials/google.json"
+    break
+  fi
+done
+
+PSI_API_KEY=""
+if [ -n "$CRED_FILE" ]; then
+  PSI_API_KEY=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1])).get('pagespeed_api_key',''))" "$CRED_FILE" 2>/dev/null || true)
+fi
+
+# Cache dir
+mkdir -p "$CLIENT_DIR/cache"
+TS=$(date -u +%Y%m%d-%H%M%S)
+RAW_OUT="$CLIENT_DIR/cache/page_audit-$TS.json"
+
+# Rodar Python worker
+if [ -n "$PSI_API_KEY" ]; then
+  echo ">> Rodando auditoria (PSI mobile+desktop + on-page + security) em paralelo..."
+  PSI_API_KEY="$PSI_API_KEY" python3 "$PY_SCRIPT" "$URL" "$RAW_OUT"
+else
+  echo ">> Sem PSI_API_KEY — rodando apenas on-page + security (PageSpeed sera pulado)..."
+  python3 "$PY_SCRIPT" "$URL" "$RAW_OUT" --skip-psi
+fi
+
+# O Builders Hub não exige client.json. Quando ele não existe, preserve o
+# cache bruto e deixe a skill interpretar os dados junto com a KB do cliente.
+if [ ! -f "$CLIENT_DIR/client.json" ]; then
+  echo "[OK] Auditoria bruta concluída; client.json ausente, merge ignorado."
+  echo "Cache raw: $RAW_OUT"
+  exit 0
+fi
+
+# Merge resumo no client.json
+python3 << PYEOF
+import json, sys
+from datetime import datetime, timezone
+
+raw_path = "$RAW_OUT"
+client_path = "$CLIENT_DIR/client.json"
+
+with open(raw_path, encoding='utf-8') as f:
+    raw = json.load(f)
+
+with open(client_path, encoding='utf-8') as f:
+    client = json.load(f)
+
+# Resumo condensado para client.json (raw fica no cache)
+psi = raw.get("pagespeed") or {}
+mob = (psi.get("mobile") or {})
+des = (psi.get("desktop") or {})
+onp = raw.get("onpage") or {}
+sec = raw.get("security") or {}
+
+summary = {
+    "fetched_at": raw.get("fetched_at"),
+    "url": raw.get("url"),
+    "cache_file": raw_path.replace("$CLIENT_DIR/", ""),
+    "pagespeed": {
+        "mobile_scores": (mob or {}).get("scores") if isinstance(mob, dict) else None,
+        "desktop_scores": (des or {}).get("scores") if isinstance(des, dict) else None,
+        "mobile_cwv_lab": (mob or {}).get("cwv_lab") if isinstance(mob, dict) else None,
+        "desktop_cwv_lab": (des or {}).get("cwv_lab") if isinstance(des, dict) else None,
+        "mobile_cwv_field": (mob or {}).get("cwv_field") if isinstance(mob, dict) else None,
+        "desktop_cwv_field": (des or {}).get("cwv_field") if isinstance(des, dict) else None,
+        "mobile_top_opportunities": ((mob or {}).get("opportunities") or [])[:10] if isinstance(mob, dict) else [],
+        "desktop_top_opportunities": ((des or {}).get("opportunities") or [])[:10] if isinstance(des, dict) else [],
+        "mobile_error": (mob or {}).get("error") if isinstance(mob, dict) else None,
+        "desktop_error": (des or {}).get("error") if isinstance(des, dict) else None,
+        "skipped": raw.get("pagespeed_skipped", False),
+    },
+    "screenshots": {
+        "mobile": (mob or {}).get("final_screenshot") if isinstance(mob, dict) else None,
+        "desktop": (des or {}).get("final_screenshot") if isinstance(des, dict) else None,
+    },
+    "onpage": {
+        "mobile": onp.get("mobile"),
+        "desktop": onp.get("desktop"),
+        "divergences": onp.get("divergences") or [],
+    },
+    "security": sec,
+}
+
+# Remove 'headers' e payload pesado do summary (fica no raw)
+for k in ("mobile", "desktop"):
+    blk = summary["onpage"].get(k)
+    if isinstance(blk, dict):
+        blk.pop("headers", None)
+
+client["page_audit"] = summary
+
+with open(client_path, "w", encoding="utf-8") as f:
+    json.dump(client, f, ensure_ascii=False, indent=2)
+
+print(f"[OK] page_audit salvo em client.json (raw: {raw_path})")
+PYEOF
+
+echo "Cache raw: $RAW_OUT"

--- a/.claude/skills/gt-diagnostico-cro/scripts/page_audit_deep.py
+++ b/.claude/skills/gt-diagnostico-cro/scripts/page_audit_deep.py
@@ -1,0 +1,875 @@
+#!/usr/bin/env python3
+"""
+page_audit_deep.py — Auditoria profunda via Playwright headless.
+
+Captura:
+  - tracking_stack: quais ferramentas (GTM, GA4, Meta Pixel, Clarity, etc.) estao presentes
+  - events_fired: quais eventos GA4/Meta Pixel sao disparados no load + interacoes
+  - dataLayer: dump do window.dataLayer
+  - platform: CMS/plataforma (WordPress, Shopify, VTEX, Next.js...)
+  - cro_elements: analise profunda de CTAs, forms, WhatsApp, prova social, urgencia
+  - compliance_lgpd: deteccao de CMP + scripts pre-consent (2-pass)
+  - quality_flags: red flags de tagueamento (UA legacy, pixel duplicado, scripts parallel)
+
+Uso:
+  python3 page_audit_deep.py <url> <output_json>
+  python3 page_audit_deep.py <url> <output_json> --skip-compliance (pula 2-pass)
+
+Requisitos:
+  pip install -r requirements-deep.txt
+  python3 -m playwright install chromium
+"""
+import sys
+import os
+import re
+import json
+import time
+import asyncio
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.parse import urlparse, parse_qs
+import yaml
+
+try:
+    from playwright.async_api import async_playwright, Page, Request, Response, TimeoutError as PWTimeout
+except ImportError:
+    print("ERRO: Playwright nao instalado. Rode: pip3 install --user -r requirements-deep.txt && python3 -m playwright install chromium", file=sys.stderr)
+    sys.exit(1)
+
+try:
+    from bs4 import BeautifulSoup
+except ImportError:
+    BeautifulSoup = None
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+SIGNATURES_FILE = SCRIPT_DIR / "signatures" / "tools.yaml"
+
+USER_AGENT_MOBILE = "Mozilla/5.0 (Linux; Android 12; Pixel 6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36"
+USER_AGENT_DESKTOP = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+
+VIEWPORT_MOBILE = {"width": 390, "height": 844}
+VIEWPORT_DESKTOP = {"width": 1440, "height": 900}
+
+NAV_TIMEOUT_MS = 45000
+IDLE_TIMEOUT_MS = 15000
+
+
+def load_signatures():
+    with open(SIGNATURES_FILE, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f).get("tools", [])
+
+
+class NetworkLog:
+    """Coleta todas as requests/responses durante a navegacao."""
+    def __init__(self):
+        self.requests = []  # [{url, method, resource_type, headers, post_data_preview, timestamp}]
+        self.responses = []  # [{url, status, headers}]
+
+    def on_request(self, req: Request):
+        try:
+            post = None
+            try:
+                post = req.post_data
+                if post and len(post) > 2000:
+                    post = post[:2000]
+            except Exception:
+                pass
+            self.requests.append({
+                "url": req.url,
+                "method": req.method,
+                "resource_type": req.resource_type,
+                "post_data_preview": post,
+                "ts": time.time(),
+            })
+        except Exception:
+            pass
+
+    def on_response(self, resp: Response):
+        try:
+            self.responses.append({
+                "url": resp.url,
+                "status": resp.status,
+                "headers": dict(resp.headers),
+            })
+        except Exception:
+            pass
+
+
+def detect_tools(signatures, network_log: NetworkLog, html: str, window_globals: list, cookies: list):
+    """Cross-checks signatures against network URLs, HTML content, window globals, and cookies."""
+    detected = {}
+    all_urls = [r["url"] for r in network_log.requests]
+    all_resp_urls = [r["url"] for r in network_log.responses]
+    urls_combined = "\n".join(all_urls + all_resp_urls)
+    globals_set = set(window_globals or [])
+    cookie_names = set((c.get("name") for c in (cookies or [])))
+
+    soup = None
+    if BeautifulSoup is not None and html:
+        try:
+            soup = BeautifulSoup(html, "lxml")
+        except Exception:
+            try:
+                soup = BeautifulSoup(html, "html.parser")
+            except Exception:
+                soup = None
+
+    for sig in signatures:
+        evidence = []
+
+        # URL patterns
+        for pat in (sig.get("url_patterns") or []):
+            if pat in urls_combined:
+                matches = [u for u in all_urls if pat in u]
+                evidence.append({"type": "url", "pattern": pat, "sample": matches[0] if matches else pat})
+                break
+
+        # window globals
+        for g in (sig.get("window_globals") or []):
+            if g in globals_set:
+                evidence.append({"type": "window", "key": g})
+                break
+
+        # DOM selectors (usar BS4 CSS selector, senao fallback conservador)
+        for sel in (sig.get("dom_selectors") or []):
+            matched = False
+            if soup is not None:
+                try:
+                    if soup.select_one(sel):
+                        matched = True
+                except Exception:
+                    matched = False
+            else:
+                # Fallback: extrair todos valores de [attr="value"] do selector e exigir todos no HTML
+                attr_vals = re.findall(r'\[[^=\]]+=["\']?([^"\'\]]+)', sel)
+                if attr_vals and all(v.lower() in html.lower() for v in attr_vals):
+                    matched = True
+                elif not attr_vals:
+                    key = sel.lstrip(".#")
+                    if key and key.lower() in html.lower():
+                        matched = True
+            if matched:
+                evidence.append({"type": "dom", "selector": sel})
+                break
+
+        # cookies
+        for cname in (sig.get("cookies") or []):
+            if cname in cookie_names:
+                evidence.append({"type": "cookie", "name": cname})
+                break
+
+        # headers (resposta do doc principal)
+        hdrs = sig.get("headers") or {}
+        if hdrs and network_log.responses:
+            # usar primeira resposta 2xx/3xx do doc principal
+            doc_resp = next((r for r in network_log.responses if r["status"] < 400), None)
+            if doc_resp:
+                for hname, hpat in hdrs.items():
+                    hval = doc_resp["headers"].get(hname.lower(), "")
+                    if hval and re.search(hpat, hval):
+                        evidence.append({"type": "header", "name": hname, "value": hval[:120]})
+                        break
+
+        if evidence:
+            detected[sig["id"]] = {
+                "id": sig["id"],
+                "name": sig["name"],
+                "category": sig["category"],
+                "evidence": evidence,
+                "notes": sig.get("notes", ""),
+            }
+
+    return detected
+
+
+def extract_ids_from_urls(network_log: NetworkLog):
+    """Extrai IDs de conta (GTM-XXX, G-XXX, UA-XXX, AW-XXX, pixel_id) das URLs."""
+    ids = {
+        "gtm": set(),
+        "ga4": set(),
+        "ua": set(),
+        "google_ads": set(),
+        "meta_pixel": set(),
+        "tiktok_pixel": set(),
+        "linkedin_partner": set(),
+    }
+    for r in network_log.requests:
+        u = r["url"]
+        # GTM container
+        m = re.search(r'[?&]id=(GTM-[A-Z0-9]+)', u)
+        if m:
+            ids["gtm"].add(m.group(1))
+        # GA4
+        m = re.search(r'[?&]tid=(G-[A-Z0-9]+)', u)
+        if m:
+            ids["ga4"].add(m.group(1))
+        m = re.search(r'[?&]id=(G-[A-Z0-9]+)', u)
+        if m:
+            ids["ga4"].add(m.group(1))
+        # UA
+        m = re.search(r'[?&]tid=(UA-\d+-\d+)', u)
+        if m:
+            ids["ua"].add(m.group(1))
+        # Google Ads
+        m = re.search(r'(AW-\d+)', u)
+        if m:
+            ids["google_ads"].add(m.group(1))
+        # Meta Pixel
+        m = re.search(r'facebook\.com/tr[/?].*[?&]id=(\d+)', u)
+        if m:
+            ids["meta_pixel"].add(m.group(1))
+        # TikTok
+        m = re.search(r'tiktok.*[?&]sdkid=([A-Z0-9]+)', u, re.I)
+        if m:
+            ids["tiktok_pixel"].add(m.group(1))
+        # LinkedIn
+        m = re.search(r'linkedin.*pid=(\d+)', u, re.I)
+        if m:
+            ids["linkedin_partner"].add(m.group(1))
+
+    return {k: sorted(list(v)) for k, v in ids.items()}
+
+
+def parse_ga4_events(network_log: NetworkLog):
+    """Parse eventos GA4 de google-analytics.com/g/collect."""
+    events = []
+    for r in network_log.requests:
+        u = r["url"]
+        if "google-analytics.com/g/collect" not in u and "analytics.google.com/g/collect" not in u:
+            continue
+        try:
+            parsed = urlparse(u)
+            qs = parse_qs(parsed.query)
+            # Alguns eventos vem em POST body (batch)
+            body_qs = {}
+            if r.get("post_data_preview"):
+                try:
+                    body_qs = parse_qs(r["post_data_preview"])
+                except Exception:
+                    pass
+            merged = {**qs, **body_qs}
+            en = merged.get("en", [None])[0]
+            if not en:
+                continue
+            event = {
+                "name": en,
+                "tid": merged.get("tid", [None])[0],
+                "gcs": merged.get("gcs", [None])[0],  # Consent Mode v2 state
+                "dl": merged.get("dl", [None])[0],  # page url
+                "dt": merged.get("dt", [None])[0],  # page title
+                "params": {},
+            }
+            # ep.* = event params, epn.* = numeric
+            for k, v in merged.items():
+                if k.startswith("ep.") or k.startswith("epn."):
+                    event["params"][k.split(".", 1)[1]] = v[0] if v else None
+            events.append(event)
+        except Exception as e:
+            continue
+    return events
+
+
+def parse_meta_pixel_events(network_log: NetworkLog):
+    """Parse eventos Meta Pixel de facebook.com/tr."""
+    events = []
+    for r in network_log.requests:
+        u = r["url"]
+        if "facebook.com/tr" not in u:
+            continue
+        try:
+            parsed = urlparse(u)
+            qs = parse_qs(parsed.query)
+            ev = qs.get("ev", [None])[0]
+            if not ev:
+                continue
+            event = {
+                "name": ev,
+                "pixel_id": qs.get("id", [None])[0],
+                "dl": qs.get("dl", [None])[0],
+                "value": qs.get("cd[value]", [None])[0],
+                "currency": qs.get("cd[currency]", [None])[0],
+                "content_ids": qs.get("cd[content_ids]", [None])[0],
+                "content_type": qs.get("cd[content_type]", [None])[0],
+            }
+            events.append(event)
+        except Exception:
+            continue
+    return events
+
+
+def compute_quality_flags(detected_tools, ga4_events, meta_events, datalayer, ids_found):
+    """Gera red flags de qualidade/tagueamento."""
+    flags = []
+
+    # 1. UA legacy ainda presente
+    if "ga_ua" in detected_tools or ids_found.get("ua"):
+        flags.append({
+            "severity": "critical",
+            "flag": "ua_legacy_detected",
+            "title": "Google Analytics UA (legado) ainda presente",
+            "detail": f"UA descontinuado desde jul/2023. IDs: {ids_found.get('ua') or 'n/a'}. Remover tags UA do GTM.",
+        })
+
+    # 2. Pixel Meta duplicado
+    pixels = ids_found.get("meta_pixel") or []
+    if len(pixels) > 1:
+        flags.append({
+            "severity": "high",
+            "flag": "meta_pixel_duplicated",
+            "title": f"Meta Pixel duplicado ({len(pixels)} IDs)",
+            "detail": f"IDs: {pixels}. Eventos sao disparados duas vezes — duplica dados em Business Manager e gasta budget em audiencias infladas.",
+        })
+
+    # 3. GA4 sem PageView
+    has_ga4 = "ga4" in detected_tools
+    has_page_view = any(e["name"] == "page_view" for e in ga4_events)
+    if has_ga4 and not has_page_view:
+        flags.append({
+            "severity": "high",
+            "flag": "ga4_no_pageview",
+            "title": "GA4 instalado mas nao dispara page_view",
+            "detail": "Load da pagina nao gerou evento page_view. Pode ser bloqueio por consent, erro de config ou tag disparando so com interacao.",
+        })
+
+    # 4. Pixel sem PageView
+    has_pixel = "meta_pixel" in detected_tools
+    has_pixel_pv = any(e["name"] == "PageView" for e in meta_events)
+    if has_pixel and not has_pixel_pv:
+        flags.append({
+            "severity": "high",
+            "flag": "pixel_no_pageview",
+            "title": "Meta Pixel instalado mas nao dispara PageView",
+            "detail": "Eventos de remarketing nao vao contar. Checar fbq('init') + fbq('track','PageView') no codigo ou GTM.",
+        })
+
+    # 5. gtag + GTM em paralelo
+    has_gtm = "gtm" in detected_tools
+    has_gtag_only = has_ga4 and not has_gtm
+    if has_gtm and any("gtag/js" in r["url"] for r in []):  # checado indiretamente
+        pass  # refinar: se houver dois pontos de init GA4, flag
+
+    # 6. Consent Mode v2 presente?
+    has_cmp = any(detected_tools.get(t) for t in ["onetrust", "cookiebot", "usercentrics", "trustarc", "termly"])
+    has_gcs = any(e.get("gcs") for e in ga4_events)
+    if has_ga4 and not has_gcs and not has_cmp:
+        flags.append({
+            "severity": "medium",
+            "flag": "no_consent_mode",
+            "title": "Sem Consent Mode v2 nem CMP detectado",
+            "detail": "Desde mar/2024 Google exige Consent Mode v2 para audiencias. Sem CMP, site pode violar LGPD.",
+        })
+
+    # 7. dataLayer vazio (so com gtm.js)
+    if datalayer is not None:
+        if isinstance(datalayer, list) and len(datalayer) <= 1:
+            flags.append({
+                "severity": "medium",
+                "flag": "datalayer_empty",
+                "title": "dataLayer praticamente vazio",
+                "detail": "Sem variaveis customizadas no dataLayer alem do gtm.js. Nao ha contexto sendo passado ao GTM — eventos ricos (user_id, ecommerce, form_step) sao impossiveis.",
+            })
+
+    # 8. GTM instalado sem GA4 nem Pixel
+    if has_gtm and not has_ga4 and not has_pixel:
+        flags.append({
+            "severity": "critical",
+            "flag": "gtm_without_analytics",
+            "title": "GTM instalado sem GA4 nem Meta Pixel",
+            "detail": "Container GTM carrega mas nao dispara nenhuma tag de analytics ou ads conhecida. Investimento em midia opera cego — sem atribuicao de conversao.",
+        })
+
+    # 9. GA4 instalado mas sem Google Ads vinculado
+    has_gads = bool(ids_found.get("google_ads"))
+    if has_ga4 and not has_gads:
+        flags.append({
+            "severity": "low",
+            "flag": "ga4_no_google_ads",
+            "title": "GA4 presente mas sem tag Google Ads",
+            "detail": "Nao e red flag se cliente nao faz Google Ads. Se faz, conversoes nao estao importando para Ads — revisar vinculo GA4↔Ads.",
+        })
+
+    # 10. Multiplos containers GTM
+    gtms = ids_found.get("gtm") or []
+    if len(gtms) > 1:
+        flags.append({
+            "severity": "medium",
+            "flag": "multiple_gtm_containers",
+            "title": f"{len(gtms)} containers GTM carregados",
+            "detail": f"IDs: {gtms}. Aumenta JS bundle, pode causar conflitos de eventos e confusao de ownership.",
+        })
+
+    return flags
+
+
+async def detect_cro_elements(page: Page):
+    """Avaliacao profunda de elementos CRO visiveis na pagina."""
+    js = """
+    () => {
+      const text = (el) => (el?.textContent || '').trim().replace(/\\s+/g,' ');
+      const isVisible = (el) => {
+        if (!el) return false;
+        const rect = el.getBoundingClientRect();
+        const style = window.getComputedStyle(el);
+        return rect.width > 0 && rect.height > 0 && style.display !== 'none' && style.visibility !== 'hidden' && parseFloat(style.opacity) > 0;
+      };
+
+      // CTAs
+      const ctas = [...document.querySelectorAll('a, button')]
+        .filter(el => isVisible(el))
+        .map(el => {
+          const t = text(el);
+          if (!t || t.length > 60) return null;
+          const rect = el.getBoundingClientRect();
+          const href = el.getAttribute('href') || '';
+          const isWhatsApp = /wa\\.me|api\\.whatsapp/i.test(href);
+          const isTel = href.startsWith('tel:');
+          const isMail = href.startsWith('mailto:');
+          return {
+            text: t,
+            tag: el.tagName.toLowerCase(),
+            href: href.substring(0, 200),
+            is_whatsapp: isWhatsApp,
+            is_tel: isTel,
+            is_mail: isMail,
+            above_fold: rect.top < window.innerHeight,
+            width: Math.round(rect.width),
+            height: Math.round(rect.height),
+          };
+        })
+        .filter(Boolean);
+
+      // Forms
+      const forms = [...document.querySelectorAll('form')].map(f => {
+        const inputs = [...f.querySelectorAll('input, select, textarea')]
+          .filter(el => !['hidden','submit','button'].includes(el.type))
+          .map(el => ({
+            name: el.name || el.id || '',
+            type: el.type || el.tagName.toLowerCase(),
+            required: el.hasAttribute('required'),
+            placeholder: el.placeholder || '',
+          }));
+        return {
+          id: f.id || '',
+          action: (f.action || '').substring(0, 200),
+          method: (f.method || 'get').toLowerCase(),
+          field_count: inputs.length,
+          fields: inputs,
+          has_consent_checkbox: !!f.querySelector('input[type="checkbox"]'),
+        };
+      });
+
+      // Prova social (heuristica)
+      const bodyText = document.body.innerText.toLowerCase();
+      const socialProof = {
+        has_testimonials: /depoimento|testimonial|avalia[cç][aã]o|review/i.test(bodyText),
+        has_ratings: !!document.querySelector('[class*="star"], [class*="rating"], [itemprop="ratingValue"]'),
+        has_numbers: /[0-9]+\\s*(clientes|pacientes|alunos|pets|atendimentos|projetos|anos)/i.test(bodyText),
+        has_certifications: /(crmv|oab|crefito|crm|certificado|selo|iso\\s)/i.test(bodyText),
+        has_logos_clients: !!document.querySelector('[class*="clients"], [class*="parceir"], [class*="logos"]'),
+      };
+
+      // Urgencia/escassez
+      const urgency = {
+        has_countdown: !!document.querySelector('[class*="countdown"], [class*="timer"], [id*="countdown"]'),
+        has_limited: /vagas limitadas|[uú]ltimas? vagas|termina hoje|s[oó] hoje|oferta expira/i.test(bodyText),
+        has_discount: /desconto|off|%\\s*(off|menos)/i.test(bodyText),
+      };
+
+      // Confianca / credenciais
+      const trust = {
+        has_address: /(rua|avenida|av\\.|travessa|alameda)\\s+[A-Z]/i.test(document.body.innerText),
+        has_cnpj: /cnpj[:\\s]*[\\d\\.\\/\\-]+/i.test(document.body.innerText),
+        has_phone: !!document.querySelector('a[href^="tel:"]'),
+        has_email: !!document.querySelector('a[href^="mailto:"]'),
+        has_privacy_link: /pol[ií]tica\\s+de\\s+privacidade|privacy\\s+policy/i.test(bodyText),
+        has_terms_link: /termos\\s+de\\s+uso|terms\\s+of/i.test(bodyText),
+      };
+
+      // WhatsApp
+      const waLinks = [...document.querySelectorAll('a[href*="wa.me/"], a[href*="api.whatsapp.com"]')].map(a => ({
+        text: text(a).substring(0, 80),
+        href: a.getAttribute('href') || '',
+        visible: isVisible(a),
+        floating: /fix|sticky/i.test(window.getComputedStyle(a).position) || !!a.closest('[class*="float"],[class*="sticky"],[class*="fixed"]'),
+      }));
+
+      // Videos
+      const videos = [...document.querySelectorAll('video, iframe[src*="youtube"], iframe[src*="vimeo"], iframe[src*="wistia"]')].map(v => ({
+        tag: v.tagName.toLowerCase(),
+        src: (v.src || v.getAttribute('src') || '').substring(0, 200),
+      }));
+
+      // Hero analysis (first viewport)
+      const h1 = document.querySelector('h1');
+      const aboveFoldCtas = ctas.filter(c => c.above_fold).length;
+
+      return {
+        cta_count: ctas.length,
+        cta_above_fold: aboveFoldCtas,
+        cta_list: ctas.slice(0, 20),
+        whatsapp_links: waLinks,
+        forms: forms,
+        form_count: forms.length,
+        avg_fields_per_form: forms.length ? Math.round(forms.reduce((s,f)=>s+f.field_count,0)/forms.length) : 0,
+        social_proof: socialProof,
+        urgency: urgency,
+        trust: trust,
+        videos: videos,
+        h1_text: h1 ? text(h1).substring(0, 200) : null,
+        page_text_length: document.body.innerText.length,
+      };
+    }
+    """
+    try:
+        return await page.evaluate(js)
+    except Exception as e:
+        return {"error": str(e)}
+
+
+async def dump_window_globals_and_datalayer(page: Page):
+    """Lista props em window (filtradas) + dataLayer."""
+    js = """
+    () => {
+      const interesting = [
+        'gtag','dataLayer','google_tag_manager','ga','_gaq',
+        'fbq','_fbq','ttq','pintrk','_linkedin_data_partner_ids','twq',
+        'clarity','hj','_hjSettings','_mfq','FS',
+        'Intercom','_hsq','HubSpotConversations','zE','$zopim','$crisp','jivo_api','Tawk_API',
+        'OneTrust','OptanonConsent','Cookiebot','UC_UI',
+        'RdstationPopup','RDStationForms',
+        'Shopify','vtex','vtexjs','elementorFrontend','__NEXT_DATA__','React','Vue'
+      ];
+      const found = interesting.filter(k => typeof window[k] !== 'undefined');
+      let dl = null;
+      try {
+        if (Array.isArray(window.dataLayer)) {
+          dl = window.dataLayer.map(item => {
+            try { return JSON.parse(JSON.stringify(item)); } catch(e) { return String(item).substring(0,200); }
+          }).slice(0, 50);
+        }
+      } catch(e) {}
+      return { globals: found, datalayer: dl, datalayer_length: (Array.isArray(window.dataLayer) ? window.dataLayer.length : null) };
+    }
+    """
+    try:
+        return await page.evaluate(js)
+    except Exception as e:
+        return {"globals": [], "datalayer": None, "datalayer_length": None, "error": str(e)}
+
+
+async def audit_one_pass(browser, url: str, device: str, wait_for_consent: bool):
+    """Navega a URL uma vez (mobile ou desktop) e retorna snapshot completo."""
+    is_mobile = device == "mobile"
+    context = await browser.new_context(
+        user_agent=USER_AGENT_MOBILE if is_mobile else USER_AGENT_DESKTOP,
+        viewport=VIEWPORT_MOBILE if is_mobile else VIEWPORT_DESKTOP,
+        is_mobile=is_mobile,
+        locale="pt-BR",
+        timezone_id="America/Sao_Paulo",
+    )
+    page = await context.new_page()
+    netlog = NetworkLog()
+    page.on("request", netlog.on_request)
+    page.on("response", netlog.on_response)
+
+    nav_error = None
+    status = None
+    try:
+        response = await page.goto(url, wait_until="domcontentloaded", timeout=NAV_TIMEOUT_MS)
+        status = response.status if response else None
+        try:
+            await page.wait_for_load_state("networkidle", timeout=IDLE_TIMEOUT_MS)
+        except PWTimeout:
+            pass
+        # Scroll para ativar lazy loaders
+        try:
+            await page.evaluate("() => window.scrollTo(0, document.body.scrollHeight)")
+            await page.wait_for_timeout(1500)
+            await page.evaluate("() => window.scrollTo(0, 0)")
+            await page.wait_for_timeout(500)
+        except Exception:
+            pass
+    except Exception as e:
+        nav_error = str(e)
+
+    # Dump state
+    try:
+        html = await page.content()
+    except Exception:
+        html = ""
+    try:
+        cookies = await context.cookies()
+    except Exception:
+        cookies = []
+
+    globals_info = await dump_window_globals_and_datalayer(page)
+    cro = await detect_cro_elements(page) if not nav_error else {}
+
+    # Screenshot full-page (compressao leve)
+    screenshot_b64 = None
+    try:
+        ss_bytes = await page.screenshot(full_page=True, type="jpeg", quality=60)
+        import base64
+        screenshot_b64 = "data:image/jpeg;base64," + base64.b64encode(ss_bytes).decode("ascii")
+    except Exception:
+        pass
+
+    await context.close()
+
+    return {
+        "device": device,
+        "status": status,
+        "nav_error": nav_error,
+        "html_length": len(html),
+        "html_preview": html[:500],
+        "html": html,  # usado internamente pela deteccao, removido do output
+        "cookies": [{"name": c["name"], "domain": c.get("domain",""), "secure": c.get("secure", False), "httpOnly": c.get("httpOnly", False), "sameSite": c.get("sameSite","")} for c in cookies],
+        "window_globals": globals_info.get("globals", []),
+        "datalayer": globals_info.get("datalayer"),
+        "datalayer_length": globals_info.get("datalayer_length"),
+        "cro_elements": cro,
+        "requests_count": len(netlog.requests),
+        "responses_count": len(netlog.responses),
+        "_netlog": netlog,  # usado internamente, removido do output
+        "screenshot_fullpage": screenshot_b64,
+    }
+
+
+async def audit_compliance_pass(browser, url: str):
+    """Segunda passada: navega com flag de 'pre-consent' simulada (sem interagir com CMP).
+    Registra quais trackers disparam ANTES de qualquer consentimento.
+    """
+    # Mesma logica do pass principal, mas sem aceitar nenhum banner
+    context = await browser.new_context(
+        user_agent=USER_AGENT_DESKTOP,
+        viewport=VIEWPORT_DESKTOP,
+        locale="pt-BR",
+        timezone_id="America/Sao_Paulo",
+    )
+    page = await context.new_page()
+    netlog = NetworkLog()
+    page.on("request", netlog.on_request)
+
+    nav_error = None
+    try:
+        await page.goto(url, wait_until="domcontentloaded", timeout=NAV_TIMEOUT_MS)
+        try:
+            await page.wait_for_load_state("networkidle", timeout=IDLE_TIMEOUT_MS)
+        except PWTimeout:
+            pass
+        # NAO interagir com CMP — ficar parado
+        await page.wait_for_timeout(2500)
+    except Exception as e:
+        nav_error = str(e)
+
+    # Contar tracker requests ANTES de consent
+    tracker_patterns = [
+        "google-analytics.com",
+        "googletagmanager.com/gtm.js",
+        "facebook.com/tr",
+        "facebook.net/en_US/fbevents.js",
+        "analytics.tiktok.com",
+        "clarity.ms",
+        "hotjar.com",
+        "linkedin.com/li/",
+        "doubleclick.net",
+    ]
+    pre_consent_trackers = {}
+    for r in netlog.requests:
+        for pat in tracker_patterns:
+            if pat in r["url"]:
+                pre_consent_trackers.setdefault(pat, []).append(r["url"])
+                break
+
+    await context.close()
+
+    return {
+        "nav_error": nav_error,
+        "pre_consent_trackers": pre_consent_trackers,
+        "pre_consent_tracker_count": sum(len(v) for v in pre_consent_trackers.values()),
+    }
+
+
+def build_compliance_report(compliance_pass, detected_tools):
+    """Monta bloco de compliance LGPD."""
+    cmps = {k: detected_tools[k] for k in ["onetrust", "cookiebot", "usercentrics", "trustarc", "termly"] if k in detected_tools}
+    has_cmp = bool(cmps)
+    pre_count = compliance_pass.get("pre_consent_tracker_count", 0)
+    pre_trackers = compliance_pass.get("pre_consent_trackers", {})
+
+    issues = []
+    if not has_cmp:
+        issues.append("Sem CMP detectado — sem mecanismo de consentimento.")
+    if pre_count > 0:
+        issues.append(f"{pre_count} requests de tracking disparam ANTES de qualquer consentimento.")
+        for pat, urls in pre_trackers.items():
+            issues.append(f"  • {pat}: {len(urls)} request(s)")
+
+    # Score 0-10
+    score = 10
+    if not has_cmp:
+        score -= 5
+    if pre_count > 0:
+        score -= min(5, pre_count)
+    score = max(0, score)
+
+    status = "compliant" if (has_cmp and pre_count == 0) else ("partial" if has_cmp else "non_compliant")
+
+    return {
+        "status": status,
+        "score": score,
+        "has_cmp": has_cmp,
+        "cmps_detected": list(cmps.keys()),
+        "pre_consent_trackers": pre_trackers,
+        "pre_consent_tracker_count": pre_count,
+        "issues": issues,
+    }
+
+
+def sanitize_output(obj):
+    """Remove campos pesados/internos do output final."""
+    if isinstance(obj, dict):
+        return {k: sanitize_output(v) for k, v in obj.items() if not k.startswith("_") and k != "html"}
+    if isinstance(obj, list):
+        return [sanitize_output(x) for x in obj]
+    return obj
+
+
+async def run_audit(url: str, out_path: str, skip_compliance: bool = False):
+    signatures = load_signatures()
+    result = {
+        "url": url,
+        "fetched_at": datetime.now(timezone.utc).isoformat(),
+        "engine": "playwright-chromium",
+    }
+
+    async with async_playwright() as pw:
+        print(">> Iniciando Chromium headless...", file=sys.stderr)
+        browser = await pw.chromium.launch(headless=True, args=["--disable-blink-features=AutomationControlled"])
+
+        print(">> Pass 1: Desktop (full audit)...", file=sys.stderr)
+        desktop_pass = await audit_one_pass(browser, url, "desktop", wait_for_consent=False)
+
+        print(">> Pass 2: Mobile (full audit)...", file=sys.stderr)
+        mobile_pass = await audit_one_pass(browser, url, "mobile", wait_for_consent=False)
+
+        compliance_pass = None
+        if not skip_compliance:
+            print(">> Pass 3: Compliance LGPD (pre-consent tracking)...", file=sys.stderr)
+            compliance_pass = await audit_compliance_pass(browser, url)
+
+        await browser.close()
+
+    # Combinar netlogs de desktop + mobile para deteccao de ferramentas (mais robusto)
+    combined_netlog = NetworkLog()
+    combined_netlog.requests = desktop_pass["_netlog"].requests + mobile_pass["_netlog"].requests
+    combined_netlog.responses = desktop_pass["_netlog"].responses + mobile_pass["_netlog"].responses
+
+    detected = detect_tools(
+        signatures,
+        combined_netlog,
+        desktop_pass.get("html", "") + mobile_pass.get("html", ""),
+        list(set(desktop_pass.get("window_globals", []) + mobile_pass.get("window_globals", []))),
+        desktop_pass.get("cookies", []) + mobile_pass.get("cookies", []),
+    )
+    ids_found = extract_ids_from_urls(combined_netlog)
+    ga4_events = parse_ga4_events(combined_netlog)
+    meta_events = parse_meta_pixel_events(combined_netlog)
+    quality_flags = compute_quality_flags(detected, ga4_events, meta_events, desktop_pass.get("datalayer"), ids_found)
+
+    compliance_report = None
+    if compliance_pass is not None:
+        compliance_report = build_compliance_report(compliance_pass, detected)
+
+    # Categorizar ferramentas
+    by_category = {}
+    for tid, info in detected.items():
+        by_category.setdefault(info["category"], []).append(info["name"])
+
+    result["tracking_stack"] = {
+        "tools_detected": detected,
+        "ids_found": ids_found,
+        "categories_summary": {cat: sorted(names) for cat, names in by_category.items()},
+        "total_tools": len(detected),
+    }
+
+    result["events_fired"] = {
+        "ga4": ga4_events,
+        "meta_pixel": meta_events,
+        "ga4_event_count": len(ga4_events),
+        "meta_event_count": len(meta_events),
+        "ga4_event_names": sorted(set(e["name"] for e in ga4_events if e.get("name"))),
+        "meta_event_names": sorted(set(e["name"] for e in meta_events if e.get("name"))),
+    }
+
+    result["datalayer"] = {
+        "desktop": {
+            "length": desktop_pass.get("datalayer_length"),
+            "sample": desktop_pass.get("datalayer"),
+        },
+        "mobile": {
+            "length": mobile_pass.get("datalayer_length"),
+            "sample": mobile_pass.get("datalayer"),
+        },
+    }
+
+    result["cro_elements"] = {
+        "desktop": desktop_pass.get("cro_elements"),
+        "mobile": mobile_pass.get("cro_elements"),
+    }
+
+    result["quality_flags"] = quality_flags
+
+    result["compliance_lgpd"] = compliance_report
+
+    result["navigation"] = {
+        "desktop": {
+            "status": desktop_pass.get("status"),
+            "nav_error": desktop_pass.get("nav_error"),
+            "requests_count": desktop_pass.get("requests_count"),
+            "responses_count": desktop_pass.get("responses_count"),
+            "cookies_count": len(desktop_pass.get("cookies") or []),
+        },
+        "mobile": {
+            "status": mobile_pass.get("status"),
+            "nav_error": mobile_pass.get("nav_error"),
+            "requests_count": mobile_pass.get("requests_count"),
+            "responses_count": mobile_pass.get("responses_count"),
+            "cookies_count": len(mobile_pass.get("cookies") or []),
+        },
+    }
+
+    result["screenshots_fullpage"] = {
+        "desktop": desktop_pass.get("screenshot_fullpage"),
+        "mobile": mobile_pass.get("screenshot_fullpage"),
+    }
+
+    # Limpar campos internos
+    result = sanitize_output(result)
+
+    # Escrever output
+    os.makedirs(os.path.dirname(out_path) or ".", exist_ok=True)
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(result, f, ensure_ascii=False, indent=2)
+
+    print(f"[OK] Deep audit salvo em {out_path}", file=sys.stderr)
+    print(f"     Ferramentas detectadas: {len(detected)}", file=sys.stderr)
+    print(f"     Eventos GA4: {len(ga4_events)} | Meta Pixel: {len(meta_events)}", file=sys.stderr)
+    print(f"     Red flags: {len(quality_flags)}", file=sys.stderr)
+    if compliance_report:
+        print(f"     Compliance: {compliance_report['status']} (score {compliance_report['score']}/10)", file=sys.stderr)
+
+
+def main():
+    if len(sys.argv) < 3:
+        print("Uso: page_audit_deep.py <url> <output_json> [--skip-compliance]", file=sys.stderr)
+        sys.exit(1)
+    url = sys.argv[1]
+    out_path = sys.argv[2]
+    skip_compliance = "--skip-compliance" in sys.argv
+    asyncio.run(run_audit(url, out_path, skip_compliance=skip_compliance))
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/gt-diagnostico-cro/scripts/page_audit_deep.sh
+++ b/.claude/skills/gt-diagnostico-cro/scripts/page_audit_deep.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# page_audit_deep.sh — Orquestra a auditoria PROFUNDA de uma URL (Playwright).
+# Complementa page_audit.sh (PSI + on-page estatico) com:
+#   - Tracking stack (GTM, GA4, Meta Pixel, Clarity, etc.)
+#   - Eventos disparados (GA4 + Meta Pixel capturados via network)
+#   - dataLayer dump
+#   - CRO elements (CTAs, forms, WhatsApp, prova social)
+#   - Compliance LGPD (pre-consent tracker detection)
+#   - Quality flags (UA legacy, pixel duplicado, etc.)
+#
+# Uso:  page_audit_deep.sh <client_dir> <url>
+# Ex:   page_audit_deep.sh squads/{squad}/clientes/{cliente} https://www.site-do-cliente.com.br
+#
+# Le:    <client_dir>/client.json
+# Grava: <client_dir>/cache/page_audit_deep-<timestamp>.json (raw)
+#        <client_dir>/client.json (campo page_audit_deep com resumo)
+
+set -euo pipefail
+
+CLIENT_DIR="${1:?Uso: page_audit_deep.sh <client_dir> <url>}"
+URL="${2:?Uso: page_audit_deep.sh <client_dir> <url>}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PY_SCRIPT="$SCRIPT_DIR/page_audit_deep.py"
+
+if [ ! -f "$PY_SCRIPT" ]; then
+  echo "ERROR: page_audit_deep.py nao encontrado em $PY_SCRIPT" >&2
+  exit 1
+fi
+
+# Cache dir
+mkdir -p "$CLIENT_DIR/cache"
+TS=$(date -u +%Y%m%d-%H%M%S)
+RAW_OUT="$CLIENT_DIR/cache/page_audit_deep-$TS.json"
+
+echo ">> Deep audit (Playwright: 3 passes — desktop full, mobile full, compliance pre-consent)..."
+python3 "$PY_SCRIPT" "$URL" "$RAW_OUT"
+
+# O Builders Hub não exige client.json. Quando ele não existe, preserve o
+# cache bruto e deixe a skill interpretar os dados junto com a KB do cliente.
+if [ ! -f "$CLIENT_DIR/client.json" ]; then
+  echo "[OK] Auditoria profunda bruta concluída; client.json ausente, merge ignorado."
+  echo "Cache raw: $RAW_OUT"
+  exit 0
+fi
+
+# Merge resumo no client.json
+python3 << PYEOF
+import json
+from datetime import datetime, timezone
+
+raw_path = "$RAW_OUT"
+client_path = "$CLIENT_DIR/client.json"
+
+with open(raw_path, encoding='utf-8') as f:
+    raw = json.load(f)
+
+with open(client_path, encoding='utf-8') as f:
+    client = json.load(f)
+
+# Summary condensado — raw fica no cache (inclui screenshots full-page pesados)
+tracking = raw.get("tracking_stack") or {}
+events = raw.get("events_fired") or {}
+cro_el = raw.get("cro_elements") or {}
+dl = raw.get("datalayer") or {}
+flags = raw.get("quality_flags") or []
+compliance = raw.get("compliance_lgpd") or {}
+nav = raw.get("navigation") or {}
+
+# tools_detected no summary: so id+name+category (sem evidence detalhada)
+tools_light = {}
+for tid, info in (tracking.get("tools_detected") or {}).items():
+    tools_light[tid] = {
+        "name": info.get("name"),
+        "category": info.get("category"),
+    }
+
+summary = {
+    "fetched_at": raw.get("fetched_at"),
+    "url": raw.get("url"),
+    "cache_file": raw_path.replace("$CLIENT_DIR/", ""),
+    "engine": raw.get("engine"),
+    "tracking_stack": {
+        "tools_detected": tools_light,
+        "ids_found": tracking.get("ids_found") or {},
+        "categories_summary": tracking.get("categories_summary") or {},
+        "total_tools": tracking.get("total_tools") or 0,
+    },
+    "events_fired": {
+        "ga4_event_count": events.get("ga4_event_count") or 0,
+        "meta_event_count": events.get("meta_event_count") or 0,
+        "ga4_event_names": events.get("ga4_event_names") or [],
+        "meta_event_names": events.get("meta_event_names") or [],
+        # eventos detalhados so no raw
+    },
+    "datalayer": {
+        "desktop_length": (dl.get("desktop") or {}).get("length"),
+        "mobile_length": (dl.get("mobile") or {}).get("length"),
+    },
+    "cro_elements": cro_el,  # leve o suficiente p/ ficar no client.json
+    "quality_flags": flags,
+    "compliance_lgpd": compliance,
+    "navigation": nav,
+    # Screenshots full-page NAO vao pro client.json (pesados) — so no raw
+}
+
+client["page_audit_deep"] = summary
+
+with open(client_path, "w", encoding="utf-8") as f:
+    json.dump(client, f, ensure_ascii=False, indent=2)
+
+print(f"[OK] page_audit_deep salvo em client.json (raw: {raw_path})")
+PYEOF
+
+echo "Cache raw: $RAW_OUT"

--- a/.claude/skills/gt-diagnostico-cro/scripts/requirements-deep.txt
+++ b/.claude/skills/gt-diagnostico-cro/scripts/requirements-deep.txt
@@ -1,0 +1,2 @@
+playwright>=1.40
+pyyaml>=6.0

--- a/.claude/skills/gt-diagnostico-cro/scripts/requirements.txt
+++ b/.claude/skills/gt-diagnostico-cro/scripts/requirements.txt
@@ -1,0 +1,3 @@
+requests>=2.31
+beautifulsoup4>=4.12
+lxml>=4.9

--- a/.claude/skills/gt-diagnostico-maturidade-digital/SKILL.md
+++ b/.claude/skills/gt-diagnostico-maturidade-digital/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: gt-diagnostico-maturidade-digital
+description: "Analisa a maturidade digital do cliente (5 pilares: Mídia, Orgânico/SEO, Criativos, CRM, CRO) com base em dados V4MOS ou briefing. Gera score por pilar, benchmark setorial e sequência de turnaround. Use quando o operador disser 'maturidade', 'diagnóstico digital', 'score', ou na Semana 2 (POP 2.4)."
+area: gt
+author: luizfreitasv4
+version: 1.0.0
+dependencies: []
+outputs: ["gt-diagnostico-maturidade-digital.json"]
+week: 2
+estimated_time: "30-45 min"
+v4mos_integration: connectors_only
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta versao foi portada do sistema de Estruturacao Estrategica. As regras abaixo tem precedencia sobre caminhos e persistencia citados no fluxo original:
+
+- Trabalhe somente em `squads/{squad}/clientes/{cliente}/`, nunca em um diretorio `clientes/` solto na raiz.
+- Leia primeiro o `CLAUDE.md` ou `AGENTS.md` da KB, `mission-control/`, `calls/`, `docs/` e `campanhas/`.
+- Se `client.json` existir, use-o como fonte complementar. Se nao existir, derive o contexto da KB e do Mission Control; nao exija nem invente esse arquivo.
+- Salve entregaveis em `squads/{squad}/clientes/{cliente}/outputs/`, em JSON e Markdown quando o fluxo pedir ambos.
+- Registre decisoes e progresso no `mission-control/historico-checkins.md` ou no arquivo de historico equivalente encontrado na KB.
+- Resolva recursos empacotados a partir do proprio diretorio desta skill. Se uma integracao externa nao estiver configurada, declare o gap e continue apenas com os dados reais disponiveis.
+
+
+# Diagnóstico de Maturidade Digital (POP 2.4)
+
+> **Posição no fluxo:** sintetiza os diagnósticos de mídia, orgânico e criativos em um score por pilar. Rode depois dos diagnósticos especializados e antes do posicionamento.
+
+Você é um estrategista sênior de marketing digital. Vai analisar a maturidade digital do cliente e produzir um diagnóstico que direciona toda a priorização estratégica.
+
+> **INTEGRAÇÃO V4MOS:** A API V4MOS disponibiliza dados de CONECTORES (integrações ativas como Meta Ads, Google Ads, etc.). Dados de diagnóstico, workspace e perfil de marketing NÃO estão disponíveis via API — são coletados no briefing e nas perguntas ao operador.
+
+## Dados necessários
+
+### Fonte V4MOS (conectores)
+Leia `squads/{squad}/clientes/{cliente}/client.json` (seção `connectors`). Se `fetched_at` existir e não for null, extraia:
+- `google_ads` → campanhas Google Ads (total_campaigns, total_cost, avg_cpa, lista de campanhas com status)
+- `facebook_ads` → campanhas Meta Ads (total_campaigns, total_spend, avg_cpm, lista de campanhas)
+- Quais plataformas estão conectadas = indicador de maturidade em mídia paga
+
+Se `connectors.fetched_at` for nulo ou inexistente, use `/v4mos-dados-meta-ads` para Meta Ads. Para Google Ads, use exportações ou dados já presentes na KB. Se não houver integração, siga com briefing e evidências disponíveis, marcando claramente a limitação.
+
+**Formato atual dos connectors:**
+```json
+{
+  "fetched_at": "2026-04-18T15:30:00Z",
+  "period": { "start": "2025-01-01", "end": "2026-04-18" },
+  "google_ads": { "total_campaigns": 15, "total_cost": 13975, "avg_cpa": 11.41, "campaigns": [...] },
+  "facebook_ads": { "total_campaigns": 15, "total_spend": 3472, "avg_cpm": 10.10, "campaigns": [...] }
+}
+```
+
+### Fonte principal: Briefing + Operador
+Leia `squads/{squad}/clientes/{cliente}/client.json (briefing)`. Extraia:
+- `identification.segment` → segmento para benchmark
+- `digital_situation` → situação digital declarada pelo cliente
+- `accesses` → quais acessos o operador já tem
+
+---
+
+## Geração
+
+Gere o output COMPLETO de uma vez usando os dados de `client.json` (briefing, connectors) e outputs de skills dependentes em `outputs/`.
+
+### Cenário A: V4MOS tem dados de conectores
+Se `client.json.connectors.fetched_at` não é null, incorpore no diagnóstico:
+- Período dos dados (`period.start` → `period.end`)
+- Google Ads: quantas campanhas, gasto total, CPA médio, status das campanhas (ENABLED/PAUSED)
+- Facebook Ads: quantas campanhas, gasto total, CPM médio, objetivos usados
+- Quais plataformas estão ausentes (ex: sem Google Analytics = gap de rastreamento)
+
+Isso dá uma visão real da maturidade — não só "tem mídia paga" mas "como está performando".
+
+### Cenário B: Diagnóstico baseado em briefing + operador (SEMPRE executado)
+O diagnóstico completo sempre usa os dados do briefing (`digital_situation`) e as seguintes informações. Se não encontrar no client.json, pergunte ao operador TUDO de uma vez:
+
+**Mídia Paga:** plataformas usadas, investimento mensal, pixel/tag configurado, ROAS ou CPA atual
+**Criativos:** criativos ativos, quem produz, frequência de atualização
+**CRO (Conversão):** site/LP existente, taxa de conversão, pontos de conversão
+**CRM:** CRM usado, registros de leads, automação de follow-up
+**SEO:** posição no Google, blog/conteúdo indexado, Google Meu Negócio
+
+### Output completo
+
+Consulte `references/scoring-framework.md` para calibrar a análise. Gere:
+
+**Resumo Executivo (máx. 3 parágrafos)**
+
+Escreva em tom direto, sem eufemismo. Se o score é ruim, diga que é ruim e por quê.
+
+Parágrafo 1: Score geral e o que significa na prática para o negócio. Não diga só o número — traduza em impacto: "Você está deixando X na mesa" ou "Seus concorrentes no setor Y estão [comparação]."
+
+Parágrafo 2: Os 2 maiores gaps que estão custando resultado AGORA. Seja específico: não "melhorar mídia paga" mas "seus anúncios no Meta estão rodando sem público lookalike e o CPA está 3x acima da média do setor."
+
+Parágrafo 3: Os 2 pontos fortes que precisam ser aproveitados/acelerados.
+
+**Score por Pilar (tabela)**
+
+| Pilar | Score | Classificação | Destaque |
+|-------|-------|---------------|----------|
+| Mídia Paga | X/100 | [Crítico/Baixo/Médio/Bom/Excelente] | [1 frase] |
+| Criativos | X/100 | ... | ... |
+| CRO | X/100 | ... | ... |
+| CRM | X/100 | ... | ... |
+| SEO | X/100 | ... | ... |
+| **GERAL** | **X/100** | ... | ... |
+
+Se não houver dados V4MOS, atribua scores estimados com base na conversa com o operador, marcando como "(estimado)" na tabela.
+
+**Prioridades de Ação (5 ações, ranqueadas)**
+
+Para cada ação:
+1. **O que fazer** (específico e acionável)
+2. **Por que é prioridade** (impacto esperado)
+3. **Esforço** (baixo/médio/alto)
+4. **Dependências** (o que precisa estar pronto antes)
+
+**Benchmark do Setor**
+
+Compare o score do cliente com a média do setor (use `references/scoring-framework.md`).
+- Quais pilares estão acima da média?
+- Quais estão abaixo?
+- Qual o gap mais crítico vs. o setor?
+
+### Estrutura visual (obrigatória)
+
+Siga o padrão canônico de `references/padrao-output.md`. Além dos campos acima, SEMPRE inclua:
+
+- **`summary_headline`** (max 200 char) — manchete com o veredito. Ex: "[Cliente] tem 5.2/10 de maturidade digital — Mídia e CRM são os pilares que mais travam crescimento."
+- **`summary_highlights`** (4-6 itens, `{category, label, value, subtext, tone}`) — para maturidade sugestões:
+  - `maturidade`: score geral, pilar mais forte, pilar mais fraco
+  - `posicao`: score vs benchmark do setor (gap %)
+  - `oportunidade`: pilar com maior upside e retorno estimado
+  - `risco`: pilar crítico que bloqueia outros
+- **`summary_key_findings`** (3-5 itens, `{category, text}`) — `vantagem|contexto|ameaca|acao`.
+
+### Ponto de alavancagem
+
+Em diagnóstico de maturidade, o ponto de alavancagem é o **pilar mais fraco com maior impacto sistêmico** (bloqueia outros pilares ou representa o maior gap vs benchmark). Estruture em `key_insight`:
+```json
+"key_insight": {
+  "headline": "Frase sobre o pilar-chave (ex: 'CRM em 2/10 bloqueia ROI de toda mídia paga')",
+  "context": "2-3 linhas sobre cascata de efeitos",
+  "numbered_reasons": ["(1) evidência do score baixo", "(2) efeito cascata", "(3) ROI de destravar"],
+  "discussion_anchor": "Por que o stakeholder precisa priorizar este pilar antes dos outros"
+}
+```
+
+Se o diagnóstico revelou maturidade baixa em todos os pilares (ex: score médio < 4) ou dados insuficientes, inclua `honesty_alert`.
+
+## Auto-validação
+
+Antes de mostrar ao operador, verifique:
+
+- [ ] Mencionou o cliente pelo nome?
+- [ ] Usou dados reais do client.json (não inventou)?
+- [ ] Nenhum item genérico (ex: "quer crescer", "qualidade e compromisso")?
+- [ ] Schema da skill validou?
+- [ ] Todos os campos do schema preenchidos (ou com `null` + `unavailable_reason` no pai)?
+- [ ] Nenhuma string vazia (`""`) — substituí por `null` + reason quando o dado não existe?
+- [ ] Estimativas marcadas com `estimated: true` ou `[E]`?
+- [ ] Consistente com outputs anteriores?
+- [ ] Resumo executivo traduz scores em impacto de negócio (não só números)?
+- [ ] Prioridades são específicas e acionáveis (não "melhorar mídia")?
+- [ ] Benchmark do setor está referenciado com fonte?
+- [ ] Tem `summary_headline` específico?
+- [ ] `summary_highlights` tem 4-6 itens com categorias e tons válidos?
+- [ ] `summary_key_findings` cobre pelo menos 3 dos 4 tipos?
+- [ ] Identificou `key_insight` (pilar-chave com efeito sistêmico)?
+- [ ] Se há fragilidade geral, incluiu `honesty_alert`?
+
+Se falhou → regenere silenciosamente. Não avise o operador.
+
+## Apresentação e decisões
+
+Apresente o output COMPLETO ao operador.
+
+Revise o output. O que está errado, exagerado ou faltando?
+
+- "A análise condiz com o que você vê no dia a dia do cliente?"
+- "As prioridades fazem sentido na ordem apresentada?"
+- "Tem algum contexto que muda a priorização? (ex: cliente já fechou contrato de mídia, CRM já está em implementação)"
+
+## Finalização
+
+Operador aprova (com ou sem ajustes).
+1. Salve em `squads/{squad}/clientes/{cliente}/outputs/gt-diagnostico-maturidade-digital.json` (com campo `summary` no topo)
+2. Atualize `client.json`: progress.skills → completed, version++, append em history[]
+3. Salve também uma versão Markdown do entregável na mesma pasta de outputs.
+4. Sugira a próxima skill com base nas dependências e no estado da KB
+   - "Diagnóstico de maturidade salvo. Fecha o bloco de diagnósticos da Semana 2; o próximo passo é o Posicionamento (geral-posicionamento-estrategico), que sintetiza tudo."
+   - O score por pilar e a sequência de turnaround alimentam o posicionamento e o forecast de mídia.

--- a/.claude/skills/gt-diagnostico-maturidade-digital/references/padrao-output.md
+++ b/.claude/skills/gt-diagnostico-maturidade-digital/references/padrao-output.md
@@ -1,0 +1,202 @@
+# Padrão de Output das Skills — V4 Estruturação IA
+
+Este documento define a **estrutura canônica** que todos os outputs de skill devem seguir para renderizar no portal com hierarquia visual consistente. O objetivo é que o operador e o stakeholder final abram qualquer entregável e encontrem o mesmo ritmo: manchete → KPIs → achados categorizados → ponto de alavancagem destacado → detalhes expansíveis.
+
+---
+
+## Princípios
+
+1. **Manchete antes de texto.** Toda skill abre com uma frase única e específica que resume a conclusão. Não é parágrafo, é headline.
+2. **Números em destaque, não escondidos no corpo do texto.** KPIs que importam viram cards. Texto corrido é para contexto, não para fato quantitativo.
+3. **Achados categorizados por intenção.** Cada insight é classificado como `vantagem | contexto | ameaca | acao` — o leitor identifica o tom antes de ler.
+4. **Ponto de alavancagem visualmente isolado.** Toda skill tem UM ponto onde a conversa com o stakeholder precisa acontecer. Esse ponto ganha hero visual (border, gradient, quote destacada).
+5. **Detalhe denso → colapsável.** Listas longas (concorrentes, itens de checklist, fontes) ficam em `<details>` para não afogar a leitura.
+
+---
+
+## Campos obrigatórios no JSON
+
+Todo output de skill DEVE ter estes campos no topo (antes dos campos específicos da skill):
+
+```json
+{
+  "client_name": "Nome do Cliente",
+  "summary": "Resumo em 1-2 frases. Específico, com dados reais. Alimenta o resumo executivo do portal.",
+
+  "summary_headline": "Manchete em 1 linha (max 120 caracteres). A frase que o stakeholder lê primeiro.",
+
+  "summary_highlights": [
+    {
+      "category": "posicao | competicao | janela | maturidade | oportunidade | risco",
+      "label": "Rótulo curto (max 30 char)",
+      "value": "Valor em destaque (número, %, status)",
+      "subtext": "Contexto em 1 linha (max 60 char)",
+      "tone": "green | yellow | red | blue | gray"
+    }
+  ],
+
+  "summary_key_findings": [
+    {
+      "category": "vantagem | contexto | ameaca | acao",
+      "text": "Achado em 1-2 linhas. Específico, acionável."
+    }
+  ]
+}
+```
+
+### Regras dos campos de summary
+
+**`summary_headline`**: É a ÚNICA frase que o stakeholder precisa ler se só tiver 5 segundos. Deve conter o veredito da skill. Exemplos bons:
+- ✓ "[Cliente] é o ÚNICO player premium da microrregião com [diferencial declarado] — janela competitiva de 12-18 meses."
+- ✗ "Análise de mercado concluída com sucesso."
+
+**`summary_highlights`** (4-6 itens): KPIs visuais. Categorias sugeridas:
+- `posicao` — onde o cliente está hoje vs potencial
+- `competicao` — quem disputa o mesmo espaço
+- `janela` — tempo/urgência
+- `maturidade` — estágio atual em algum eixo
+- `oportunidade` — tamanho do ganho possível
+- `risco` — tamanho da ameaça
+
+Agrupar de 2 em 2 por categoria no renderer (dá layout balanceado 3x2 ou 2x2).
+
+**`summary_key_findings`** (3-5 itens): Achados que embasam a manchete. Categorias:
+- `vantagem` (✓ verde) — o que o cliente tem a favor
+- `contexto` (i azul) — o que é fato do mercado, neutro
+- `ameaca` (! vermelho) — o que pode dar errado
+- `acao` (▸ laranja) — o que precisa ser feito
+
+---
+
+## Ponto de Alavancagem (hero block)
+
+Toda skill deve identificar **UM bloco que merece destaque visual especial** — o ponto onde a conversa estratégica precisa acontecer. O nome do campo varia por skill, mas a estrutura é consistente:
+
+```json
+{
+  "key_leverage_point": {
+    "headline": "Frase-manchete do ponto (pode ir como quote)",
+    "context": "Contexto em 2-3 linhas explicando o cenário",
+    "numbered_reasons": [
+      "Razão 1 (parse-friendly, pode começar com texto direto)",
+      "Razão 2",
+      "Razão 3"
+    ],
+    "discussion_anchor": "Frase curta sobre POR QUE este é o ponto de conversa com o stakeholder"
+  }
+}
+```
+
+Exemplos por skill:
+- `pesquisa-mercado` → `unexploited_opportunity` (whitespace estratégico)
+- `persona-icp` → persona principal + dor mais ignorada
+- `swot` → combinação força × oportunidade mais assimétrica
+- `posicionamento` → PUV vs alternativas descartadas
+- `diagnostico-midia` → canal mais subotimizado + upside estimado
+- `diagnostico-maturidade` → pilar mais fraco com maior impacto
+
+O renderer aplica:
+- Border verde 2px + gradient sutil
+- Selo "Whitespace Estratégico · Discussão com Stakeholder" no topo
+- Pill de viabilidade/urgência à direita
+- Quote/headline em card branco isolado
+- Razões numeradas em 3 círculos
+- Footer "💬 Momento de validar com a stakeholder"
+
+---
+
+## Alerta de honestidade
+
+Se a pesquisa/análise revelou fragilidade do cliente (não há diferencial real, ICP mal definido, mercado saturado, etc.), inclua:
+
+```json
+{
+  "honesty_alert": "Texto explicando a fragilidade encontrada e o que precisa ser feito antes de seguir."
+}
+```
+
+Esse campo renderiza em box amarelo/vermelho após os achados. **Nunca omita** se a realidade justifica. O valor do sistema depende de não vender aspiracional como real.
+
+---
+
+## Instrução para a IA da skill
+
+Em cada `SKILL.md`, incluir esta seção na geração:
+
+> ### Estrutura visual (obrigatória)
+>
+> Além dos campos específicos desta skill, gere SEMPRE:
+>
+> - `summary_headline` — manchete em 1 linha com o veredito
+> - `summary_highlights` — 4-6 KPIs categorizados (`posicao|competicao|janela|maturidade|oportunidade|risco`) com `{label, value, subtext, tone}`
+> - `summary_key_findings` — 3-5 achados categorizados (`vantagem|contexto|ameaca|acao`)
+> - `honesty_alert` se houver fragilidade
+>
+> Identifique o **ponto de alavancagem** desta skill (o bloco que merece hero visual) e estruture-o com headline + contexto + razões numeradas + discussion anchor.
+>
+> Consulte `references/padrao-output.md` para especificação completa.
+
+E na auto-validação:
+
+> - [ ] Tem `summary_headline` específico (não "análise concluída")?
+> - [ ] `summary_highlights` tem 4-6 itens com categorias válidas?
+> - [ ] `summary_key_findings` cobre pelo menos 3 dos 4 tipos (vantagem/contexto/ameaça/ação)?
+> - [ ] Identificou o ponto de alavancagem para discussão com stakeholder?
+> - [ ] Se há fragilidade, incluiu `honesty_alert`?
+
+---
+
+## Completude (regra crítica)
+
+**Todo campo definido no schema da skill é obrigatório no output.** Não omitir campos — o renderer assume que os campos do schema existem e quebra/fica vazio silenciosamente quando faltam.
+
+Se um dado **não pode ser obtido** (GA4 não instalado, conector não conectado, cliente não sabe, etc.), preencher com `null` E adicionar `unavailable_reason` no objeto pai:
+
+```json
+{
+  "current_conversion_rate": null,
+  "current_bounce_rate": null,
+  "avg_time_on_page": null,
+  "unavailable_reason": "GA4 não instalado no site — métricas de analytics não coletadas nesta auditoria"
+}
+```
+
+Para arrays vazios legitimamente (ex: nenhum competidor identificado), preencher com `[]` e adicionar uma nota no campo irmão `{campo}_note`:
+
+```json
+{
+  "competitors": [],
+  "competitors_note": "Nenhum concorrente direto identificado na microrregião após busca em Google Maps + Instagram."
+}
+```
+
+Para valores **estimados** (sem fonte pública), adicionar flag `[E]` no texto OU campo `estimated: true` no objeto:
+
+```json
+{ "tam_brl": 450000000, "estimated": true, "estimation_basis": "IBGE população × SEBRAE ticket médio" }
+```
+
+**Nunca** deixar string vazia (`""`), zero falso (`0` quando não é zero real), ou omitir o campo. Essas três formas são invisíveis para o renderer e geram o bug "coluna vazia".
+
+Valide o JSON contra o `schema.json` empacotado na skill e corrija campos ausentes ou `null` sem `unavailable_reason`.
+
+### Checklist adicional de auto-validação
+
+> - [ ] Todos os campos do schema estão presentes (preenchidos ou com `null` + `unavailable_reason`)?
+> - [ ] Nenhuma string vazia (`""`) — substituí por `null` + reason quando o dado não existe?
+> - [ ] Arrays vazios legítimos têm `{campo}_note` explicando por quê?
+> - [ ] Estimativas marcadas com `estimated: true` ou `[E]`?
+
+---
+
+## Tons de voz
+
+- `green` — oportunidade/vantagem/confirmado
+- `yellow` — atenção/potencial/médio
+- `red` — risco/ameaça/fraco
+- `blue` — contexto/informativo/neutro
+- `gray` — desativado/aspiracional/ausente
+
+Usar tons consistentemente: nunca pintar ameaça de verde ou vantagem de vermelho para "chamar atenção". O tom é semântico.
+
+---

--- a/.claude/skills/gt-diagnostico-maturidade-digital/references/scoring-framework.md
+++ b/.claude/skills/gt-diagnostico-maturidade-digital/references/scoring-framework.md
@@ -1,0 +1,232 @@
+# Framework de Scoring — Maturidade Digital
+
+## Visao Geral
+
+O score de maturidade digital avalia 5 pilares do marketing digital de um negocio. Cada pilar e pontuado de 0 a 100, e o score geral e a media ponderada.
+
+### Pesos dos Pilares
+
+| Pilar | Peso | Justificativa |
+|-------|------|---------------|
+| Midia Paga | 25% | Principal alavanca de resultado de curto prazo |
+| Criativos | 20% | Qualidade dos criativos impacta diretamente CPA e CTR |
+| CRO (Conversao) | 25% | De nada adianta trazer trafego se nao converte |
+| CRM | 15% | Retenção e reativação — receita recorrente |
+| SEO | 15% | Aquisição orgânica e autoridade de longo prazo |
+
+### Classificacoes
+
+| Score | Classificação | Significado |
+|-------|---------------|-------------|
+| 0-20 | Crítico | Praticamente inexistente ou completamente disfuncional. Ação imediata necessária. |
+| 21-40 | Baixo | Existe mas com gaps severos. Muitas oportunidades de melhoria básica. |
+| 41-60 | Médio | Funcional mas sem otimização. Concorrentes provavelmente estão melhor. |
+| 61-80 | Bom | Acima da média. Otimizações incrementais podem acelerar resultado. |
+| 81-100 | Excelente | Best-in-class. Manter e inovar. |
+
+---
+
+## Pilar 1: Midia Paga (Peso 25%)
+
+### Critérios de Avaliação
+
+| Critério | Peso no pilar | 0-20 (Crítico) | 21-40 (Baixo) | 41-60 (Médio) | 61-80 (Bom) | 81-100 (Excelente) |
+|----------|---------------|-----------------|----------------|----------------|--------------|---------------------|
+| Estrutura de conta | 15% | Sem conta ou conta bagunçada | Conta existe mas campanhas desorganizadas | Estrutura básica (1-2 campanhas por objetivo) | Estrutura por funil (topo/meio/fundo) | Estrutura granular com testes A/B contínuos |
+| Pixel/Tag | 15% | Sem pixel instalado | Pixel instalado mas sem eventos | Eventos básicos (PageView, Lead) | Eventos customizados + conversões offline | Tracking completo + server-side + CAPI |
+| Segmentação | 20% | Público amplo sem critério | Interesses básicos | Lookalike + custom audiences | Lookalike por valor + retargeting por etapa | Segmentação dinâmica + exclusões inteligentes |
+| Criativos em mídia | 15% | Sem criativos ou 1 criativo rodando há meses | 2-3 criativos sem variação | 5+ criativos com alguma variação | Testes A/B regulares (semanal) | Framework criativo com iteração contínua |
+| Budget allocation | 15% | Sem critério / "R$X por dia" | Baseado em feeling | Baseado em CPA meta | Alocação dinâmica por ROAS | Alocação por margem de contribuição |
+| Performance (ROAS/CPA) | 20% | CPA 5x+ acima da meta | CPA 2-5x acima | CPA até 2x acima | CPA na meta | CPA abaixo da meta com escala |
+
+### Benchmarks por Segmento — Mídia Paga
+
+| Segmento | Score médio | CPA referência | ROAS referência |
+|----------|-------------|----------------|-----------------|
+| E-commerce moda | 52 | R$25-45 | 4-8x |
+| E-commerce geral | 48 | R$20-60 | 3-6x |
+| Saúde/estética | 38 | R$30-80 | 3-5x |
+| Educação (cursos) | 45 | R$15-40 | 5-12x |
+| SaaS | 42 | R$50-200 | 4-10x |
+| Serviços locais | 35 | R$20-50 | N/A (lead) |
+| Imobiliário | 40 | R$80-300 | N/A (lead) |
+| Alimentação/restaurante | 32 | R$10-30 | 2-5x |
+| Varejo físico | 30 | R$15-40 | 3-7x |
+| B2B serviços | 38 | R$100-500 | N/A (lead) |
+| Advocacia | 35 | R$50-150 | N/A (lead) |
+
+---
+
+## Pilar 2: Criativos (Peso 20%)
+
+### Critérios de Avaliação
+
+| Critério | Peso no pilar | 0-20 (Crítico) | 21-40 (Baixo) | 41-60 (Médio) | 61-80 (Bom) | 81-100 (Excelente) |
+|----------|---------------|-----------------|----------------|----------------|--------------|---------------------|
+| Volume | 20% | 0-1 criativo ativo | 2-3 criativos | 4-8 criativos | 9-15 criativos | 15+ com rotação ativa |
+| Variedade de formatos | 20% | Só imagem estática | Imagem + carrossel | Imagem + vídeo curto | Múltiplos formatos + UGC | Full-stack (estático, vídeo, UGC, animação, catálogo) |
+| Qualidade visual | 20% | Amador / genérico Canva | Visual básico, sem identidade | Identidade visual presente | Identidade forte e consistente | Premium, para scroll, diferenciado |
+| Copy | 20% | Sem copy ou genérica | Copy básica sem hook | Hook + benefício | Hook + benefício + prova social + CTA | Framework de copy com variações A/B |
+| Renovação | 20% | Mesmo criativo há 3+ meses | Troca a cada 2-3 meses | Troca mensal | Troca semanal | Iteração contínua com dados |
+
+### Benchmarks por Segmento — Criativos
+
+| Segmento | Score médio | Volume típico | Formato dominante |
+|----------|-------------|---------------|-------------------|
+| E-commerce moda | 55 | 10-20 | Carrossel + vídeo curto |
+| Saúde/estética | 40 | 3-8 | Antes/depois + depoimento |
+| Educação | 50 | 8-15 | Vídeo longo + headline forte |
+| Serviços locais | 28 | 1-3 | Imagem estática |
+| B2B serviços | 32 | 2-5 | Imagem + texto longo |
+
+---
+
+## Pilar 3: CRO — Conversão (Peso 25%)
+
+### Critérios de Avaliação
+
+| Critério | Peso no pilar | 0-20 (Crítico) | 21-40 (Baixo) | 41-60 (Médio) | 61-80 (Bom) | 81-100 (Excelente) |
+|----------|---------------|-----------------|----------------|----------------|--------------|---------------------|
+| Proposta de valor | 20% | Não existe ou confusa | Existe mas genérica | Clara na homepage | Clara + diferenciada na primeira dobra | Testada e otimizada por conversão |
+| CTA principal | 15% | Sem CTA ou perdido | CTA existe mas fraco | CTA visível | CTA visível + urgência + benefício | Múltiplos CTAs contextuais por etapa |
+| Prova social | 15% | Nenhuma | Logo de clientes | Depoimentos genéricos | Depoimentos com nome + foto + resultado | Cases completos + rating + volume |
+| Velocidade/mobile | 15% | 5s+ de load / quebra no mobile | 3-5s / funciona no mobile | 2-3s / responsivo | <2s / mobile-first | <1.5s / PWA ou experience nativa |
+| Formulário/conversão | 15% | Sem formulário ou WhatsApp quebrado | Formulário básico no rodapé | Formulário acima da dobra | Formulário otimizado + poucos campos | Multi-step + lead scoring + automação |
+| Objeções | 10% | Não trata objeções | FAQ básico | FAQ + garantia | Tratamento de objeções ao longo da página | Prova social contextual + FAQ + chat + garantia |
+| Tracking | 10% | Sem Analytics | GA4 básico | GA4 + eventos de conversão | GA4 + funil completo + heatmap | Full tracking + atribuição + testes A/B |
+
+### Benchmarks por Segmento — CRO
+
+| Segmento | Score médio | Taxa de conversão referência (site) |
+|----------|-------------|--------------------------------------|
+| E-commerce | 45 | 1.5-3% |
+| Lead gen (serviços) | 38 | 3-8% |
+| Saúde/estética | 35 | 2-5% |
+| Educação (LP curso) | 50 | 5-15% |
+| SaaS (trial) | 42 | 2-7% |
+| Imobiliário | 32 | 1-3% |
+
+---
+
+## Pilar 4: CRM (Peso 15%)
+
+### Critérios de Avaliação
+
+| Critério | Peso no pilar | 0-20 (Crítico) | 21-40 (Baixo) | 41-60 (Médio) | 61-80 (Bom) | 81-100 (Excelente) |
+|----------|---------------|-----------------|----------------|----------------|--------------|---------------------|
+| Ferramenta | 20% | Sem CRM (planilha/WhatsApp) | CRM básico sem uso | CRM usado parcialmente | CRM ativo com pipeline configurado | CRM integrado com automações |
+| Pipeline | 20% | Sem pipeline | Pipeline genérico (1 etapa) | Pipeline por funil (3-5 etapas) | Pipeline com SLA por etapa | Pipeline com scoring + rotação automática |
+| Automação | 20% | Nenhuma | Auto-resposta básica | Sequência de nurturing | Réguas multicanal (email + WhatsApp) | Automação contextual por comportamento |
+| Dados/Higiene | 20% | Sem dados ou dados sujos | Dados básicos (nome + telefone) | Dados completos + segmentação | Enriquecimento + limpeza periódica | CDP com visão 360 do cliente |
+| Métricas | 20% | Sem métricas | Sabe quantos leads entram | Taxa de conversão por etapa | LTV + churn + velocidade de pipeline | Dashboard em tempo real + predições |
+
+### Benchmarks por Segmento — CRM
+
+| Segmento | Score médio | Ferramenta típica |
+|----------|-------------|-------------------|
+| E-commerce | 35 | Plataforma nativa (Shopify, Nuvemshop) |
+| Serviços (saúde, educação) | 30 | Kommo, RD Station, ou planilha |
+| SaaS | 55 | HubSpot, Pipedrive |
+| Imobiliário | 40 | CRM específico (Anapro, CV) |
+| Varejo | 25 | Nenhum ou WhatsApp manual |
+
+---
+
+## Pilar 5: SEO (Peso 15%)
+
+### Critérios de Avaliação
+
+| Critério | Peso no pilar | 0-20 (Crítico) | 21-40 (Baixo) | 41-60 (Médio) | 61-80 (Bom) | 81-100 (Excelente) |
+|----------|---------------|-----------------|----------------|----------------|--------------|---------------------|
+| SEO técnico | 25% | Site sem HTTPS ou não indexado | Erros graves (404, canonical) | Técnico básico OK | Sitemap + robots + schema markup | Core Web Vitals verde + schema rico |
+| Conteúdo | 25% | Sem blog/conteúdo | Blog com 1-5 posts antigos | Blog ativo mas sem estratégia | Blog com palavras-chave mapeadas | Cluster de conteúdo + internal linking |
+| Autoridade | 20% | DA 0-10 / sem backlinks | DA 10-20 | DA 20-35 | DA 35-50 | DA 50+ com backlinks relevantes |
+| Local SEO | 15% | Sem GMB | GMB criado mas incompleto | GMB completo + fotos | GMB otimizado + reviews | GMB dominante + pack local |
+| Keywords | 15% | Não ranqueia para nada | Ranqueia para marca própria | Ranqueia para 5-10 termos | Ranqueia top 10 para termos relevantes | Domina 50+ keywords no nicho |
+
+### Benchmarks por Segmento — SEO
+
+| Segmento | Score médio | Importância relativa |
+|----------|-------------|---------------------|
+| E-commerce | 35 | Alta (tráfego orgânico escala) |
+| Serviços locais | 40 | Muito alta (GMB é decisivo) |
+| SaaS | 50 | Alta (conteúdo é canal principal) |
+| Saúde | 30 | Média-alta (busca por especialista) |
+| Educação | 45 | Alta (busca por curso) |
+| Restaurante | 38 | Alta (GMB + reviews) |
+
+---
+
+## Score Geral — Cálculo
+
+```
+score_geral = (midia_paga * 0.25) + (criativos * 0.20) + (cro * 0.25) + (crm * 0.15) + (seo * 0.15)
+```
+
+### Interpretação do Score Geral por Segmento
+
+| Segmento | Score médio geral | Faixa "normal" |
+|----------|-------------------|----------------|
+| E-commerce moda/geral | 42 | 30-55 |
+| Saúde/estética | 34 | 20-45 |
+| Educação | 46 | 35-60 |
+| SaaS | 45 | 30-60 |
+| Serviços locais | 32 | 20-45 |
+| Imobiliário | 36 | 25-50 |
+| Alimentação | 28 | 15-40 |
+| B2B serviços | 35 | 25-50 |
+| Advocacia | 30 | 18-42 |
+| Varejo físico | 30 | 18-42 |
+
+### Mensagem por Faixa
+
+**0-20 (Crítico):**
+"O negócio está praticamente invisível no digital. Cada dia sem ação é receita perdida. Prioridade: montar o básico (pixel, LP, CRM mínimo) e começar a rodar mídia com estrutura."
+
+**21-40 (Baixo):**
+"As peças existem mas estão desconectadas. Tem tráfego sem conversão, ou conversão sem follow-up, ou CRM sem dados. Prioridade: conectar os pontos e eliminar os vazamentos do funil."
+
+**41-60 (Médio):**
+"O digital funciona mas está no piloto automático. Concorrentes mais maduros estão capturando a demanda que você está deixando na mesa. Prioridade: otimizar o que já roda e atacar o pilar mais fraco."
+
+**61-80 (Bom):**
+"Acima da média do mercado. O digital já gera resultado. Prioridade: escalar o que funciona, testar canais novos, e automatizar para eficiência."
+
+**81-100 (Excelente):**
+"Best-in-class. Poucos concorrentes no seu setor estão neste nível. Prioridade: inovar (IA, personalização, omnichannel) e proteger a vantagem competitiva."
+
+---
+
+## Como usar quando NAO tem dados V4MOS
+
+Quando o operador não tem dados automáticos:
+
+1. Para cada pilar, faça 3-5 perguntas diretas ao operador
+2. Com base nas respostas, atribua um score estimado usando as faixas acima
+3. Marque o score como "(estimado)" no output
+4. Seja conservador: na dúvida, score para baixo. É melhor o cliente descobrir que está melhor do que pior
+5. Recomende conectar o V4MOS para scores automáticos nas skills de diagnóstico detalhado (semana 2)
+
+## Sinais de alerta por pilar
+
+### Sinais de que Mídia Paga é Crítica
+- Não sabe o CPA
+- Nunca ouviu falar de pixel/CAPI
+- "Deixa o Meta decidir tudo" (broad sem lookalalike)
+- Mesmo criativo há 3+ meses
+
+### Sinais de que CRO é Crítico
+- Site não tem HTTPS
+- CTA é "Entre em contato" no rodapé
+- Sem prova social nenhuma
+- Carrega em mais de 5s no mobile
+
+### Sinais de que CRM é Crítico
+- Leads vão pro WhatsApp pessoal e morrem lá
+- Não sabe quantos leads recebeu no último mês
+- "Responde quando dá"
+
+### Sinais de que SEO é Crítico
+- Não aparece no Google nem para o nome da empresa
+- Site sem SSL
+- GMB não reivindicado

--- a/.claude/skills/gt-diagnostico-maturidade-digital/schema.json
+++ b/.claude/skills/gt-diagnostico-maturidade-digital/schema.json
@@ -1,0 +1,358 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DiagnosticoMaturidade",
+  "description": "Output estruturado da skill diagnostico-maturidade: score por pilar, resumo executivo, prioridades e benchmark.",
+  "type": "object",
+  "required": [
+    "summary",
+    "overall_score",
+    "pillar_scores",
+    "executive_summary",
+    "priorities",
+    "sector_benchmark",
+    "client_name",
+    "summary_headline",
+    "summary_highlights",
+    "summary_key_findings"
+  ],
+  "properties": {
+    "client_name": {
+      "type": "string",
+      "description": "Nome do cliente — sempre presente em todo output."
+    },
+    "summary": {
+      "type": "string",
+      "description": "Resumo de 1-2 frases do diagnóstico. Usado como referência rápida por outras skills."
+    },
+    "summary_headline": {
+      "type": "string",
+      "maxLength": 200,
+      "description": "Manchete em 1 linha com o veredito desta skill (hero do resumo executivo no portal). Ver references/padrao-output.md"
+    },
+    "summary_highlights": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 8,
+      "description": "KPIs visuais categorizados para o resumo executivo. Cada item: {category, label, value, subtext, tone}.",
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "label",
+          "value"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "posicao",
+              "competicao",
+              "janela",
+              "maturidade",
+              "oportunidade",
+              "risco"
+            ]
+          },
+          "label": {
+            "type": "string",
+            "maxLength": 40
+          },
+          "value": {
+            "type": "string"
+          },
+          "subtext": {
+            "type": "string",
+            "maxLength": 80
+          },
+          "tone": {
+            "type": "string",
+            "enum": [
+              "green",
+              "yellow",
+              "red",
+              "blue",
+              "gray"
+            ]
+          }
+        }
+      }
+    },
+    "summary_key_findings": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 6,
+      "description": "Achados categorizados por intenção (vantagem/contexto/ameaça/ação). Pelo menos 3 dos 4 tipos cobertos.",
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "text"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "vantagem",
+              "contexto",
+              "ameaca",
+              "acao"
+            ]
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "data_source": {
+      "type": "string",
+      "enum": [
+        "v4mos",
+        "manual",
+        "mixed"
+      ],
+      "description": "De onde vieram os dados: V4MOS automático, coleta manual com operador, ou misto."
+    },
+    "overall_score": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 100,
+      "description": "Score geral de maturidade digital (média ponderada dos pilares)."
+    },
+    "overall_classification": {
+      "type": "string",
+      "enum": [
+        "critical",
+        "low",
+        "medium",
+        "good",
+        "excellent"
+      ],
+      "description": "Classificação textual do score geral."
+    },
+    "pillar_scores": {
+      "type": "array",
+      "minItems": 5,
+      "maxItems": 5,
+      "items": {
+        "type": "object",
+        "required": [
+          "pillar",
+          "score",
+          "classification",
+          "highlight"
+        ],
+        "properties": {
+          "pillar": {
+            "type": "string",
+            "enum": [
+              "midia_paga",
+              "criativos",
+              "cro",
+              "crm",
+              "seo"
+            ],
+            "description": "Nome do pilar."
+          },
+          "score": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 100,
+            "description": "Score do pilar (0-100)."
+          },
+          "classification": {
+            "type": "string",
+            "enum": [
+              "critical",
+              "low",
+              "medium",
+              "good",
+              "excellent"
+            ],
+            "description": "Classificação do pilar."
+          },
+          "highlight": {
+            "type": "string",
+            "description": "1 frase destacando o principal achado deste pilar."
+          },
+          "estimated": {
+            "type": "boolean",
+            "description": "Se true, o score foi estimado manualmente (sem dados V4MOS)."
+          },
+          "details": {
+            "type": "object",
+            "description": "Detalhes específicos por pilar.",
+            "properties": {
+              "strengths": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Pontos fortes identificados."
+              },
+              "weaknesses": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Pontos fracos identificados."
+              },
+              "metrics": {
+                "type": "object",
+                "description": "Métricas específicas do pilar (CPA, ROAS, taxa de conversão, etc.).",
+                "additionalProperties": true
+              }
+            }
+          }
+        }
+      },
+      "description": "Scores detalhados por pilar de maturidade."
+    },
+    "executive_summary": {
+      "type": "string",
+      "description": "Resumo executivo de 3 parágrafos: significado do score, top 2 gaps, top 2 forças."
+    },
+    "priorities": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 7,
+      "items": {
+        "type": "object",
+        "required": [
+          "rank",
+          "action",
+          "rationale",
+          "effort",
+          "pillar"
+        ],
+        "properties": {
+          "rank": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Posição na prioridade (1 = mais importante)."
+          },
+          "action": {
+            "type": "string",
+            "description": "Ação específica e acionável."
+          },
+          "rationale": {
+            "type": "string",
+            "description": "Por que é prioridade (impacto esperado)."
+          },
+          "effort": {
+            "type": "string",
+            "enum": [
+              "low",
+              "medium",
+              "high"
+            ],
+            "description": "Nível de esforço para implementar."
+          },
+          "pillar": {
+            "type": "string",
+            "description": "Qual pilar essa ação impacta."
+          },
+          "dependencies": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "O que precisa estar pronto antes."
+          }
+        }
+      },
+      "description": "Ações prioritárias ranqueadas por impacto."
+    },
+    "sector_benchmark": {
+      "type": "object",
+      "required": [
+        "sector",
+        "sector_average",
+        "comparison"
+      ],
+      "properties": {
+        "sector": {
+          "type": "string",
+          "description": "Segmento/setor do cliente para benchmark."
+        },
+        "sector_average": {
+          "type": "number",
+          "description": "Score médio do setor (referência)."
+        },
+        "comparison": {
+          "type": "string",
+          "enum": [
+            "above_average",
+            "at_average",
+            "below_average",
+            "significantly_below"
+          ],
+          "description": "Posição do cliente vs. média do setor."
+        },
+        "pillar_comparison": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "pillar": {
+                "type": "string"
+              },
+              "client_score": {
+                "type": "number"
+              },
+              "sector_average": {
+                "type": "number"
+              },
+              "gap": {
+                "type": "number"
+              },
+              "position": {
+                "type": "string",
+                "enum": [
+                  "above",
+                  "at",
+                  "below",
+                  "critical_gap"
+                ]
+              }
+            }
+          },
+          "description": "Comparação por pilar vs. média do setor."
+        },
+        "key_insight": {
+          "type": "string",
+          "description": "Insight principal da comparação com o setor."
+        }
+      }
+    },
+    "key_insight": {
+      "type": "object",
+      "description": "Ponto de alavancagem desta skill — o bloco que merece destaque visual para conversa com o stakeholder. Ver PADRAO-OUTPUT.md.",
+      "properties": {
+        "headline": {
+          "type": "string",
+          "description": "Frase-manchete do ponto (pode virar quote destacada no renderer)"
+        },
+        "context": {
+          "type": "string",
+          "description": "Contexto em 2-3 linhas explicando o cenário"
+        },
+        "numbered_reasons": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Razões numeradas (o renderer vira 3 cards numerados)"
+        },
+        "discussion_anchor": {
+          "type": "string",
+          "description": "Por que este é o ponto para stakeholder decidir/validar"
+        }
+      }
+    },
+    "honesty_alert": {
+      "type": "string",
+      "description": "Alerta se a análise revelou fragilidade real do cliente (não há diferencial claro, premissa contraditória, etc.). Nunca omitir se justificado."
+    }
+  }
+}

--- a/.claude/skills/gt-diagnostico-midia-paga/SKILL.md
+++ b/.claude/skills/gt-diagnostico-midia-paga/SKILL.md
@@ -1,0 +1,365 @@
+---
+name: gt-diagnostico-midia-paga
+description: "Diagnostico de midia paga: metricas atuais vs benchmarks, top 3 problemas e plano de acao 30 dias. Puxa dados reais do V4MOS (MediaInvestment). Use quando o operador disser /gt-diagnostico-midia-paga ou 'analisar midia paga' ou 'diagnostico de ads' ou 'como esta a conta de anuncios'."
+area: gt
+author: luizfreitasv4
+version: 1.0.0
+dependencies:
+  - geral-persona-icp
+tools: []
+week: 2
+estimated_time: "3h"
+output_file: "gt-diagnostico-midia-paga.json"
+v4mos_data: true
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta versao foi portada do sistema de Estruturacao Estrategica. As regras abaixo tem precedencia sobre caminhos e persistencia citados no fluxo original:
+
+- Trabalhe somente em `squads/{squad}/clientes/{cliente}/`, nunca em um diretorio `clientes/` solto na raiz.
+- Leia primeiro o `CLAUDE.md` ou `AGENTS.md` da KB, `mission-control/`, `calls/`, `docs/` e `campanhas/`.
+- Se `client.json` existir, use-o como fonte complementar. Se nao existir, derive o contexto da KB e do Mission Control; nao exija nem invente esse arquivo.
+- Salve entregaveis em `squads/{squad}/clientes/{cliente}/outputs/`, em JSON e Markdown quando o fluxo pedir ambos.
+- Registre decisoes e progresso no `mission-control/historico-checkins.md` ou no arquivo de historico equivalente encontrado na KB.
+- Resolva recursos empacotados a partir do proprio diretorio desta skill. Se uma integracao externa nao estiver configurada, declare o gap e continue apenas com os dados reais disponiveis.
+
+
+# Diagnostico de Midia Paga (POP 2.1)
+
+Voce e um especialista em midia paga com foco em performance para PMEs brasileiras. Vai analisar a conta de midia do cliente, comparar com benchmarks do setor, e gerar um plano de acao prioritizado.
+
+> **Posição no fluxo:** Semana 2 — comum a todos os modelos. Pull de 90 dias, CAC/CPL/ROAS vs benchmark, diagnóstico campanha a campanha, plano de 30 dias e cenários de realocação. Alimenta o forecast (POP 3.12).
+
+**DIFERENCIAL V4MOS:** Se o cliente tem workspace ativo no V4MOS, voce puxa dados REAIS de MediaInvestment via API. Isso e ouro — a maioria das ferramentas so trabalha com dados que o operador exporta manualmente.
+
+## Dados necessários
+
+1. Leia `client.json` (seção `briefing`) — extraia: NOME_CLIENTE, SEGMENTO, BUDGET_MENSAL, OBJETIVO_MIDIA
+2. Leia `outputs/geral-persona-icp.json` — extraia: RESUMO_ICP, canais preferenciais do ICP
+3. Verifique `client.json` (seção `connectors`):
+   - Se `connectors.fetched_at` não é null: use os dados de `google_ads` e `facebook_ads` já salvos
+   - Se `connectors.fetched_at` é null: use `/v4mos-dados-meta-ads` para Meta Ads e os dados reais disponíveis na KB para Google Ads
+   - Se não há `workspace_id` no client.json: peça dados ao operador (exportação manual dos últimos 90 dias)
+
+   **Estrutura dos dados V4MOS em connectors (atualizada — agregações temporais e por dimensão):**
+   - `connectors.google_ads.campaigns[]` → {name, type, status, cost, clicks, impressions, conversions, ctr, cpa}
+   - `connectors.google_ads.monthly_evolution[]` → {month, cost, clicks, impressions, conversions, ctr, cpa} — **use direto em `google_ads.monthly_evolution`**
+   - `connectors.google_ads.day_of_week[]` → {day, clicks, impressions, cost, pct, ctr} — ordem Seg→Dom
+   - `connectors.google_ads.gender_breakdown[]` → {gender, clicks, cost, pct_clicks, ctr, cpa}
+   - `connectors.google_ads.top_keywords[]` → {keyword, match_type, clicks, impressions, ctr, cost, cpc, cpa, conversions}
+   - `connectors.facebook_ads.campaigns[]` → {name, objective, spend, impressions, clicks, reach, cpm, ctr}
+   - `connectors.facebook_ads.monthly_evolution[]` → {month, spend, impressions, clicks, reach, cpm, ctr}
+   - `connectors.facebook_ads.creatives[]` → {ad_id, ad_name, spend, impressions, clicks, ctr, cpc, cpm, reach, object_type, thumbnail_url, instagram_permalink_url, ad_created_time, ...}
+   - `connectors.period` → {start, end} — período dos dados (normalmente 90 dias)
+
+   **IMPORTANTE — evite a armadilha de totais inflados:** o endpoint V4MOS `facebook/ads/campaigns` (e potencialmente outros) **ignora** o filtro de data `createdStart/createdEnd` e retorna histórico completo. O script `v4mos_fetch.sh` agora filtra por `segments_date`/`date_start` no Python — portanto os totais em `connectors.*.total_*` refletem o período real. Não some campanhas brutas por conta própria sem filtrar data.
+
+   **API V4MOS (para referência, se precisar buscar manualmente):**
+   ```bash
+   # workspaceId é QUERY PARAMETER — não path
+   curl -s "https://api.data.v4.marketing/v1/google/ads/campaigns?workspaceId={WORKSPACE_ID}&limit=500" \
+     -H "x-client-id: {CLIENT_ID}" -H "x-client-secret: {CLIENT_SECRET}"
+   curl -s "https://api.data.v4.marketing/v1/facebook/ads/campaigns?workspaceId={WORKSPACE_ID}&limit=500" \
+     -H "x-client-id: {CLIENT_ID}" -H "x-client-secret: {CLIENT_SECRET}"
+   ```
+   Nunca exponha credenciais. Se a integração não estiver configurada, peça uma exportação dos últimos 90 dias.
+
+### Se o cliente NAO investe em midia
+
+Se nao ha dados de midia paga (nem no V4MOS, nem exportacao):
+
+> Este cliente ainda nao investe em midia paga. Em vez de diagnostico, vou gerar um **plano de lancamento** de midia alinhado ao ICP e posicionamento. Posso seguir?
+
+Se sim, adapte a geração para plano de lancamento (estrutura de campanhas, budget recomendado, publicos iniciais, criativos prioritarios).
+
+---
+
+## Geração
+
+Gere o output COMPLETO de uma vez usando os dados de `client.json` (briefing, connectors) e outputs de skills dependentes em `outputs/`.
+
+Consulte `references/benchmarks-por-setor.md` para os benchmarks do segmento.
+
+### Dados de mídia e status de integração
+
+Apresente fonte dos dados, período, budget, integrações V4MOS e métricas atuais (CPL, CTR, taxa de conversão LP, ROAS, CPC). Liste dados faltantes.
+
+Se algum dado crítico estiver faltando, pergunte ao operador de uma vez.
+
+### Blocos `google_ads` e `meta_ads` — obrigatórios (por canal)
+
+O portal renderiza cada canal em uma seção separada, iniciando por um **bloco de abertura** com 4 cards + 1 card "Resumo Executivo". Gere os dois objetos top-level `google_ads` e `meta_ads` com os campos abaixo — o renderer NÃO inventa fallback, se o campo estiver ausente o card some.
+
+**`google_ads` — campos esperados:**
+```json
+{
+  "integration": "nome da conta no V4MOS",
+  "budget_monthly_declared": 2400,
+  "budget_monthly_actual": 1450.92,
+  "total_campaigns": 6,
+  "active_campaigns": 1,
+  "paused_campaigns": 5,
+  "status": "healthy_but_choked | subscale | healthy | critical | broken",
+  "score": 62,
+  "score_classification": "medium",
+  "total_spend_90d": 4352.77,
+  "total_clicks_90d": 1751,
+  "total_impressions_90d": 46491,
+  "total_conversions_90d": 300,
+  "avg_cpa": 14.51,
+  "avg_ctr": 3.77,
+  "strategic_diagnosis": "3-5 linhas. Veredito do canal: o que está acontecendo, por que acontece, qual é o destravamento. Usado no card Resumo Executivo.",
+  "active_campaign": { "name":"...", "type":"SEARCH", "status":"ENABLED", "cost_90d":..., "ctr":..., "cpa":..., "note":"..." },
+  "paused_campaigns_opportunity": [ {name,type,cost_90d,clicks,impressions,conversions,ctr,cpa,note} ],
+  "monthly_evolution": [ {month,cost,clicks,impressions,conversions,ctr,cpa} ],
+  "day_of_week": [ {day,clicks,impressions,cost,pct,ctr} ],
+  "gender_breakdown": [ {gender,clicks,cost,pct_clicks,ctr,cpa} ],
+  "top_keywords": [ {keyword,match_type,clicks,impressions,ctr,cost,cpc,cpa,conversions,insight?,tag?} ]
+}
+```
+
+**`meta_ads` — campos esperados:**
+```json
+{
+  "integration": "nome da conta no V4MOS",
+  "budget_monthly_declared": 800,
+  "budget_monthly_actual": 424.53,
+  "total_campaigns": 5,
+  "total_ads": 43,
+  "total_creatives": 43,
+  "status": "critical | subscale | healthy | broken",
+  "score": 38,
+  "score_classification": "medium_low",
+  "total_spend_90d": 1273.60,
+  "total_clicks_90d": 1442,
+  "total_impressions_90d": 112295,
+  "total_reach_90d": 71890,
+  "avg_ctr": 1.28,
+  "avg_cpm": 11.34,
+  "strategic_diagnosis": "3-5 linhas. Veredito do canal. Usado no card Resumo Executivo.",
+  "critical_issues": [ "marcador por linha, começa com ▲ implicitamente no render" ],
+  "top_5_ads_by_spend": [ {ad_name,campaign_context,spend,impressions,clicks,ctr,cpc,cpm,object_type,creative_id,note} ],
+  "icp_aligned_creatives": [ ... ],          // opcional — destaques temáticos alinhados ao ICP
+  "monthly_evolution": [ {month,spend,impressions,clicks,reach,cpm,ctr} ],
+  "creative_gallery": [ ... ],              // vem do connectors.facebook_ads.creatives, mas com verdict M/O/E por ad
+  "creative_gallery_summary": { total_displayed, total_ads, manter, otimizar, eliminar, note }
+}
+```
+
+**COMO O PORTAL RENDERIZA O BLOCO DE ABERTURA (Google e Meta):**
+1. **4 cards** com cores semáforo:
+   - Google: Investido 90d · CTR médio · CPA médio · Conversões 90d
+   - Meta: Investido 90d · CTR médio · CPM médio · Alcance 90d (fallback: Clicks 90d)
+2. **Linha de stats secundárias** (muted): Média mensal · Clicks · Impressões · Ads/Campanhas
+3. **Card "Resumo Executivo"** com o texto de `strategic_diagnosis` (use este campo para a narrativa do canal — não é local para sinônimo do `summary` global, é o veredito específico de Google OU Meta).
+
+Se `strategic_diagnosis` estiver ausente, o card some. Sempre preencha.
+
+### Métricas vs benchmarks por segmento
+
+| Metrica | Atual | Benchmark setor | Status | Gap |
+|---------|-------|-----------------|--------|-----|
+| CPL | R$ {atual} | R$ {bench} | {acima/abaixo/ok} | {%} |
+| CTR | {atual}% | {bench}% | ... | ... |
+| Conv. LP | {atual}% | {bench}% | ... | ... |
+| ROAS | {atual}x | {bench}x | ... | ... |
+| CPC | R$ {atual} | R$ {bench} | ... | ... |
+
+Legenda: 🔴 Critico (>50% abaixo) | 🟡 Atencao (20-50% abaixo) | 🟢 Saudavel
+
+### Diagnóstico por dimensão
+
+**ESTRUTURA DE CONTA:** organização, segmentação, budget allocation
+**CRIATIVOS:** ativos, melhor/pior performance, teste A/B, frequência
+**PÁGINAS DE DESTINO:** LPs usadas, coerência, taxa de rejeição
+**PÚBLICOS:** tipos usados, sobreposição, retargeting
+
+### Top 3 problemas críticos
+
+Para cada: título, evidência nos dados, impacto estimado, dimensão afetada.
+
+### Plano de ação — 30 dias
+
+| # | Acao | Prioridade | Impacto esperado | Responsavel | Prazo |
+|---|------|-----------|------------------|-------------|-------|
+
+### Keyword Clusters (OBRIGATÓRIO — search)
+
+Não trate keywords como lista única. Agrupe em 4-6 clusters estratégicos. Para cada:
+- `cluster`: nome (ex: "Marca", "Produto/Serviço", "Localização", "Genéricas")
+- `keywords`: exemplos (5-15) — keywords ATUALMENTE EM USO no cluster
+- `intent`: navegacional | informacional | transacional | comercial
+- `budget_allocation_pct`: % do budget de search para esse cluster
+- `expected_cpc_range`: faixa esperada (R$)
+- `bid_strategy`: estratégia (máx. conv., CPA alvo, manual)
+- `copy_angle`: ângulo da copy para esse cluster
+- `risk`: principal risco (ex: concorrência alta, baixa intenção, canibalização)
+- `opportunity_keywords`: **opcional mas RECOMENDADO** — lista de keywords relevantes para o ICP que o cliente NÃO usa hoje. Itens `{keyword, intent?, volume_estimate?|search_volume_monthly?, expected_cpc?|cpc_range?, rationale}`. Base: compare `google_ads.top_keywords` (ativas) contra ICP + segmento + concorrentes. O portal renderiza uma tabela "Keywords Relevantes Não Utilizadas Hoje — Oportunidades" agregando estes campos de todos os clusters.
+
+Alternativa: gere `opportunity_keywords` como array top-level (fora dos clusters) no formato `[{keyword, cluster, intent, volume_estimate, expected_cpc, rationale}]` — o renderer aceita ambos.
+
+### Budget Reallocation Scenarios (OBRIGATÓRIO — 3 cenários)
+
+Não entregue apenas uma recomendação de budget — gere 3 cenários para o operador escolher.
+- **A. Conservador:** mantém budget atual, reorganiza mix
+- **B. Realista (RECOMENDADO):** reorganização + leve aumento, mapeamento de campanhas — o renderer marca automaticamente o cenário do meio como "★ Recomendado"
+- **C. Agressivo:** aumento significativo para buscar teto de demanda
+
+Para cada cenário, gere os seguintes campos (os nomes **preferidos** são os primeiros; alternativas são aceitas pelo renderer):
+
+**Obrigatórios / estruturais:**
+- `name` (pref) ou `label` — nome do cenário
+- `total_budget_monthly` — budget total mensal. Se ausente, o renderer soma automaticamente os splits.
+- `google_split` (pref) ou `google_allocation{value|amount|brl, pct}` — valor em R$ no Google
+- `meta_split` (pref) ou `meta_allocation{value|amount|brl, pct}` — valor em R$ no Meta
+- `expected_leads_monthly` (pref) ou `projected_leads_month` — leads/mês esperados
+- `expected_cpl` (pref) ou `projected_cpl` — CPL esperado em R$
+- `expected_roas` — ROAS esperado
+- `risk_assessment` — avaliação do risco
+
+**Opcionais (enriquecem o card do cenário):**
+- `delta_leads` — variação vs. atual (número ou "+15%")
+- `effort_weeks` — semanas para implementar
+- `confidence` — high/medium/low (ou alta/média/baixa)
+- `campaigns_structure[]` — lista de campanhas com {campaign, platform, budget_monthly, objective}
+
+> **COMO O PORTAL RENDERIZA:** Tabela side-by-side com cenários como colunas e métricas (Budget, Google, Meta, Leads/mês, CPL, ROAS) como linhas. Cada linha tem barras normalizadas por métrica para comparação visual. **Não existe mais gráfico de barras agrupadas com escalas mistas** — escolha os campos acima e o renderer formata o resto.
+
+### Creative Testing Hypotheses (OBRIGATÓRIO — 4-6 hipóteses)
+
+Cada hipótese é um teste A/B real, não uma ideia vaga. Para cada (H1, H2, ...):
+- `hypothesis`: afirmação testável ("Se X, então Y, porque Z")
+- `angle`: ângulo de comunicação
+- `format`: formato (single image, carousel, reels, VSL)
+- `hook`: primeiras 3 segundos / headline
+- `body`: copy principal
+- `cta`: call to action
+- `target_audience`: público específico
+- `success_criteria`: métrica + threshold (ex: "CTR > 1.5% E CPL < R$20")
+- `testing_budget`: R$ do teste
+- `testing_duration_days`: dias
+
+Feche com `testing_budget_total_week_1`.
+
+### Daypart Optimization (OBRIGATÓRIO)
+
+Não basta "rodar o dia todo". Proponha ajustes de lance por dia/hora baseados no comportamento da persona. Para cada ajuste:
+- `day_time`: janela (ex: "Segunda-Sexta 9-12h", "Sábado 10-18h", "Domingo")
+- `bid_adjustment_pct`: +X% ou -X%
+- `rationale`: por que (dado de comportamento, padrão do segmento)
+
+### Forecast Sensitivity Analysis (opcional)
+
+**Status:** Não é mais obrigatório. O portal suporta o bloco mas ele é dispensável — `honesty_alert` e `realistic_goal_90d.alert` cobrem os riscos principais. Gere apenas se:
+- O caso tem múltiplas variáveis interdependentes que mudam significativamente o forecast, ou
+- O operador pede explicitamente o what-if.
+
+Se gerar, use a estrutura:
+- `base_case`: meta central com `leads_monthly`, `cpl`, `cac`, `revenue_monthly`, `roas`.
+- `variations`: 4-6 cenários "what-if" `{scenario, variable_change, impact_on_leads, impact_on_cpl, impact_on_revenue, delta_vs_base_pct}`.
+
+O renderer exibe apenas os cards (sem gráfico).
+
+### Meta realista — 90 dias
+
+Gere `realistic_goal_90d` com os seguintes campos (o portal renderiza 4 cards + card "Premissas"):
+- `current_cpl`, `target_cpl` — CPL atual e alvo em R$
+- `current_cac`, `target_cac` — CAC atual e alvo em R$
+- `current_leads_month`, `target_leads_month` — volume de leads atual e alvo
+- `current_agendamentos_month`, `target_agendamentos_month` — opcional, se a skill de posicionamento define funil lead→agendamento
+- `premissas`: lista de 3-6 premissas concretas (ex: "LP do produto principal no ar na Semana 3")
+
+**NÃO gere** o campo `alert` em `realistic_goal_90d` — o portal não renderiza mais essa caixa. Se há risco de prazo/acesso/budget, inclua em `honesty_alert` (global) ou como premissa condicional.
+
+Gere também `realistic_goal` com `target_cpl`, `target_roas`, `justification`, `assumptions`, `risk_factors` — usado como texto de apoio.
+
+### Estrutura visual (obrigatória)
+
+Siga o padrão canônico de `references/padrao-output.md`. Além dos campos acima, SEMPRE inclua:
+
+- **`summary_headline`** (max 200 char) — manchete com o veredito. Ex: "CPL atual (R$ 85) está 40% acima do benchmark — realocação B recupera R$ 12K/mês sem subir orçamento."
+- **`summary_highlights`** (4-6 itens, `{category, label, value, subtext, tone}`) — para diagnóstico de mídia sugestões:
+  - `posicao`: CPL atual vs benchmark, leads/mês, CAC, ROAS
+  - `oportunidade`: cenário de realocação com maior upside, economia projetada
+  - `risco`: plataforma/campanha queimando verba sem retorno
+  - `janela`: tempo de ramp-up para estabilizar CPL alvo
+- **`summary_key_findings`** (3-5 itens, `{category, text}`) — `vantagem|contexto|ameaca|acao`.
+
+### Ponto de alavancagem
+
+Em diagnóstico de mídia, o ponto de alavancagem é o **canal/campanha com maior gap entre performance atual e potencial** — tipicamente o cenário de realocação recomendado + hipótese criativa principal. Estruture em `key_insight`:
+```json
+"key_insight": {
+  "headline": "Frase sobre o destravamento (ex: 'Cortar Performance Max e dobrar Search Branded baixa CPL em 35%')",
+  "context": "2-3 linhas sobre por que o desperdício acontece e o caminho",
+  "numbered_reasons": ["(1) evidência do gap", "(2) causa-raiz (estrutura/copy/segmentação)", "(3) upside projetado"],
+  "discussion_anchor": "Por que o stakeholder precisa aprovar a realocação antes do próximo ciclo"
+}
+```
+
+Se os dados são insuficientes (menos de 60 dias, tracking quebrado) ou o orçamento é incompatível com o objetivo, inclua `honesty_alert`.
+
+## Auto-validação
+
+Antes de mostrar ao operador, verifique:
+
+- [ ] Mencionou o cliente pelo nome?
+- [ ] Usou dados reais do client.json (não inventou)?
+- [ ] Nenhum item genérico (ex: "quer crescer", "qualidade e compromisso")?
+- [ ] Schema da skill validou?
+- [ ] Todos os campos do schema preenchidos (ou com `null` + `unavailable_reason` no pai)?
+- [ ] Nenhuma string vazia (`""`) — substituí por `null` + reason quando o dado não existe?
+- [ ] Estimativas marcadas com `estimated: true` ou `[E]`?
+- [ ] Consistente com outputs anteriores (ICP)?
+- [ ] Benchmarks são do segmento correto do cliente?
+- [ ] Plano de ação tem responsáveis e prazos realistas?
+- [ ] Meta de 90 dias é honesta (não promessa mágica)?
+- [ ] `google_ads` tem total_spend_90d, avg_ctr, avg_cpa, total_conversions_90d E `strategic_diagnosis` preenchido (3-5 linhas)?
+- [ ] `meta_ads` tem total_spend_90d, avg_ctr, avg_cpm, total_reach_90d E `strategic_diagnosis` preenchido (3-5 linhas)?
+- [ ] Totais 90d de google_ads e meta_ads BATEM com `connectors.google_ads.total_cost` e `connectors.facebook_ads.total_spend` (V4MOS filtrado)?
+- [ ] `budget_monthly_actual` por canal é `total_spend_90d / 3` (cliente pode estar subinvestindo — flag isso se delta vs declarado > 20%)?
+- [ ] `keyword_clusters` (search) tem 4-6 clusters com intent, budget %, copy angle e risco?
+- [ ] Pelo menos 1 cluster tem `opportunity_keywords[]` (keywords relevantes para o ICP NÃO ativas hoje)?
+- [ ] `budget_reallocation_scenarios` tem 3 cenários (A/B/C) com estrutura de campanhas e projeção?
+- [ ] `creative_testing_hypotheses` tem 4-6 hipóteses testáveis com success_criteria numérico e budget?
+- [ ] `daypart_optimization` traz ajustes específicos por janela com rationale?
+- [ ] `forecast_sensitivity_analysis` (opcional) — se gerar, tem base_case + 4-6 variações?
+- [ ] Tem `summary_headline` específico?
+- [ ] `summary_highlights` tem 4-6 itens com categorias e tons válidos?
+- [ ] `summary_key_findings` cobre pelo menos 3 dos 4 tipos?
+- [ ] Identificou `key_insight` (realocação/hipótese com maior upside)?
+- [ ] Se há limitação de dados/orçamento, incluiu `honesty_alert`?
+
+Se falhou → regenere silenciosamente. Não avise o operador.
+
+## Apresentação e decisões
+
+Apresente o output COMPLETO ao operador.
+
+Revise o output. O que está errado, exagerado ou faltando?
+
+- "Os benchmarks fazem sentido para a realidade deste cliente especifico? Algum contexto que mude a leitura?"
+- "O plano de acao e executavel na realidade deste cliente? Alguma acao que depende de algo que nao temos?"
+- "A meta de 90 dias parece realista?"
+
+## Finalização
+
+Operador aprova (com ou sem ajustes).
+1. Salve em `squads/{squad}/clientes/{cliente}/outputs/gt-diagnostico-midia-paga.json` (com campo `summary` no topo)
+2. Atualize `client.json`: progress.skills → completed, version++, append em history[]
+3. Salve também uma versão Markdown do entregável na mesma pasta de outputs.
+4. Sugira próxima skill do dependency_graph
+   - "Diagnóstico concluído. CPL atual: R$ {atual} → Meta 90d: R$ {meta}. Problemas críticos: {numero}."
+   - "Este diagnostico alimenta: /gt-forecast-midia, /copy-anuncios, /designer-criativos-anuncios"
+   - "Proximo passo recomendado: /gt-diagnostico-criativos"
+
+
+## Campo obrigatório: summary
+
+Sempre inclua no JSON de saída:
+```json
+"summary": "Resumo de 1-2 frases do diagnóstico de mídia: principal problema e ROAS atual vs benchmark. Seja específico — mencione o cliente, números reais e a conclusão principal."
+```
+
+Este campo alimenta o Resumo Executivo do portal de entregas. Deve ser objetivo, com dados reais, sem genéricos.

--- a/.claude/skills/gt-diagnostico-midia-paga/references/benchmarks-por-setor.md
+++ b/.claude/skills/gt-diagnostico-midia-paga/references/benchmarks-por-setor.md
@@ -1,0 +1,196 @@
+# Benchmarks de Midia Paga por Setor — PMEs Brasileiras
+
+## Como usar estes benchmarks
+
+Estes benchmarks sao REFERENCIAS baseadas em medias de mercado para PMEs brasileiras. Use-os como ponto de partida para o diagnostico, nao como verdade absoluta.
+
+**Fatores que alteram benchmarks:**
+- Regiao (capital vs interior — CPL pode variar 2-3x)
+- Ticket medio do produto/servico (ticket alto = CPL aceitavel mais alto)
+- Maturidade digital do cliente (contas novas tem CPL mais alto)
+- Sazonalidade (Black Friday, volta as aulas, etc.)
+- Nivel de concorrencia local (mais concorrentes = CPC mais alto)
+
+**Fontes:** Dados agregados de agencias V4 Company (2024-2025), WordStream, HubSpot Latin America, RD Station Benchmarks, Resultados Digitais.
+
+---
+
+## Benchmarks por setor
+
+### 1. Odontologia / Clinicas Dentarias
+
+| Metrica | Benchmark | Range aceitavel |
+|---------|-----------|-----------------|
+| CPL (Meta Ads) | R$ 15-30 | R$ 10-45 |
+| CPL (Google Ads) | R$ 25-50 | R$ 15-70 |
+| CTR (Meta Ads) | 1.2-2.0% | 0.8-3.0% |
+| CTR (Google Search) | 3.5-6.0% | 2.5-8.0% |
+| Conv. LP | 8-15% | 5-25% |
+| CPC (Meta) | R$ 1.50-3.00 | R$ 0.80-4.50 |
+| CPC (Google) | R$ 3.00-6.00 | R$ 2.00-10.00 |
+
+**Observacoes:** Implantes e ortodontia tem CPL mais alto (R$ 40-80). Limpeza e clareamento tem CPL mais baixo (R$ 8-20). Google Ads geralmente entrega leads mais qualificados (busca ativa).
+
+### 2. Clinicas de Estetica / Beleza
+
+| Metrica | Benchmark | Range aceitavel |
+|---------|-----------|-----------------|
+| CPL (Meta Ads) | R$ 8-20 | R$ 5-35 |
+| CPL (Google Ads) | R$ 20-40 | R$ 12-55 |
+| CTR (Meta Ads) | 1.5-2.5% | 1.0-4.0% |
+| CTR (Google Search) | 3.0-5.5% | 2.0-7.0% |
+| Conv. LP | 10-18% | 6-25% |
+| CPC (Meta) | R$ 1.00-2.50 | R$ 0.50-3.50 |
+| CPC (Google) | R$ 2.50-5.00 | R$ 1.50-8.00 |
+
+**Observacoes:** Harmonizacao facial gera muito lead frio. Filtragem por WhatsApp e essencial. Video criativos performam 2-3x melhor que estaticos neste setor.
+
+### 3. Imobiliarias / Construtoras
+
+| Metrica | Benchmark | Range aceitavel |
+|---------|-----------|-----------------|
+| CPL (Meta Ads) | R$ 25-60 | R$ 15-100 |
+| CPL (Google Ads) | R$ 40-90 | R$ 25-150 |
+| CTR (Meta Ads) | 0.8-1.5% | 0.5-2.5% |
+| CTR (Google Search) | 2.5-5.0% | 1.5-7.0% |
+| Conv. LP | 3-8% | 2-12% |
+| CPC (Meta) | R$ 2.00-4.00 | R$ 1.00-6.00 |
+| CPC (Google) | R$ 5.00-12.00 | R$ 3.00-20.00 |
+
+**Observacoes:** CPL alto e aceitavel porque ticket e alto. ROAS e mais relevante que CPL. Imobiliarios tem ciclo de venda longo — considere atribuicao multi-touch.
+
+### 4. Restaurantes / Delivery / Alimentacao
+
+| Metrica | Benchmark | Range aceitavel |
+|---------|-----------|-----------------|
+| CPL (Meta Ads) | R$ 3-10 | R$ 2-15 |
+| CTR (Meta Ads) | 2.0-3.5% | 1.2-5.0% |
+| Conv. LP | 12-25% | 8-35% |
+| CPC (Meta) | R$ 0.50-1.50 | R$ 0.30-2.50 |
+| ROAS (delivery) | 4-8x | 3-12x |
+
+**Observacoes:** Funciona melhor com Meta Ads (impulso visual). Google Ads Local (Maps) e poderoso para presencial. Cupom de desconto funciona bem como conversao de primeiro pedido.
+
+### 5. Academias / Studios Fitness
+
+| Metrica | Benchmark | Range aceitavel |
+|---------|-----------|-----------------|
+| CPL (Meta Ads) | R$ 10-25 | R$ 6-40 |
+| CPL (Google Ads) | R$ 20-45 | R$ 12-60 |
+| CTR (Meta Ads) | 1.5-2.5% | 1.0-3.5% |
+| Conv. LP | 8-15% | 5-20% |
+| CPC (Meta) | R$ 1.00-2.00 | R$ 0.50-3.00 |
+
+**Observacoes:** Sazonalidade forte (janeiro, pos-carnaval). Oferta de "aula experimental gratis" converte bem. Video com transformacao real performa melhor que foto de equipamento.
+
+### 6. E-commerce / Varejo Online
+
+| Metrica | Benchmark | Range aceitavel |
+|---------|-----------|-----------------|
+| CPC (Meta Ads) | R$ 1.00-3.00 | R$ 0.50-5.00 |
+| CPC (Google Shopping) | R$ 0.80-2.50 | R$ 0.40-4.00 |
+| CTR (Meta Ads) | 1.0-2.0% | 0.6-3.0% |
+| CTR (Google Shopping) | 2.0-4.0% | 1.0-6.0% |
+| Conv. site | 1.5-3.0% | 0.8-5.0% |
+| ROAS (Meta) | 3-6x | 2-10x |
+| ROAS (Google) | 4-8x | 3-12x |
+| CAC | R$ 30-80 | R$ 15-120 |
+
+**Observacoes:** ROAS e a metrica mais importante. Google Shopping e obrigatorio. Retargeting geralmente tem ROAS 2-3x superior a cold traffic. LTV importa mais que CAC isolado.
+
+### 7. Advocacia / Servicos Juridicos
+
+| Metrica | Benchmark | Range aceitavel |
+|---------|-----------|-----------------|
+| CPL (Google Ads) | R$ 30-70 | R$ 20-100 |
+| CPL (Meta Ads) | R$ 15-40 | R$ 10-60 |
+| CTR (Google Search) | 3.0-6.0% | 2.0-8.0% |
+| Conv. LP | 5-12% | 3-18% |
+| CPC (Google) | R$ 5.00-15.00 | R$ 3.00-25.00 |
+
+**Observacoes:** Google Ads Search e o canal principal (busca ativa). Palavras-chave de urgencia ("advogado trabalhista urgente") tem CPL alto mas conversao melhor. Meta Ads funciona para educacao/awareness.
+
+### 8. Contabilidade / Servicos Financeiros
+
+| Metrica | Benchmark | Range aceitavel |
+|---------|-----------|-----------------|
+| CPL (Google Ads) | R$ 25-55 | R$ 15-80 |
+| CPL (Meta Ads) | R$ 12-30 | R$ 8-45 |
+| CTR (Google Search) | 2.5-5.0% | 1.5-7.0% |
+| Conv. LP | 6-12% | 4-18% |
+| CPC (Google) | R$ 3.00-8.00 | R$ 2.00-12.00 |
+
+**Observacoes:** Nicho e o diferencial. "Contabilidade para e-commerce" tem CPL menor que "contabilidade" generico. Conteudo educativo (planilha, calculadora) funciona como isca.
+
+### 9. Educacao / Cursos / Coaching
+
+| Metrica | Benchmark | Range aceitavel |
+|---------|-----------|-----------------|
+| CPL (Meta Ads) | R$ 5-20 | R$ 3-35 |
+| CPL (Google Ads) | R$ 15-40 | R$ 10-60 |
+| CTR (Meta Ads) | 1.5-3.0% | 1.0-4.5% |
+| Conv. LP | 10-20% | 6-30% |
+| CPC (Meta) | R$ 0.80-2.00 | R$ 0.40-3.00 |
+
+**Observacoes:** Webinar/aula gratis tem alta conversao para captura. Lead de "aula gratis" e frio — qualificacao via email/WhatsApp e essencial. Video longo (2-5min) funciona como criativo de topo.
+
+### 10. SaaS / Software B2B
+
+| Metrica | Benchmark | Range aceitavel |
+|---------|-----------|-----------------|
+| CPL (Google Ads) | R$ 50-120 | R$ 30-200 |
+| CPL (Meta Ads) | R$ 30-70 | R$ 20-100 |
+| CPL (LinkedIn Ads) | R$ 80-200 | R$ 50-350 |
+| CTR (Google Search) | 2.0-4.5% | 1.5-6.0% |
+| Conv. LP trial | 3-8% | 2-12% |
+| CPC (Google) | R$ 8.00-20.00 | R$ 5.00-35.00 |
+
+**Observacoes:** CPL alto e aceitavel se LTV justifica. Free trial ou demo gratis converte melhor que "fale com vendas". LinkedIn tem CPL alto mas qualidade de lead B2B superior.
+
+### 11. Pet Shops / Veterinarias
+
+| Metrica | Benchmark | Range aceitavel |
+|---------|-----------|-----------------|
+| CPL (Meta Ads) | R$ 5-15 | R$ 3-25 |
+| CTR (Meta Ads) | 2.0-3.5% | 1.2-5.0% |
+| Conv. LP | 10-20% | 6-30% |
+| CPC (Meta) | R$ 0.50-1.50 | R$ 0.30-2.50 |
+
+**Observacoes:** Fotos de pets reais do cliente performam muito melhor que stock. Google Local e poderoso para veterinarias (emergencia). Oferta de "primeiro banho gratis" converte bem.
+
+### 12. Construcao / Reformas / Home Services
+
+| Metrica | Benchmark | Range aceitavel |
+|---------|-----------|-----------------|
+| CPL (Google Ads) | R$ 20-50 | R$ 12-80 |
+| CPL (Meta Ads) | R$ 10-30 | R$ 6-45 |
+| CTR (Google Search) | 3.0-5.5% | 2.0-7.0% |
+| Conv. LP | 5-12% | 3-18% |
+| CPC (Google) | R$ 3.00-8.00 | R$ 2.00-12.00 |
+
+**Observacoes:** Antes/depois e o criativo mais poderoso. Google Ads Local converte bem (busca urgente). Orcamento gratis como CTA funciona melhor que "saiba mais".
+
+---
+
+## Como interpretar os benchmarks no diagnostico
+
+### Status por gap
+
+| Gap vs benchmark | Status | Acao |
+|---|---|---|
+| Dentro do range aceitavel | Saudavel | Monitorar, otimizar gradualmente |
+| 20-50% acima do benchmark | Atencao | Investigar causa, prioridade media |
+| >50% acima do benchmark | Critico | Acao imediata, prioridade alta |
+| Abaixo do benchmark | Excelente | Documentar o que funciona, escalar |
+
+### Meta realista de melhoria em 90 dias
+
+| Situacao atual | Meta realista |
+|---|---|
+| CPL 2x acima do benchmark | Reduzir 30-40% (atingir range aceitavel) |
+| CPL 3x+ acima do benchmark | Reduzir 50% (ainda pode estar acima do benchmark ideal) |
+| CTR abaixo de 0.5% | Dobrar (indicativo de criativo/segmentacao ruim) |
+| Conv. LP abaixo de 3% | Subir para 5-8% (landing page precisa de rebuild) |
+| Sem retargeting | Implementar retargeting = reducao de 15-25% no CPL |
+
+**ATENCAO:** Nunca prometa atingir o benchmark ideal em 90 dias se o cliente esta 3x acima. Melhoria de 30-50% e realista. Atingir benchmark leva 4-6 meses de otimizacao continua.

--- a/.claude/skills/gt-diagnostico-midia-paga/references/padrao-output.md
+++ b/.claude/skills/gt-diagnostico-midia-paga/references/padrao-output.md
@@ -1,0 +1,202 @@
+# Padrão de Output das Skills — V4 Estruturação IA
+
+Este documento define a **estrutura canônica** que todos os outputs de skill devem seguir para renderizar no portal com hierarquia visual consistente. O objetivo é que o operador e o stakeholder final abram qualquer entregável e encontrem o mesmo ritmo: manchete → KPIs → achados categorizados → ponto de alavancagem destacado → detalhes expansíveis.
+
+---
+
+## Princípios
+
+1. **Manchete antes de texto.** Toda skill abre com uma frase única e específica que resume a conclusão. Não é parágrafo, é headline.
+2. **Números em destaque, não escondidos no corpo do texto.** KPIs que importam viram cards. Texto corrido é para contexto, não para fato quantitativo.
+3. **Achados categorizados por intenção.** Cada insight é classificado como `vantagem | contexto | ameaca | acao` — o leitor identifica o tom antes de ler.
+4. **Ponto de alavancagem visualmente isolado.** Toda skill tem UM ponto onde a conversa com o stakeholder precisa acontecer. Esse ponto ganha hero visual (border, gradient, quote destacada).
+5. **Detalhe denso → colapsável.** Listas longas (concorrentes, itens de checklist, fontes) ficam em `<details>` para não afogar a leitura.
+
+---
+
+## Campos obrigatórios no JSON
+
+Todo output de skill DEVE ter estes campos no topo (antes dos campos específicos da skill):
+
+```json
+{
+  "client_name": "Nome do Cliente",
+  "summary": "Resumo em 1-2 frases. Específico, com dados reais. Alimenta o resumo executivo do portal.",
+
+  "summary_headline": "Manchete em 1 linha (max 120 caracteres). A frase que o stakeholder lê primeiro.",
+
+  "summary_highlights": [
+    {
+      "category": "posicao | competicao | janela | maturidade | oportunidade | risco",
+      "label": "Rótulo curto (max 30 char)",
+      "value": "Valor em destaque (número, %, status)",
+      "subtext": "Contexto em 1 linha (max 60 char)",
+      "tone": "green | yellow | red | blue | gray"
+    }
+  ],
+
+  "summary_key_findings": [
+    {
+      "category": "vantagem | contexto | ameaca | acao",
+      "text": "Achado em 1-2 linhas. Específico, acionável."
+    }
+  ]
+}
+```
+
+### Regras dos campos de summary
+
+**`summary_headline`**: É a ÚNICA frase que o stakeholder precisa ler se só tiver 5 segundos. Deve conter o veredito da skill. Exemplos bons:
+- ✓ "[Cliente] é o ÚNICO player premium da microrregião com [diferencial declarado] — janela competitiva de 12-18 meses."
+- ✗ "Análise de mercado concluída com sucesso."
+
+**`summary_highlights`** (4-6 itens): KPIs visuais. Categorias sugeridas:
+- `posicao` — onde o cliente está hoje vs potencial
+- `competicao` — quem disputa o mesmo espaço
+- `janela` — tempo/urgência
+- `maturidade` — estágio atual em algum eixo
+- `oportunidade` — tamanho do ganho possível
+- `risco` — tamanho da ameaça
+
+Agrupar de 2 em 2 por categoria no renderer (dá layout balanceado 3x2 ou 2x2).
+
+**`summary_key_findings`** (3-5 itens): Achados que embasam a manchete. Categorias:
+- `vantagem` (✓ verde) — o que o cliente tem a favor
+- `contexto` (i azul) — o que é fato do mercado, neutro
+- `ameaca` (! vermelho) — o que pode dar errado
+- `acao` (▸ laranja) — o que precisa ser feito
+
+---
+
+## Ponto de Alavancagem (hero block)
+
+Toda skill deve identificar **UM bloco que merece destaque visual especial** — o ponto onde a conversa estratégica precisa acontecer. O nome do campo varia por skill, mas a estrutura é consistente:
+
+```json
+{
+  "key_leverage_point": {
+    "headline": "Frase-manchete do ponto (pode ir como quote)",
+    "context": "Contexto em 2-3 linhas explicando o cenário",
+    "numbered_reasons": [
+      "Razão 1 (parse-friendly, pode começar com texto direto)",
+      "Razão 2",
+      "Razão 3"
+    ],
+    "discussion_anchor": "Frase curta sobre POR QUE este é o ponto de conversa com o stakeholder"
+  }
+}
+```
+
+Exemplos por skill:
+- `pesquisa-mercado` → `unexploited_opportunity` (whitespace estratégico)
+- `persona-icp` → persona principal + dor mais ignorada
+- `swot` → combinação força × oportunidade mais assimétrica
+- `posicionamento` → PUV vs alternativas descartadas
+- `diagnostico-midia` → canal mais subotimizado + upside estimado
+- `diagnostico-maturidade` → pilar mais fraco com maior impacto
+
+O renderer aplica:
+- Border verde 2px + gradient sutil
+- Selo "Whitespace Estratégico · Discussão com Stakeholder" no topo
+- Pill de viabilidade/urgência à direita
+- Quote/headline em card branco isolado
+- Razões numeradas em 3 círculos
+- Footer "💬 Momento de validar com a stakeholder"
+
+---
+
+## Alerta de honestidade
+
+Se a pesquisa/análise revelou fragilidade do cliente (não há diferencial real, ICP mal definido, mercado saturado, etc.), inclua:
+
+```json
+{
+  "honesty_alert": "Texto explicando a fragilidade encontrada e o que precisa ser feito antes de seguir."
+}
+```
+
+Esse campo renderiza em box amarelo/vermelho após os achados. **Nunca omita** se a realidade justifica. O valor do sistema depende de não vender aspiracional como real.
+
+---
+
+## Instrução para a IA da skill
+
+Em cada `SKILL.md`, incluir esta seção na geração:
+
+> ### Estrutura visual (obrigatória)
+>
+> Além dos campos específicos desta skill, gere SEMPRE:
+>
+> - `summary_headline` — manchete em 1 linha com o veredito
+> - `summary_highlights` — 4-6 KPIs categorizados (`posicao|competicao|janela|maturidade|oportunidade|risco`) com `{label, value, subtext, tone}`
+> - `summary_key_findings` — 3-5 achados categorizados (`vantagem|contexto|ameaca|acao`)
+> - `honesty_alert` se houver fragilidade
+>
+> Identifique o **ponto de alavancagem** desta skill (o bloco que merece hero visual) e estruture-o com headline + contexto + razões numeradas + discussion anchor.
+>
+> Consulte `references/padrao-output.md` para especificação completa.
+
+E na auto-validação:
+
+> - [ ] Tem `summary_headline` específico (não "análise concluída")?
+> - [ ] `summary_highlights` tem 4-6 itens com categorias válidas?
+> - [ ] `summary_key_findings` cobre pelo menos 3 dos 4 tipos (vantagem/contexto/ameaça/ação)?
+> - [ ] Identificou o ponto de alavancagem para discussão com stakeholder?
+> - [ ] Se há fragilidade, incluiu `honesty_alert`?
+
+---
+
+## Completude (regra crítica)
+
+**Todo campo definido no schema da skill é obrigatório no output.** Não omitir campos — o renderer assume que os campos do schema existem e quebra/fica vazio silenciosamente quando faltam.
+
+Se um dado **não pode ser obtido** (GA4 não instalado, conector não conectado, cliente não sabe, etc.), preencher com `null` E adicionar `unavailable_reason` no objeto pai:
+
+```json
+{
+  "current_conversion_rate": null,
+  "current_bounce_rate": null,
+  "avg_time_on_page": null,
+  "unavailable_reason": "GA4 não instalado no site — métricas de analytics não coletadas nesta auditoria"
+}
+```
+
+Para arrays vazios legitimamente (ex: nenhum competidor identificado), preencher com `[]` e adicionar uma nota no campo irmão `{campo}_note`:
+
+```json
+{
+  "competitors": [],
+  "competitors_note": "Nenhum concorrente direto identificado na microrregião após busca em Google Maps + Instagram."
+}
+```
+
+Para valores **estimados** (sem fonte pública), adicionar flag `[E]` no texto OU campo `estimated: true` no objeto:
+
+```json
+{ "tam_brl": 450000000, "estimated": true, "estimation_basis": "IBGE população × SEBRAE ticket médio" }
+```
+
+**Nunca** deixar string vazia (`""`), zero falso (`0` quando não é zero real), ou omitir o campo. Essas três formas são invisíveis para o renderer e geram o bug "coluna vazia".
+
+Valide o JSON contra o `schema.json` empacotado na skill e corrija campos ausentes ou `null` sem `unavailable_reason`.
+
+### Checklist adicional de auto-validação
+
+> - [ ] Todos os campos do schema estão presentes (preenchidos ou com `null` + `unavailable_reason`)?
+> - [ ] Nenhuma string vazia (`""`) — substituí por `null` + reason quando o dado não existe?
+> - [ ] Arrays vazios legítimos têm `{campo}_note` explicando por quê?
+> - [ ] Estimativas marcadas com `estimated: true` ou `[E]`?
+
+---
+
+## Tons de voz
+
+- `green` — oportunidade/vantagem/confirmado
+- `yellow` — atenção/potencial/médio
+- `red` — risco/ameaça/fraco
+- `blue` — contexto/informativo/neutro
+- `gray` — desativado/aspiracional/ausente
+
+Usar tons consistentemente: nunca pintar ameaça de verde ou vantagem de vermelho para "chamar atenção". O tom é semântico.
+
+---

--- a/.claude/skills/gt-diagnostico-midia-paga/schema.json
+++ b/.claude/skills/gt-diagnostico-midia-paga/schema.json
@@ -1,0 +1,991 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DiagnosticoMidia",
+  "description": "Output estruturado do diagnostico de midia paga: metricas, benchmarks, diagnostico por dimensao, problemas e plano de acao.",
+  "type": "object",
+  "required": [
+    "summary",
+    "client_name",
+    "segment",
+    "data_source",
+    "data_period",
+    "current_metrics",
+    "benchmarks",
+    "diagnosis_by_dimension",
+    "top_problems",
+    "action_plan",
+    "realistic_goal",
+    "summary_headline",
+    "summary_highlights",
+    "summary_key_findings"
+  ],
+  "properties": {
+    "client_name": {
+      "type": "string",
+      "description": "Nome do cliente"
+    },
+    "summary": {
+      "type": "string",
+      "description": "Resumo de 1-2 frases do diagnóstico de mídia. Inclui principal problema identificado e ROAS atual vs benchmark."
+    },
+    "summary_headline": {
+      "type": "string",
+      "maxLength": 200,
+      "description": "Manchete em 1 linha com o veredito desta skill (hero do resumo executivo no portal). Ver references/padrao-output.md"
+    },
+    "summary_highlights": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 8,
+      "description": "KPIs visuais categorizados para o resumo executivo. Cada item: {category, label, value, subtext, tone}.",
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "label",
+          "value"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "posicao",
+              "competicao",
+              "janela",
+              "maturidade",
+              "oportunidade",
+              "risco"
+            ]
+          },
+          "label": {
+            "type": "string",
+            "maxLength": 40
+          },
+          "value": {
+            "type": "string"
+          },
+          "subtext": {
+            "type": "string",
+            "maxLength": 80
+          },
+          "tone": {
+            "type": "string",
+            "enum": [
+              "green",
+              "yellow",
+              "red",
+              "blue",
+              "gray"
+            ]
+          }
+        }
+      }
+    },
+    "summary_key_findings": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 6,
+      "description": "Achados categorizados por intenção (vantagem/contexto/ameaça/ação). Pelo menos 3 dos 4 tipos cobertos.",
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "text"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "vantagem",
+              "contexto",
+              "ameaca",
+              "acao"
+            ]
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "segment": {
+      "type": "string",
+      "description": "Segmento de atuacao"
+    },
+    "data_source": {
+      "type": "string",
+      "enum": [
+        "v4mos_api",
+        "manual_export",
+        "operator_provided",
+        "no_data"
+      ],
+      "description": "Origem dos dados de midia"
+    },
+    "data_period": {
+      "type": "string",
+      "description": "Periodo dos dados analisados (ex: ultimos 90 dias)"
+    },
+    "monthly_budget": {
+      "type": "number",
+      "description": "Budget mensal em reais"
+    },
+    "platforms_active": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Plataformas de midia paga ativas"
+    },
+    "integrations_status": {
+      "type": "object",
+      "description": "Status das integracoes V4MOS",
+      "properties": {
+        "meta_ads": {
+          "type": "string",
+          "enum": [
+            "connected",
+            "disconnected",
+            "not_configured"
+          ]
+        },
+        "google_ads": {
+          "type": "string",
+          "enum": [
+            "connected",
+            "disconnected",
+            "not_configured"
+          ]
+        },
+        "google_analytics": {
+          "type": "string",
+          "enum": [
+            "connected",
+            "disconnected",
+            "not_configured"
+          ]
+        }
+      }
+    },
+    "current_metrics": {
+      "type": "object",
+      "required": [
+        "cpl",
+        "ctr",
+        "conversion_rate"
+      ],
+      "properties": {
+        "cpl": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Custo por Lead em reais"
+        },
+        "ctr": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Taxa de clique em percentual"
+        },
+        "conversion_rate": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Taxa de conversao da landing page em percentual"
+        },
+        "roas": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Return on Ad Spend (multiplicador)"
+        },
+        "cpc": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Custo por clique em reais"
+        },
+        "total_investment": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Investimento total no periodo em reais"
+        },
+        "total_leads": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Total de leads gerados no periodo"
+        },
+        "total_clicks": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Total de cliques no periodo"
+        },
+        "impressions": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Total de impressoes no periodo"
+        },
+        "frequency": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Frequencia media dos anuncios"
+        }
+      }
+    },
+    "benchmarks": {
+      "type": "object",
+      "description": "Benchmarks do setor para comparacao",
+      "properties": {
+        "cpl": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "CPL benchmark do setor em reais"
+        },
+        "ctr": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "CTR benchmark do setor em percentual"
+        },
+        "conversion_rate": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Taxa de conversao benchmark do setor"
+        },
+        "roas": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "ROAS benchmark do setor"
+        },
+        "cpc": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "CPC benchmark do setor em reais"
+        },
+        "source": {
+          "type": "string",
+          "description": "Fonte dos benchmarks"
+        }
+      }
+    },
+    "diagnosis_by_dimension": {
+      "type": "object",
+      "required": [
+        "account_structure",
+        "creatives",
+        "landing_pages",
+        "audiences"
+      ],
+      "properties": {
+        "account_structure": {
+          "type": "object",
+          "required": [
+            "organization",
+            "segmentation",
+            "budget_allocation",
+            "observation"
+          ],
+          "properties": {
+            "organization": {
+              "type": "string",
+              "enum": [
+                "adequate",
+                "fragmented",
+                "nonexistent"
+              ],
+              "description": "Organizacao de campanhas e conjuntos"
+            },
+            "segmentation": {
+              "type": "string",
+              "description": "Avaliacao da segmentacao vs ICP"
+            },
+            "budget_allocation": {
+              "type": "string",
+              "enum": [
+                "well_distributed",
+                "concentrated",
+                "dispersed"
+              ],
+              "description": "Distribuicao do budget entre campanhas"
+            },
+            "observation": {
+              "type": "string",
+              "description": "Observacao especifica"
+            }
+          }
+        },
+        "creatives": {
+          "type": "object",
+          "required": [
+            "evaluation"
+          ],
+          "properties": {
+            "active_count": {
+              "type": "integer",
+              "description": "Numero de criativos ativos"
+            },
+            "best_performer": {
+              "type": "string",
+              "description": "Criativo com melhor performance e metricas"
+            },
+            "worst_performer": {
+              "type": "string",
+              "description": "Criativo com pior performance e metricas"
+            },
+            "ab_testing_active": {
+              "type": "boolean",
+              "description": "Se ha teste A/B ativo"
+            },
+            "average_frequency": {
+              "type": [
+                "number",
+                "null"
+              ],
+              "description": "Frequencia media"
+            },
+            "fatigue_detected": {
+              "type": "boolean",
+              "description": "Se ha fadiga de criativo detectada"
+            },
+            "evaluation": {
+              "type": "string",
+              "description": "Avaliacao geral dos criativos"
+            }
+          }
+        },
+        "landing_pages": {
+          "type": "object",
+          "required": [
+            "evaluation"
+          ],
+          "properties": {
+            "lp_count": {
+              "type": "integer",
+              "description": "Numero de LPs usadas"
+            },
+            "coherence_with_ads": {
+              "type": "string",
+              "enum": [
+                "high",
+                "medium",
+                "low"
+              ],
+              "description": "Coerencia entre anuncios e LPs"
+            },
+            "estimated_bounce_rate": {
+              "type": [
+                "number",
+                "null"
+              ],
+              "description": "Taxa de rejeicao estimada"
+            },
+            "evaluation": {
+              "type": "string",
+              "description": "Avaliacao geral das LPs"
+            }
+          }
+        },
+        "audiences": {
+          "type": "object",
+          "required": [
+            "evaluation"
+          ],
+          "properties": {
+            "types_used": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "broad",
+                  "interest",
+                  "lookalike",
+                  "retargeting",
+                  "custom"
+                ]
+              },
+              "description": "Tipos de publico usados"
+            },
+            "overlap_detected": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "description": "Se ha sobreposicao de publicos"
+            },
+            "retargeting_active": {
+              "type": "boolean",
+              "description": "Se retargeting esta ativo"
+            },
+            "evaluation": {
+              "type": "string",
+              "description": "Avaliacao geral de publicos"
+            }
+          }
+        }
+      }
+    },
+    "top_problems": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "problem",
+          "data_evidence",
+          "impact"
+        ],
+        "properties": {
+          "problem": {
+            "type": "string",
+            "description": "Descricao do problema"
+          },
+          "data_evidence": {
+            "type": "string",
+            "description": "Evidencia nos dados que comprova o problema"
+          },
+          "impact": {
+            "type": "string",
+            "description": "Impacto estimado (quanto esta custando)"
+          },
+          "dimension": {
+            "type": "string",
+            "enum": [
+              "account_structure",
+              "creatives",
+              "landing_pages",
+              "audiences"
+            ],
+            "description": "Dimensao do problema"
+          }
+        }
+      },
+      "description": "Top 3 problemas criticos, em ordem de impacto"
+    },
+    "action_plan": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "action",
+          "priority",
+          "expected_impact",
+          "responsible"
+        ],
+        "properties": {
+          "action": {
+            "type": "string",
+            "description": "Descricao da acao"
+          },
+          "priority": {
+            "type": "string",
+            "enum": [
+              "high",
+              "medium",
+              "normal"
+            ],
+            "description": "Prioridade da acao"
+          },
+          "expected_impact": {
+            "type": "string",
+            "description": "Impacto esperado"
+          },
+          "responsible": {
+            "type": "string",
+            "description": "Quem e responsavel pela execucao"
+          },
+          "deadline": {
+            "type": "string",
+            "description": "Prazo (ex: Semana 1, Semana 2)"
+          }
+        }
+      },
+      "description": "Plano de acao para os proximos 30 dias"
+    },
+    "realistic_goal": {
+      "type": "object",
+      "required": [
+        "justification"
+      ],
+      "properties": {
+        "target_cpl": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "CPL alvo em 90 dias (em reais)"
+        },
+        "target_roas": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "ROAS alvo em 90 dias (multiplicador)"
+        },
+        "justification": {
+          "type": "string",
+          "description": "Justificativa da meta com base nos dados"
+        },
+        "assumptions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Premissas para atingir a meta"
+        },
+        "risk_factors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Fatores de risco que podem impedir a meta"
+        }
+      }
+    },
+    "keyword_clusters": {
+      "type": "array",
+      "description": "Agrupamento estratégico de keywords de search (4-6 clusters).",
+      "items": {
+        "type": "object",
+        "required": [
+          "cluster"
+        ],
+        "properties": {
+          "cluster": {
+            "type": "string"
+          },
+          "keywords": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "intent": {
+            "type": "string",
+            "enum": [
+              "navigational",
+              "informational",
+              "transactional",
+              "commercial"
+            ]
+          },
+          "budget_allocation_pct": {
+            "type": "number"
+          },
+          "expected_cpc_range": {
+            "type": "string"
+          },
+          "bid_strategy": {
+            "type": "string"
+          },
+          "copy_angle": {
+            "type": "string"
+          },
+          "risk": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "budget_reallocation_scenarios": {
+      "type": "object",
+      "description": "3 cenários de realocação de budget (A conservador, B realista, C agressivo).",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "scenario_a_conservative": {
+          "$ref": "#/definitions/budgetScenario"
+        },
+        "scenario_b_realistic": {
+          "$ref": "#/definitions/budgetScenario"
+        },
+        "scenario_c_aggressive": {
+          "$ref": "#/definitions/budgetScenario"
+        },
+        "recommendation": {
+          "type": "string"
+        }
+      }
+    },
+    "creative_testing_hypotheses": {
+      "type": "object",
+      "description": "Hipóteses de testes A/B de criativos.",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "hypotheses": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "id",
+              "hypothesis"
+            ],
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "hypothesis": {
+                "type": "string"
+              },
+              "angle": {
+                "type": "string"
+              },
+              "format": {
+                "type": "string"
+              },
+              "hook": {
+                "type": "string"
+              },
+              "body": {
+                "type": "string"
+              },
+              "cta": {
+                "type": "string"
+              },
+              "target_audience": {
+                "type": "string"
+              },
+              "success_criteria": {
+                "type": "string"
+              },
+              "testing_budget": {
+                "type": "number"
+              },
+              "testing_duration_days": {
+                "type": "number"
+              }
+            }
+          }
+        },
+        "testing_budget_total_week_1": {
+          "type": "number"
+        }
+      }
+    },
+    "daypart_optimization": {
+      "type": "object",
+      "description": "Ajustes de lance por janela de dia/hora.",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "adjustments": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "day_time"
+            ],
+            "properties": {
+              "day_time": {
+                "type": "string"
+              },
+              "bid_adjustment_pct": {
+                "type": "number"
+              },
+              "rationale": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "forecast_sensitivity_analysis": {
+      "type": "object",
+      "description": "Análise de sensibilidade da meta: base_case + variações what-if. NOTA: o renderer do portal NÃO exibe mais o gráfico de sensibilidade — apenas os cards de detalhe (base_case + lista de variations). Mantenha os dados ricos mesmo assim, eles alimentam os cards.",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "base_case": {
+          "type": "object",
+          "description": "Caso base da projeção. Aceita nomenclatura com sufixo '_90d' ou sem.",
+          "properties": {
+            "leads_monthly": {
+              "type": "number",
+              "description": "Leads mensais no base case. Nome preferido."
+            },
+            "leads_month_90d": {
+              "type": "number",
+              "description": "Alternativa a leads_monthly (leads projetados ao final de 90d)."
+            },
+            "cpl": {
+              "type": "number",
+              "description": "CPL no base case (R$). Nome preferido."
+            },
+            "cpl_90d_brl": {
+              "type": "number",
+              "description": "Alternativa a cpl."
+            },
+            "cac": {
+              "type": "number",
+              "description": "CAC no base case (R$)."
+            },
+            "cac_90d_brl": {
+              "type": "number",
+              "description": "Alternativa a cac."
+            },
+            "revenue_monthly": {
+              "type": "number",
+              "description": "Receita mensal projetada."
+            },
+            "roas": {
+              "type": "number",
+              "description": "ROAS no base case."
+            }
+          }
+        },
+        "variations": {
+          "type": "array",
+          "description": "Cenários what-if. O renderer exibe como lista de cards (sem gráfico). 4-6 itens.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "scenario": {
+                "type": "string",
+                "description": "Nome do cenário (ex: 'CPC +10%'). Nome preferido."
+              },
+              "scenario_name": {
+                "type": "string",
+                "description": "Alternativa a scenario."
+              },
+              "variable_change": {
+                "type": "string",
+                "description": "Descrição da mudança na variável."
+              },
+              "impact_on_leads": {
+                "type": "string",
+                "description": "Impacto em leads (texto ou número). Nome preferido."
+              },
+              "impact_on_leads_month_90d": {
+                "type": [
+                  "string",
+                  "number"
+                ],
+                "description": "Alternativa numérica — variação em leads/mês no 90d."
+              },
+              "impact_on_cpl": {
+                "type": "string",
+                "description": "Impacto no CPL. Nome preferido."
+              },
+              "impact_on_cpl_brl": {
+                "type": [
+                  "string",
+                  "number"
+                ],
+                "description": "Alternativa numérica (R$)."
+              },
+              "impact_on_revenue": {
+                "type": "string",
+                "description": "Impacto na receita."
+              },
+              "delta_vs_base_pct": {
+                "type": "number",
+                "description": "Variação vs. base_case em % (ex: -15.5 = -15.5%). Usado pelos cards de detalhe."
+              }
+            }
+          }
+        }
+      }
+    },
+    "is_launch_plan": {
+      "type": "boolean",
+      "default": false,
+      "description": "Se true, este e um plano de lancamento (cliente nao tem midia ativa)"
+    },
+    "completed_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Data/hora de conclusao"
+    },
+    "key_insight": {
+      "type": "object",
+      "description": "Ponto de alavancagem desta skill — o bloco que merece destaque visual para conversa com o stakeholder. Ver PADRAO-OUTPUT.md.",
+      "properties": {
+        "headline": {
+          "type": "string",
+          "description": "Frase-manchete do ponto (pode virar quote destacada no renderer)"
+        },
+        "context": {
+          "type": "string",
+          "description": "Contexto em 2-3 linhas explicando o cenário"
+        },
+        "numbered_reasons": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Razões numeradas (o renderer vira 3 cards numerados)"
+        },
+        "discussion_anchor": {
+          "type": "string",
+          "description": "Por que este é o ponto para stakeholder decidir/validar"
+        }
+      }
+    },
+    "honesty_alert": {
+      "type": "string",
+      "description": "Alerta se a análise revelou fragilidade real do cliente (não há diferencial claro, premissa contraditória, etc.). Nunca omitir se justificado."
+    }
+  },
+  "definitions": {
+    "budgetScenario": {
+      "type": "object",
+      "description": "Cenário de realocação de budget. Aceita dois conjuntos de nomes — o renderer do portal usa '??' para cair no alternativo quando o preferido está ausente.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Nome do cenário (ex: 'Conservador'). Nome preferido."
+        },
+        "label": {
+          "type": "string",
+          "description": "Alternativa a name."
+        },
+        "total_budget_monthly": {
+          "type": "number",
+          "description": "Budget total mensal em R$. Se ausente, o renderer soma google_split + meta_split (ou os valores dentro de google_allocation/meta_allocation)."
+        },
+        "google_split": {
+          "type": "number",
+          "description": "Valor em R$ para Google Ads. Nome preferido."
+        },
+        "meta_split": {
+          "type": "number",
+          "description": "Valor em R$ para Meta Ads. Nome preferido."
+        },
+        "google_allocation": {
+          "type": "object",
+          "description": "Alternativa estruturada a google_split. Se presente, o renderer usa .value (ou .amount/.brl) como valor.",
+          "properties": {
+            "value": {
+              "type": "number"
+            },
+            "amount": {
+              "type": "number"
+            },
+            "brl": {
+              "type": "number"
+            },
+            "pct": {
+              "type": "number",
+              "description": "Percentual do total alocado."
+            }
+          }
+        },
+        "meta_allocation": {
+          "type": "object",
+          "description": "Alternativa estruturada a meta_split.",
+          "properties": {
+            "value": {
+              "type": "number"
+            },
+            "amount": {
+              "type": "number"
+            },
+            "brl": {
+              "type": "number"
+            },
+            "pct": {
+              "type": "number"
+            }
+          }
+        },
+        "campaigns_structure": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "campaign": {
+                "type": "string"
+              },
+              "platform": {
+                "type": "string"
+              },
+              "budget_monthly": {
+                "type": "number"
+              },
+              "objective": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "expected_leads_monthly": {
+          "type": "number",
+          "description": "Leads mensais esperados. Nome preferido."
+        },
+        "projected_leads_month": {
+          "type": "number",
+          "description": "Alternativa a expected_leads_monthly."
+        },
+        "expected_cpl": {
+          "type": "number",
+          "description": "CPL esperado (R$). Nome preferido."
+        },
+        "projected_cpl": {
+          "type": "number",
+          "description": "Alternativa a expected_cpl."
+        },
+        "expected_roas": {
+          "type": "number",
+          "description": "ROAS esperado."
+        },
+        "delta_leads": {
+          "type": [
+            "number",
+            "string"
+          ],
+          "description": "Variação de leads vs. cenário atual (número absoluto ou '+15%')."
+        },
+        "effort_weeks": {
+          "type": "number",
+          "description": "Semanas de esforço para implementar o cenário."
+        },
+        "confidence": {
+          "type": "string",
+          "enum": [
+            "high",
+            "medium",
+            "low",
+            "alta",
+            "média",
+            "media",
+            "baixa"
+          ],
+          "description": "Nível de confiança na projeção."
+        },
+        "risk_assessment": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/.claude/skills/gt-diagnostico-organico-instagram/SKILL.md
+++ b/.claude/skills/gt-diagnostico-organico-instagram/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: gt-diagnostico-organico-instagram
+description: "Diagnostico de conteudo organico no Instagram — cliente vs 2 concorrentes, ultimos 90 dias, via Instagram Graph API + business_discovery. Use quando o operador disser /gt-diagnostico-organico-instagram ou 'analisar conteudo organico' ou 'diagnostico de instagram' ou 'analise de conteudo do cliente'."
+area: gt
+author: luizfreitasv4
+version: 1.0.0
+dependencies:
+  - geral-persona-icp
+  - geral-pesquisa-mercado
+tools: []
+week: 2
+estimated_time: "45min"
+output_file: "gt-diagnostico-organico-instagram.json"
+multimodal: true
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta versao foi portada do sistema de Estruturacao Estrategica. As regras abaixo tem precedencia sobre caminhos e persistencia citados no fluxo original:
+
+- Trabalhe somente em `squads/{squad}/clientes/{cliente}/`, nunca em um diretorio `clientes/` solto na raiz.
+- Leia primeiro o `CLAUDE.md` ou `AGENTS.md` da KB, `mission-control/`, `calls/`, `docs/` e `campanhas/`.
+- Se `client.json` existir, use-o como fonte complementar. Se nao existir, derive o contexto da KB e do Mission Control; nao exija nem invente esse arquivo.
+- Salve entregaveis em `squads/{squad}/clientes/{cliente}/outputs/`, em JSON e Markdown quando o fluxo pedir ambos.
+- Registre decisoes e progresso no `mission-control/historico-checkins.md` ou no arquivo de historico equivalente encontrado na KB.
+- Resolva recursos empacotados a partir do proprio diretorio desta skill. Se uma integracao externa nao estiver configurada, declare o gap e continue apenas com os dados reais disponiveis.
+
+
+# Diagnostico de Conteudo Organico — Instagram (POP 2.2)
+
+> **Posição no fluxo:** Semana 2 — comum a todos os modelos. Engagement sempre **normalizado por seguidores** (taxa, não absoluto). Gera ações editoriais guiadas por gaps dos concorrentes.
+
+Voce e um diretor de conteudo digital focado em PMEs brasileiras. Vai rodar um diagnostico comparativo do feed organico do cliente contra 2 concorrentes no Instagram — ultimos 90 dias — usando dados reais da Instagram Graph API (sem necessidade de acesso do cliente), com embed oficial dos posts no portal.
+
+**CAPACIDADE MULTIMODAL:** Voce pode analisar visualmente as mídias baixadas (imagens e thumbnails de vídeo) para complementar a analise quantitativa.
+
+## Pre-requisitos
+
+1. `.credentials/meta-graph-api.json` preenchido com token de longa duracao (60 dias) valido.
+   - O token DEVE incluir as permissions: `instagram_basic`, `instagram_manage_insights`, `pages_show_list`, `pages_read_engagement`. Sem `instagram_manage_insights` o endpoint `business_discovery` retorna erro #10.
+2. Cliente com conta Instagram Business ou Creator (validar via business_discovery antes).
+3. `outputs/geral-pesquisa-mercado.json` presente (usado para selecionar os 2 concorrentes automaticamente).
+
+## Selecao automatica de concorrentes (regra fixa)
+
+1. Ler `outputs/geral-pesquisa-mercado.json` → `competitors[]`
+2. Ordenar por `digital_score` DESC
+3. Pegar os **TOP 2** com handle Instagram conhecido
+4. Validar via `business_discovery` — se algum nao for Business/Creator, cair para o #3, e assim por diante
+5. Se o @handle de um concorrente nao estiver mapeado no briefing ou na pesquisa, perguntar ao operador uma unica vez
+
+Nunca deixe o operador decidir manualmente a menos que a regra falhe — padrao e automatico.
+
+## Dados necessarios
+
+1. Leia `client.json` (seção `briefing`) — extraia: NOME_CLIENTE, SEGMENTO, instagram (handle do cliente), ICP resumido, tom de voz
+2. Leia `outputs/geral-persona-icp.json` — extraia: RESUMO_ICP, dores, linguagem
+3. Leia `outputs/geral-posicionamento-estrategico.json` — extraia: PUV, tagline, territorio, tom
+4. Leia `outputs/geral-pesquisa-mercado.json` — extraia TOP 2 competitors por `digital_score`
+
+Se faltar o @handle do cliente no briefing, pergunte:
+
+> Qual o @ do Instagram do {NOME_CLIENTE}?
+
+## Execucao
+
+O script empacotado usa `client.json` para descobrir o handle do cliente e os concorrentes. Se esse arquivo não existir na KB do Hub, não o crie só para satisfazer o script: peça os três handles ao operador e faça a coleta pela integração disponível ou trabalhe com uma exportação fornecida, sempre registrando a limitação.
+
+```bash
+bash .claude/skills/gt-diagnostico-organico-instagram/scripts/ig_organic_audit.sh squads/{squad}/clientes/{cliente}
+```
+
+O script:
+1. Lê `.credentials/meta-graph-api.json`, `client.json`, `outputs/geral-pesquisa-mercado.json`
+2. Identifica o handle do cliente + 2 concorrentes top do scorecard
+3. Chama `business_discovery` para cada um (perfil + posts 90 dias)
+4. Calcula metricas publicas (engagement proxy) e classifica por formato/cadencia
+5. Salva raw em `squads/{squad}/clientes/{cliente}/cache/ig_organic_audit-{ts}.json`
+6. Condensa em `squads/{squad}/clientes/{cliente}/cache/ig_organic_audit-summary.json` — input direto pra skill gerar o output
+
+## Geracao
+
+Gere o output COMPLETO de uma vez usando o summary do script + outputs de dependencias.
+
+Interpretacoes obrigatorias (nao pular):
+
+### `top_posts` (top 3 por conta)
+Para CADA post nos top 3 de CADA uma das 3 contas:
+- `permalink` → `embed_url` = `permalink` + `embed/` (o portal vai montar o iframe)
+- Caption completa, formato (FEED/REELS/CAROUSEL), likes, comments, engagement_proxy
+- **Diagnostico qualitativo**: o que esta funcionando neste post (hook, visual, angulo). 2 frases objetivas.
+- Se for concorrente e o cliente NAO tem algo similar, marcar `gap_para_cliente: true` e explicar o que replicar.
+
+### `bottom_posts` (bottom 3 do CLIENTE apenas)
+Os 3 piores do cliente por engagement_proxy:
+- Mesmo formato dos top_posts
+- **Diagnostico de por que quebrou** — hipotese: caption fraca? hora errada? formato errado? falta de hook?
+
+### `format_distribution` e `cadence`
+Tabela comparativa das 3 contas. Aponte especificamente onde o cliente esta DESALINHADO com quem performa melhor (ex: concorrente posta 60% em Reels, cliente posta 10%).
+
+### `competitor_patterns_missing` (priorizado)
+Padroes recorrentes que aparecem nos concorrentes e NAO aparecem no cliente. Cada item com:
+- Descricao do padrao
+- Quantos posts dos concorrentes usam
+- Por que provavelmente funciona para o ICP do cliente
+- Como o cliente poderia implementar
+
+Esta e a parte mais acionavel do relatorio.
+
+### `client_winning_patterns`
+Padroes do cliente acima da media — replicar e amplificar.
+
+### `instagram_compliance`
+Checagem rapida de aspect ratio, uso de texto em imagem, safe zones de Reels. Usar dados publicos (aspect ratio via media_url, analise visual dos frames extraidos).
+
+### `next_actions`
+Lista priorizada de 5-8 acoes (o que mudar, qual formato testar, qual tipo de conteudo replicar). Cada uma com impacto estimado + facilidade.
+
+## Auto-validacao
+
+- [ ] Mencionou o cliente pelo nome?
+- [ ] Usou dados reais da Graph API (nao inventou numeros)?
+- [ ] Nenhum item generico?
+- [ ] Schema validou?
+- [ ] Top 3 de cada conta tem permalink valido + embed_url?
+- [ ] Consistente com ICP e posicionamento?
+- [ ] Padroes missing sao acionaveis (nao "melhorar conteudo")?
+- [ ] next_actions sao especificos?
+
+Se falhou → regenere silenciosamente.
+
+## Apresentacao e decisoes
+
+Apresente o output COMPLETO ao operador.
+
+- "Os posts top 3 do cliente e concorrentes batem com o que voce observou empiricamente?"
+- "Algum padrao dos concorrentes que voce ja sabia que funciona e esta aqui listado?"
+- "As proximas acoes sao factiveis no time atual?"
+- "Alguma limitacao do cliente que eu nao considerei? (ex: nao pode gravar Reels pra quem tem pouco tempo de filmagem)"
+
+## Finalizacao
+
+1. Salve `squads/{squad}/clientes/{cliente}/outputs/gt-diagnostico-organico-instagram.json` (com `summary` no topo)
+2. Atualize `client.json`: progress.skills → completed, version++, history[]
+3. Salve também uma versão Markdown do diagnóstico na pasta de outputs compatível com o Hub.
+4. Sugira proxima skill:
+   - "Diagnostico organico IG concluido. Cliente: {followers} seguidores, {posts_90d} posts/90d. Top formato do cliente: {formato}. Gaps identificados: {numero}."
+   - "Este diagnostico alimenta: /designer-criativos-anuncios (padroes que funcionam para o ICP no organico)"
+   - "Próximo passo recomendado: consolidar os diagnósticos com /gt-diagnostico-maturidade-digital e fechar com /geral-posicionamento-estrategico."
+
+## Campo obrigatorio: summary
+
+```json
+"summary": "Resumo 1-2 frases com nome do cliente, metricas-chave (eng_proxy cliente vs top concorrente), gap principal e acao prioritaria. Sem generico."
+```

--- a/.claude/skills/gt-diagnostico-organico-instagram/schema.json
+++ b/.claude/skills/gt-diagnostico-organico-instagram/schema.json
@@ -1,0 +1,522 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DiagnosticoOrganicoIG",
+  "description": "Diagnostico comparativo de conteudo organico no Instagram — cliente vs 2 concorrentes, 90 dias, via Graph API + business_discovery.",
+  "type": "object",
+  "required": [
+    "summary",
+    "client_name",
+    "period",
+    "client_account",
+    "competitor_accounts",
+    "format_distribution",
+    "cadence",
+    "engagement_benchmark",
+    "top_posts",
+    "bottom_posts",
+    "competitor_patterns_missing",
+    "client_winning_patterns",
+    "next_actions",
+    "summary_headline",
+    "summary_highlights",
+    "summary_key_findings"
+  ],
+  "properties": {
+    "client_name": {
+      "type": "string"
+    },
+    "summary": {
+      "type": "string",
+      "description": "Resumo 1-2 frases com cliente, metricas-chave, gap principal, acao prioritaria."
+    },
+    "summary_headline": {
+      "type": "string",
+      "description": "Manchete em 1 linha (~120 caracteres) com o veredito da skill."
+    },
+    "summary_highlights": {
+      "type": "array",
+      "description": "KPIs em destaque (4-6 itens). Categorias: posicao | competicao | janela | maturidade | oportunidade | risco.",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "label",
+          "value",
+          "tone"
+        ],
+        "properties": {
+          "category": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "subtext": {
+            "type": "string"
+          },
+          "tone": {
+            "type": "string",
+            "enum": [
+              "green",
+              "yellow",
+              "red",
+              "blue",
+              "gray"
+            ]
+          }
+        }
+      }
+    },
+    "summary_key_findings": {
+      "type": "array",
+      "description": "3-5 achados categorizados (vantagem | contexto | ameaca | acao).",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "text"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "vantagem",
+              "contexto",
+              "ameaca",
+              "acao"
+            ]
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "period": {
+      "type": "object",
+      "required": [
+        "start",
+        "end",
+        "days"
+      ],
+      "properties": {
+        "start": {
+          "type": "string",
+          "format": "date"
+        },
+        "end": {
+          "type": "string",
+          "format": "date"
+        },
+        "days": {
+          "type": "integer"
+        }
+      }
+    },
+    "client_account": {
+      "$ref": "#/definitions/account"
+    },
+    "competitor_accounts": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 3,
+      "items": {
+        "$ref": "#/definitions/account"
+      }
+    },
+    "format_distribution": {
+      "type": "object",
+      "description": "Distribuicao por formato (FEED_IMAGE / CAROUSEL / REELS / VIDEO) por conta.",
+      "required": [
+        "by_account",
+        "insight"
+      ],
+      "properties": {
+        "by_account": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "username",
+              "counts"
+            ],
+            "properties": {
+              "username": {
+                "type": "string"
+              },
+              "counts": {
+                "type": "object",
+                "properties": {
+                  "FEED_IMAGE": {
+                    "type": "integer"
+                  },
+                  "CAROUSEL": {
+                    "type": "integer"
+                  },
+                  "REELS": {
+                    "type": "integer"
+                  },
+                  "VIDEO": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "insight": {
+          "type": "string",
+          "description": "Leitura comparativa (onde o cliente esta desalinhado)."
+        }
+      }
+    },
+    "cadence": {
+      "type": "object",
+      "required": [
+        "by_account",
+        "insight"
+      ],
+      "properties": {
+        "by_account": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "username",
+              "posts_per_week"
+            ],
+            "properties": {
+              "username": {
+                "type": "string"
+              },
+              "posts_per_week": {
+                "type": "number"
+              },
+              "preferred_weekday": {
+                "type": "string"
+              },
+              "preferred_hour": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "insight": {
+          "type": "string"
+        }
+      }
+    },
+    "engagement_benchmark": {
+      "type": "object",
+      "required": [
+        "by_account",
+        "insight"
+      ],
+      "properties": {
+        "by_account": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "username",
+              "avg_likes",
+              "avg_comments",
+              "avg_engagement_proxy"
+            ],
+            "properties": {
+              "username": {
+                "type": "string"
+              },
+              "avg_likes": {
+                "type": "number"
+              },
+              "avg_comments": {
+                "type": "number"
+              },
+              "avg_engagement_proxy": {
+                "type": "number",
+                "description": "(likes + 3*comments) / followers * 100"
+              },
+              "best_format_by_engagement": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "insight": {
+          "type": "string"
+        }
+      }
+    },
+    "top_posts": {
+      "type": "array",
+      "description": "Top 3 posts de cada conta (cliente + 2 concorrentes) por engagement_proxy.",
+      "minItems": 3,
+      "items": {
+        "$ref": "#/definitions/post"
+      }
+    },
+    "bottom_posts": {
+      "type": "array",
+      "description": "Bottom 3 posts do CLIENTE apenas — posts com menor engagement_proxy.",
+      "minItems": 1,
+      "maxItems": 3,
+      "items": {
+        "$ref": "#/definitions/post"
+      }
+    },
+    "competitor_patterns_missing": {
+      "type": "array",
+      "description": "Padroes recorrentes em concorrentes que o cliente nao usa.",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "pattern",
+          "seen_in_count",
+          "why_works",
+          "how_to_apply"
+        ],
+        "properties": {
+          "pattern": {
+            "type": "string"
+          },
+          "seen_in_count": {
+            "type": "integer"
+          },
+          "seen_in_competitors": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "example_permalinks": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "why_works": {
+            "type": "string"
+          },
+          "how_to_apply": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "client_winning_patterns": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "pattern",
+          "seen_in_count",
+          "recommendation"
+        ],
+        "properties": {
+          "pattern": {
+            "type": "string"
+          },
+          "seen_in_count": {
+            "type": "integer"
+          },
+          "example_permalinks": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "recommendation": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "instagram_compliance": {
+      "type": "object",
+      "properties": {
+        "aspect_ratio_issues_count": {
+          "type": "integer"
+        },
+        "notes": {
+          "type": "string"
+        }
+      }
+    },
+    "next_actions": {
+      "type": "array",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "action",
+          "impact",
+          "effort",
+          "priority"
+        ],
+        "properties": {
+          "action": {
+            "type": "string"
+          },
+          "impact": {
+            "type": "string",
+            "enum": [
+              "alto",
+              "medio",
+              "baixo"
+            ]
+          },
+          "effort": {
+            "type": "string",
+            "enum": [
+              "baixo",
+              "medio",
+              "alto"
+            ]
+          },
+          "priority": {
+            "type": "integer",
+            "minimum": 1
+          }
+        }
+      }
+    },
+    "completed_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "definitions": {
+    "account": {
+      "type": "object",
+      "required": [
+        "username",
+        "name",
+        "followers_count",
+        "media_count_total",
+        "posts_90d"
+      ],
+      "properties": {
+        "username": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "biography": {
+          "type": "string"
+        },
+        "profile_picture_url": {
+          "type": "string"
+        },
+        "website": {
+          "type": "string"
+        },
+        "followers_count": {
+          "type": "integer"
+        },
+        "follows_count": {
+          "type": "integer"
+        },
+        "media_count_total": {
+          "type": "integer"
+        },
+        "posts_90d": {
+          "type": "integer"
+        },
+        "permalink": {
+          "type": "string"
+        }
+      }
+    },
+    "post": {
+      "type": "object",
+      "required": [
+        "username",
+        "permalink",
+        "embed_url",
+        "media_type",
+        "format",
+        "timestamp",
+        "caption",
+        "like_count",
+        "comments_count",
+        "engagement_proxy",
+        "diagnosis"
+      ],
+      "properties": {
+        "username": {
+          "type": "string"
+        },
+        "post_id": {
+          "type": "string"
+        },
+        "permalink": {
+          "type": "string"
+        },
+        "embed_url": {
+          "type": "string",
+          "description": "permalink + 'embed/' — o portal monta o iframe oficial do Instagram."
+        },
+        "media_type": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string",
+          "enum": [
+            "FEED_IMAGE",
+            "CAROUSEL",
+            "REELS",
+            "VIDEO"
+          ]
+        },
+        "thumbnail_url": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "caption": {
+          "type": "string"
+        },
+        "caption_length": {
+          "type": "integer"
+        },
+        "hashtags_count": {
+          "type": "integer"
+        },
+        "mentions_count": {
+          "type": "integer"
+        },
+        "has_cta": {
+          "type": "boolean"
+        },
+        "like_count": {
+          "type": "integer"
+        },
+        "comments_count": {
+          "type": "integer"
+        },
+        "engagement_proxy": {
+          "type": "number",
+          "description": "(likes + 3*comments) / followers * 100"
+        },
+        "diagnosis": {
+          "type": "string",
+          "description": "2 frases: o que funcionou (se top) ou o que quebrou (se bottom)."
+        },
+        "gap_para_cliente": {
+          "type": "boolean",
+          "description": "Se este eh um post de concorrente e o cliente nao tem padrao similar."
+        }
+      }
+    }
+  }
+}

--- a/.claude/skills/gt-diagnostico-organico-instagram/scripts/ig_organic_audit.py
+++ b/.claude/skills/gt-diagnostico-organico-instagram/scripts/ig_organic_audit.py
@@ -1,0 +1,474 @@
+#!/usr/bin/env python3
+"""
+ig_organic_audit.py — Coleta publica via Instagram Graph API + business_discovery.
+
+Uso:
+  python3 ig_organic_audit.py <client_dir>
+
+Le:
+  .credentials/meta-graph-api.json  (token longo + ig_business_account_v4)
+  <client_dir>/client.json          (briefing.instagram = @handle do cliente)
+  <client_dir>/outputs/geral-pesquisa-mercado.json  (escolhe top 2 concorrentes por digital_score)
+
+Grava:
+  <client_dir>/cache/ig_organic_audit-<ts>.json         (raw por conta)
+  <client_dir>/cache/ig_organic_audit-summary.json      (input direto para a skill)
+"""
+
+import json
+import os
+import re
+import sys
+import time
+import urllib.request
+import urllib.parse
+import urllib.error
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+
+GRAPH_BASE = "https://graph.facebook.com/v21.0"
+DAYS_WINDOW = 90
+TOP_N = 3
+BOTTOM_N = 3
+
+
+def log(msg):
+    print(f"[ig_audit] {msg}", flush=True)
+
+
+def die(msg, code=1):
+    print(f"[ig_audit] ERRO: {msg}", file=sys.stderr, flush=True)
+    sys.exit(code)
+
+
+def find_credentials(client_dir: Path) -> Path:
+    d = client_dir.resolve()
+    for _ in range(6):
+        candidate = d / ".credentials" / "meta-graph-api.json"
+        if candidate.exists():
+            return candidate
+        if d.parent == d:
+            break
+        d = d.parent
+    die("meta-graph-api.json nao encontrado subindo a partir de " + str(client_dir))
+
+
+def http_get(url: str, retries: int = 3, backoff: float = 1.5):
+    last_err = None
+    for i in range(retries):
+        try:
+            req = urllib.request.Request(url, headers={"User-Agent": "v4-ig-audit/1.0"})
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                data = resp.read().decode("utf-8")
+                return json.loads(data)
+        except urllib.error.HTTPError as e:
+            body = e.read().decode("utf-8", errors="ignore")
+            last_err = f"HTTP {e.code}: {body[:400]}"
+            if e.code in (500, 502, 503, 504):
+                time.sleep(backoff ** i)
+                continue
+            raise RuntimeError(last_err)
+        except Exception as e:
+            last_err = str(e)
+            time.sleep(backoff ** i)
+    raise RuntimeError(last_err or "http_get falhou")
+
+
+def clean_handle(h: str) -> str:
+    if not h:
+        return ""
+    h = h.strip()
+    m = re.search(r"instagram\.com/([^/?#]+)", h)
+    if m:
+        h = m.group(1)
+    return h.lstrip("@").strip("/").strip()
+
+
+def call_business_discovery(ig_user_id: str, target_username: str, token: str, since_iso: str):
+    """
+    Uma unica chamada retorna perfil + posts recentes (limit=50).
+    Inclui paginacao manual via next cursor.
+    """
+    fields = (
+        "business_discovery.username(" + target_username + "){"
+        "id,username,name,biography,profile_picture_url,website,followers_count,"
+        "follows_count,media_count,"
+        "media.limit(50){id,caption,media_type,media_product_type,media_url,"
+        "permalink,thumbnail_url,timestamp,like_count,comments_count,children{media_type,media_url}}"
+        "}"
+    )
+    url = f"{GRAPH_BASE}/{ig_user_id}?fields={urllib.parse.quote(fields)}&access_token={token}"
+    payload = http_get(url)
+    bd = payload.get("business_discovery")
+    if not bd:
+        raise RuntimeError(f"business_discovery vazio para @{target_username}: {json.dumps(payload)[:400]}")
+
+    # Paginacao: tentamos uma segunda pagina se tiver
+    posts = (bd.get("media") or {}).get("data") or []
+    after = ((bd.get("media") or {}).get("paging") or {}).get("cursors", {}).get("after")
+    pages = 1
+    # Filtro 90d — se a ultima ja eh mais antiga, nao precisa paginar
+    def oldest_ts(items):
+        if not items: return None
+        return min(p.get("timestamp","") for p in items)
+
+    while after and pages < 5:
+        last_old = oldest_ts(posts)
+        if last_old and last_old < since_iso:
+            break
+        fields2 = (
+            "business_discovery.username(" + target_username + "){"
+            "media.after(" + after + ").limit(50){id,caption,media_type,media_product_type,media_url,"
+            "permalink,thumbnail_url,timestamp,like_count,comments_count,children{media_type,media_url}}"
+            "}"
+        )
+        url2 = f"{GRAPH_BASE}/{ig_user_id}?fields={urllib.parse.quote(fields2)}&access_token={token}"
+        try:
+            nxt = http_get(url2)
+        except Exception as e:
+            log(f"paginacao parou: {e}")
+            break
+        nbd = nxt.get("business_discovery") or {}
+        nposts = (nbd.get("media") or {}).get("data") or []
+        if not nposts:
+            break
+        posts.extend(nposts)
+        after = ((nbd.get("media") or {}).get("paging") or {}).get("cursors", {}).get("after")
+        pages += 1
+
+    bd["_all_media"] = posts
+    return bd
+
+
+def classify_format(p: dict) -> str:
+    mt = (p.get("media_type") or "").upper()
+    mpt = (p.get("media_product_type") or "").upper()
+    if mpt == "REELS":
+        return "REELS"
+    if mt == "CAROUSEL_ALBUM":
+        return "CAROUSEL"
+    if mt == "VIDEO":
+        return "VIDEO"
+    if mt == "IMAGE":
+        return "FEED_IMAGE"
+    return mt or "UNKNOWN"
+
+
+def post_summary(p: dict, username: str, followers: int):
+    caption = p.get("caption") or ""
+    likes = p.get("like_count") or 0
+    comments = p.get("comments_count") or 0
+    eng = 0.0
+    if followers and followers > 0:
+        eng = round((likes + 3 * comments) / followers * 100, 3)
+    permalink = p.get("permalink") or ""
+    embed = permalink.rstrip("/") + "/embed/" if permalink else ""
+    caption_clean = caption.replace("\n", " ").strip()
+    hashtags = re.findall(r"#\w+", caption)
+    mentions = re.findall(r"@\w+", caption)
+    cta_markers = ["clique", "acesse", "agende", "whatsapp", "link", "bio", "chama", "reserve", "confira"]
+    has_cta = any(m in caption.lower() for m in cta_markers)
+    return {
+        "username": username,
+        "post_id": p.get("id"),
+        "permalink": permalink,
+        "embed_url": embed,
+        "media_type": p.get("media_type"),
+        "format": classify_format(p),
+        "thumbnail_url": p.get("thumbnail_url") or p.get("media_url"),
+        "media_url": p.get("media_url"),
+        "timestamp": p.get("timestamp"),
+        "caption": caption_clean[:1200],
+        "caption_length": len(caption),
+        "hashtags_count": len(hashtags),
+        "mentions_count": len(mentions),
+        "has_cta": has_cta,
+        "like_count": likes,
+        "comments_count": comments,
+        "engagement_proxy": eng,
+    }
+
+
+def weekday_name(ts: str) -> str:
+    try:
+        dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        return ["Mon","Tue","Wed","Thu","Fri","Sat","Sun"][dt.weekday()]
+    except Exception:
+        return ""
+
+
+def hour_bucket(ts: str) -> str:
+    try:
+        dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        return f"{dt.hour:02d}h"
+    except Exception:
+        return ""
+
+
+def aggregate_account(raw_bd: dict, handle: str, since_dt: datetime):
+    posts_all = raw_bd.get("_all_media") or []
+    since_iso = since_dt.isoformat()
+    posts_90d = [p for p in posts_all if (p.get("timestamp") or "") >= since_iso]
+    followers = raw_bd.get("followers_count") or 0
+    enriched = [post_summary(p, handle, followers) for p in posts_90d]
+
+    counts = {"FEED_IMAGE": 0, "CAROUSEL": 0, "REELS": 0, "VIDEO": 0}
+    for e in enriched:
+        counts[e["format"]] = counts.get(e["format"], 0) + 1
+
+    # Cadencia
+    weeks = max(1, round(DAYS_WINDOW / 7))
+    posts_per_week = round(len(enriched) / weeks, 2)
+
+    wd = {}
+    hr = {}
+    for e in enriched:
+        d = weekday_name(e.get("timestamp") or "")
+        h = hour_bucket(e.get("timestamp") or "")
+        if d: wd[d] = wd.get(d, 0) + 1
+        if h: hr[h] = hr.get(h, 0) + 1
+
+    preferred_weekday = max(wd.items(), key=lambda x: x[1])[0] if wd else None
+    preferred_hour = max(hr.items(), key=lambda x: x[1])[0] if hr else None
+
+    # Engajamento
+    likes_avg = round(sum(e["like_count"] for e in enriched) / len(enriched), 1) if enriched else 0
+    comm_avg = round(sum(e["comments_count"] for e in enriched) / len(enriched), 1) if enriched else 0
+    eng_avg = round(sum(e["engagement_proxy"] for e in enriched) / len(enriched), 3) if enriched else 0
+
+    # Melhor formato por engajamento
+    by_fmt = {}
+    for e in enriched:
+        by_fmt.setdefault(e["format"], []).append(e["engagement_proxy"])
+    best_format = None
+    if by_fmt:
+        best_format = max(
+            by_fmt.items(),
+            key=lambda kv: (sum(kv[1]) / len(kv[1])) if kv[1] else 0
+        )[0]
+
+    account = {
+        "username": handle,
+        "name": raw_bd.get("name"),
+        "biography": raw_bd.get("biography"),
+        "profile_picture_url": raw_bd.get("profile_picture_url"),
+        "website": raw_bd.get("website"),
+        "followers_count": followers,
+        "follows_count": raw_bd.get("follows_count"),
+        "media_count_total": raw_bd.get("media_count"),
+        "posts_90d": len(enriched),
+        "permalink": f"https://www.instagram.com/{handle}/",
+    }
+
+    top = sorted(enriched, key=lambda e: e["engagement_proxy"], reverse=True)[:TOP_N]
+    bottom = sorted(enriched, key=lambda e: e["engagement_proxy"])[:BOTTOM_N]
+
+    return {
+        "account": account,
+        "counts": counts,
+        "cadence": {
+            "posts_per_week": posts_per_week,
+            "preferred_weekday": preferred_weekday,
+            "preferred_hour": preferred_hour,
+        },
+        "engagement": {
+            "avg_likes": likes_avg,
+            "avg_comments": comm_avg,
+            "avg_engagement_proxy": eng_avg,
+            "best_format_by_engagement": best_format,
+        },
+        "top_posts": top,
+        "bottom_posts": bottom,
+        "all_posts_90d": enriched,
+    }
+
+
+def pick_competitors(pesquisa_path: Path, briefing_competitor_handles: dict, top_n: int = 2):
+    """
+    Le outputs/geral-pesquisa-mercado.json, ordena por digital_score DESC,
+    retorna lista de (nome, handle) dos top_n com handle conhecido.
+    handle pode vir de digital_details.instagram ou de briefing_competitor_handles (override).
+    """
+    if not pesquisa_path.exists():
+        die(f"Nao encontrei {pesquisa_path} — rode geral-pesquisa-mercado antes")
+    data = json.loads(pesquisa_path.read_text(encoding="utf-8"))
+    comps = data.get("competitors") or []
+    comps_sorted = sorted(comps, key=lambda c: c.get("digital_score") or 0, reverse=True)
+    picked = []
+    for c in comps_sorted:
+        name = c.get("name", "")
+        name_lc = name.lower()
+        handle_raw = ""
+        # 1) Override manual — substring match case-insensitive (a chave pode ser parte do nome)
+        for k, v in briefing_competitor_handles.items():
+            if not k:
+                continue
+            if k in name_lc or name_lc.startswith(k):
+                handle_raw = v
+                break
+        # 2) Extracao do campo instagram do digital_details
+        if not handle_raw:
+            ig_field = ((c.get("digital_details") or {}).get("instagram") or "")
+            m = re.search(r"@([A-Za-z0-9._]+)", ig_field)
+            if m:
+                handle_raw = m.group(1)
+        if handle_raw:
+            picked.append({"name": name, "handle": clean_handle(handle_raw), "digital_score": c.get("digital_score")})
+        if len(picked) >= top_n:
+            break
+    return picked
+
+
+def main():
+    if len(sys.argv) < 2:
+        die("Uso: ig_organic_audit.py <client_dir>")
+    client_dir = Path(sys.argv[1])
+    if not client_dir.exists():
+        die(f"client_dir {client_dir} nao existe")
+
+    cred_path = find_credentials(client_dir)
+    cred = json.loads(cred_path.read_text(encoding="utf-8"))
+    token = cred.get("access_token_long") or cred.get("access_token_short")
+    ig_user_id = cred.get("ig_business_account_v4")
+    if not token or not ig_user_id:
+        die("Credenciais incompletas: falta access_token ou ig_business_account_v4")
+
+    client_json_path = client_dir / "client.json"
+    if not client_json_path.exists():
+        die(f"{client_json_path} nao existe")
+    client_json = json.loads(client_json_path.read_text(encoding="utf-8"))
+
+    briefing = client_json.get("briefing") or {}
+    client_handle_raw = (
+        (briefing.get("identification") or {}).get("instagram")
+        or briefing.get("instagram")
+        or ""
+    )
+    if not client_handle_raw:
+        # procura recursivamente por chave "instagram"
+        def find_ig(obj):
+            if isinstance(obj, dict):
+                for k, v in obj.items():
+                    if k == "instagram" and isinstance(v, str) and v.strip():
+                        return v
+                    r = find_ig(v)
+                    if r: return r
+            elif isinstance(obj, list):
+                for x in obj:
+                    r = find_ig(x)
+                    if r: return r
+            return None
+        client_handle_raw = find_ig(briefing) or ""
+
+    client_handle = clean_handle(client_handle_raw)
+    if not client_handle:
+        die("Handle do Instagram do cliente nao encontrado em client.json (briefing.identification.instagram)")
+
+    # Override manual via env var CMP_HANDLES (formato: "Nome1=@handle1;Nome2=@handle2")
+    manual = {}
+    env = os.environ.get("CMP_HANDLES", "").strip()
+    if env:
+        for pair in env.split(";"):
+            if "=" in pair:
+                k, v = pair.split("=", 1)
+                manual[k.strip().lower()] = clean_handle(v)
+
+    # Concorrentes: top 2 por digital_score em geral-pesquisa-mercado
+    pesquisa_path = client_dir / "outputs" / "geral-pesquisa-mercado.json"
+    competitors = pick_competitors(pesquisa_path, manual, top_n=2)
+    if len(competitors) < 1:
+        die("Nao consegui identificar 2 concorrentes com handle de Instagram — use CMP_HANDLES para override")
+
+    log(f"Cliente: @{client_handle}")
+    for c in competitors:
+        log(f"Concorrente: @{c['handle']} (digital_score={c['digital_score']})")
+
+    since_dt = datetime.now(timezone.utc) - timedelta(days=DAYS_WINDOW)
+    since_iso = since_dt.isoformat()
+
+    accounts = []
+
+    # Cliente
+    log(f"Chamando business_discovery para @{client_handle}...")
+    client_bd = call_business_discovery(ig_user_id, client_handle, token, since_iso)
+    client_agg = aggregate_account(client_bd, client_handle, since_dt)
+    client_agg["_role"] = "client"
+    accounts.append(client_agg)
+
+    # Concorrentes
+    for c in competitors:
+        try:
+            log(f"Chamando business_discovery para @{c['handle']}...")
+            bd = call_business_discovery(ig_user_id, c["handle"], token, since_iso)
+            agg = aggregate_account(bd, c["handle"], since_dt)
+            agg["_role"] = "competitor"
+            agg["account"]["competitor_source_name"] = c["name"]
+            agg["account"]["digital_score"] = c["digital_score"]
+            accounts.append(agg)
+        except Exception as e:
+            log(f"Falha em @{c['handle']}: {e}")
+
+    # Raw
+    cache_dir = client_dir / "cache"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    raw_path = cache_dir / f"ig_organic_audit-{ts}.json"
+    raw_path.write_text(
+        json.dumps(
+            {
+                "fetched_at": datetime.now(timezone.utc).isoformat(),
+                "period": {
+                    "start": since_dt.date().isoformat(),
+                    "end": datetime.now(timezone.utc).date().isoformat(),
+                    "days": DAYS_WINDOW,
+                },
+                "client_handle": client_handle,
+                "accounts": accounts,
+            },
+            ensure_ascii=False,
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    log(f"Raw salvo em {raw_path}")
+
+    # Summary — insumo direto para a skill gerar o output
+    def acc_lite(a):
+        return {
+            "role": a["_role"],
+            "account": a["account"],
+            "counts": a["counts"],
+            "cadence": a["cadence"],
+            "engagement": a["engagement"],
+            "top_posts": a["top_posts"],
+            "bottom_posts": a["bottom_posts"],
+        }
+
+    summary = {
+        "fetched_at": datetime.now(timezone.utc).isoformat(),
+        "period": {
+            "start": since_dt.date().isoformat(),
+            "end": datetime.now(timezone.utc).date().isoformat(),
+            "days": DAYS_WINDOW,
+        },
+        "client": acc_lite(accounts[0]),
+        "competitors": [acc_lite(a) for a in accounts[1:]],
+        "raw_cache_file": str(raw_path.relative_to(client_dir.parent.parent)) if raw_path.is_absolute() else str(raw_path),
+    }
+
+    summary_path = cache_dir / "ig_organic_audit-summary.json"
+    summary_path.write_text(json.dumps(summary, ensure_ascii=False, indent=2), encoding="utf-8")
+    log(f"Summary salvo em {summary_path}")
+
+    # Breve resumo no stdout
+    print()
+    print("=== RESUMO ===")
+    for a in accounts:
+        acc = a["account"]
+        eng = a["engagement"]
+        print(f"@{acc['username']:<30} followers={acc.get('followers_count')} posts_90d={acc.get('posts_90d')} eng={eng['avg_engagement_proxy']}% best={eng['best_format_by_engagement']}")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/gt-diagnostico-organico-instagram/scripts/ig_organic_audit.sh
+++ b/.claude/skills/gt-diagnostico-organico-instagram/scripts/ig_organic_audit.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# ig_organic_audit.sh — Orquestra a auditoria de conteudo organico no Instagram
+# Uso:  ig_organic_audit.sh <client_dir>
+# Ex:   ig_organic_audit.sh squads/{squad}/clientes/{cliente}
+#
+# Opcional (override dos handles dos concorrentes):
+#   CMP_HANDLES="Concorrente 1=@concorrente1;Concorrente 2=@concorrente2" \
+#     ig_organic_audit.sh squads/{squad}/clientes/{cliente}
+
+set -euo pipefail
+
+CLIENT_DIR="${1:?Uso: ig_organic_audit.sh <client_dir>}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PY_SCRIPT="$SCRIPT_DIR/ig_organic_audit.py"
+
+if [ ! -f "$PY_SCRIPT" ]; then
+  echo "ERROR: ig_organic_audit.py nao encontrado em $PY_SCRIPT" >&2
+  exit 1
+fi
+
+if [ ! -d "$CLIENT_DIR" ]; then
+  echo "ERROR: client_dir $CLIENT_DIR nao existe" >&2
+  exit 1
+fi
+
+mkdir -p "$CLIENT_DIR/cache"
+
+echo ">> Rodando ig_organic_audit para $CLIENT_DIR ..."
+python3 "$PY_SCRIPT" "$CLIENT_DIR"
+
+echo
+echo ">> Summary pronto em: $CLIENT_DIR/cache/ig_organic_audit-summary.json"

--- a/.claude/skills/gt-diagnostico-organico-instagram/scripts/ig_profile_screenshot.py
+++ b/.claude/skills/gt-diagnostico-organico-instagram/scripts/ig_profile_screenshot.py
@@ -1,0 +1,135 @@
+"""
+ig_profile_screenshot.py — Captura print do header do perfil Instagram para embed no portal.
+
+Uso:
+    python3 ig_profile_screenshot.py <client_dir> --usernames user1,user2,user3
+    python3 ig_profile_screenshot.py <client_dir>   # le de outputs/gt-diagnostico-organico-instagram.json
+
+Saida:
+    <client_dir>/assets/instagram/<username>.png
+    Atualiza outputs/gt-diagnostico-organico-instagram.json com profile_screenshot_data_uri nos accounts.
+"""
+import asyncio
+import argparse
+import base64
+import json
+import sys
+from pathlib import Path
+
+from playwright.async_api import async_playwright
+
+
+async def snap(page, username, out_path):
+    url = f"https://www.instagram.com/{username}/"
+    await page.goto(url, wait_until="domcontentloaded", timeout=30000)
+    await asyncio.sleep(4)
+    for sel in [
+        'div[role="dialog"] button[aria-label="Close"]',
+        'svg[aria-label="Close"]',
+        'button[aria-label="Close"]',
+    ]:
+        try:
+            el = await page.query_selector(sel)
+            if el:
+                await el.click()
+                break
+        except Exception:
+            pass
+    await asyncio.sleep(1)
+    header = await page.query_selector("header")
+    if not header:
+        return False
+    await header.screenshot(path=str(out_path))
+    return True
+
+
+async def run(client_dir: Path, usernames: list[str]):
+    assets_dir = client_dir / "assets" / "instagram"
+    assets_dir.mkdir(parents=True, exist_ok=True)
+
+    results = {}
+    async with async_playwright() as p:
+        browser = await p.chromium.launch(headless=True)
+        ctx = await browser.new_context(
+            user_agent=(
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36"
+            ),
+            viewport={"width": 1280, "height": 900},
+            device_scale_factor=2,
+        )
+        page = await ctx.new_page()
+        for username in usernames:
+            username = username.strip().lstrip("@")
+            if not username:
+                continue
+            out = assets_dir / f"{username}.png"
+            try:
+                ok = await snap(page, username, out)
+                if ok and out.exists():
+                    data = out.read_bytes()
+                    uri = f"data:image/png;base64,{base64.b64encode(data).decode('ascii')}"
+                    results[username] = {"path": str(out.relative_to(client_dir)), "data_uri": uri, "bytes": len(data)}
+                    print(f"OK  @{username}: {len(data)} bytes -> {out}")
+                else:
+                    print(f"FAIL @{username}: header nao encontrado", file=sys.stderr)
+            except Exception as e:
+                print(f"FAIL @{username}: {e}", file=sys.stderr)
+        await browser.close()
+    return results
+
+
+def update_output(client_dir: Path, results: dict):
+    out_path = client_dir / "outputs" / "gt-diagnostico-organico-instagram.json"
+    if not out_path.exists():
+        return
+    with out_path.open() as f:
+        d = json.load(f)
+    accounts = [d.get("client_account") or {}] + list(d.get("competitor_accounts") or [])
+    for a in accounts:
+        if not a:
+            continue
+        u = (a.get("username") or "").lstrip("@")
+        if u in results:
+            a["profile_screenshot_data_uri"] = results[u]["data_uri"]
+            a["profile_screenshot_path"] = results[u]["path"]
+    with out_path.open("w") as f:
+        json.dump(d, f, ensure_ascii=False, indent=2)
+    print(f"Atualizado {out_path}")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("client_dir", type=Path)
+    ap.add_argument("--usernames", type=str, default="")
+    args = ap.parse_args()
+
+    if args.usernames:
+        usernames = [u.strip() for u in args.usernames.split(",") if u.strip()]
+    else:
+        out = args.client_dir / "outputs" / "gt-diagnostico-organico-instagram.json"
+        if not out.exists():
+            print("ERROR: --usernames nao fornecido e nao ha gt-diagnostico-organico-instagram.json", file=sys.stderr)
+            sys.exit(1)
+        with out.open() as f:
+            d = json.load(f)
+        usernames = []
+        c = d.get("client_account")
+        if c and c.get("username"):
+            usernames.append(c["username"])
+        for comp in d.get("competitor_accounts") or []:
+            if comp.get("username"):
+                usernames.append(comp["username"])
+
+    if not usernames:
+        print("ERROR: nenhum username para capturar", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Capturando {len(usernames)} perfis: {', '.join('@'+u for u in usernames)}")
+    results = asyncio.run(run(args.client_dir, usernames))
+    if results:
+        update_output(args.client_dir, results)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/gt-diagnostico-organico-instagram/scripts/requirements-meta.txt
+++ b/.claude/skills/gt-diagnostico-organico-instagram/scripts/requirements-meta.txt
@@ -1,0 +1,2 @@
+playwright==1.48.0
+requests==2.32.3

--- a/.claude/skills/gt-forecast-midia/SKILL.md
+++ b/.claude/skills/gt-forecast-midia/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: gt-forecast-midia
+description: "Cria o forecast e plano de mídia de 6 meses: modelagem financeira evolutiva, distribuição por plataforma/funil, campanhas detalhadas (TECR), cronograma e assumptions explícitas. Output exportado para Google Sheets. Use quando disser /gt-forecast-midia ou 'planejamento de mídia' ou 'forecast' ou 'budget de anúncios'."
+area: gt
+author: luizfreitasv4
+version: 1.0.0
+dependencies:
+  - gt-diagnostico-midia-paga
+inputs:
+  - client.json (briefing)
+  - gt-diagnostico-midia-paga.json
+  - geral-persona-icp.json
+  - geral-posicionamento-estrategico.json
+output: gt-forecast-midia.json
+export: google-sheets
+week: 4
+type: automated
+estimated_time: "2h"
+---
+
+## Compatibilidade com o Builders Hub
+
+Esta versao foi portada do sistema de Estruturacao Estrategica. As regras abaixo tem precedencia sobre caminhos e persistencia citados no fluxo original:
+
+- Trabalhe somente em `squads/{squad}/clientes/{cliente}/`, nunca em um diretorio `clientes/` solto na raiz.
+- Leia primeiro o `CLAUDE.md` ou `AGENTS.md` da KB, `mission-control/`, `calls/`, `docs/` e `campanhas/`.
+- Se `client.json` existir, use-o como fonte complementar. Se nao existir, derive o contexto da KB e do Mission Control; nao exija nem invente esse arquivo.
+- Salve entregaveis em `squads/{squad}/clientes/{cliente}/outputs/`, em JSON e Markdown quando o fluxo pedir ambos.
+- Registre decisoes e progresso no `mission-control/historico-checkins.md` ou no arquivo de historico equivalente encontrado na KB.
+- Resolva recursos empacotados a partir do proprio diretorio desta skill. Se uma integracao externa nao estiver configurada, declare o gap e continue apenas com os dados reais disponiveis.
+
+
+# Forecast e Plano de Mídia — 6 Meses (POP 3.12)
+
+> **Posição no fluxo:** Semana 4 — Identidade de Comunicação e Plano de Mídia (**comum** a todos os modelos) (e-commerce / inside-sales / pdv) — entregável final que amarra toda a estratégia. Horizonte de **6 meses** com curva evolutiva (não linear) e **assumptions explícitas**. Se mudar a premissa, refaz o forecast.
+
+Você é um especialista em planejamento de mídia paga para PMEs brasileiras. Vai criar o forecast completo de 6 meses: budget recomendado, distribuição por plataforma e funil, campanhas detalhadas, metas de resultado evolutivas e critérios de alerta.
+
+## Dados necessários
+
+1. `client.json` (seção `briefing`) — nome, segmento, budget disponível, ticket médio, objetivo
+2. `outputs/gt-diagnostico-midia-paga.json` — análise de mídia atual, CPL/ROAS atual, problemas, benchmarks
+3. `outputs/geral-persona-icp.json` — ICP, canais preferidos
+4. `outputs/geral-posicionamento-estrategico.json` — PUV, diferenciais
+5. `client.json` (seção `history`) — decisões anteriores
+
+Consulte `references/benchmarks-forecast.md` para benchmarks de CPL/ROAS por segmento.
+
+---
+
+## Geração
+
+Gere o output COMPLETO de uma vez: modelagem + distribuição + cronograma + alertas. Use os dados de `client.json` (briefing) e outputs de skills dependentes em `outputs/`.
+
+### Premissas (explicitar todas)
+
+CPL estimado (com fonte), taxa de conversão, ROAS esperado, ramp-up (Mês 1 tem CPL 20-30% maior), sazonalidade.
+
+### Modelagem financeira de 6 meses (evolutiva, não linear)
+
+Fases: **M1 setup/aprendizado** · **M2–M3 otimização** · **M4–M6 escala**.
+
+| Métrica | M1 (setup) | M2 | M3 | M4 | M5 | M6 |
+|---|---|---|---|---|---|---|
+| Budget, CPL, Leads, Taxa conversão, Vendas, Faturamento, ROAS |
+
+A curva evolui: M1 com CPL 20-30% maior (aprendizado), ganho gradual de eficiência em M2-M3, escala em M4-M6. NÃO modele crescimento linear ("+10%/mês").
+
+**Cenários:** Otimista (CPL -20%, conversão +20%), Realista (benchmarks), Pessimista (CPL +30%, conversão -20%).
+
+### Campanhas detalhadas (TECR)
+
+Para cada campanha: **T**ópico, **E**stratégia, **C**onjunto (segmentação/criativos), **R**esultado esperado — com objetivo, verba e fase de funil.
+
+### Distribuição por plataforma
+
+| Plataforma | % do budget | R$/mês | Objetivo principal |
+Lógica: ICP busca no Google? → Google Search. ICP impactado visual? → Meta. Budget < R$3k? → 1 plataforma só.
+
+### Distribuição por fase do funil
+
+| Fase | % do budget | Objetivo |
+Regras: Marca nova → mais topo (40-50%). Marca conhecida → mais fundo (40-50%). Remarketing sempre 10-15%.
+
+### Cronograma de 6 meses (180 dias)
+
+*M1 (Setup/Aprendizado):* configuração, lançamento, primeiras otimizações. Meta e ações semanais.
+*M2–M3 (Otimização):* eliminar piores, escalar melhores, novos hooks, calibrar segmentação. Metas e ações.
+*M4–M6 (Escala):* dobrar budget nos melhores, expandir lookalike/novas praças, sustentar eficiência. Metas e ações.
+
+Cada fase com `assumptions` e `dependencies` explícitas (criativo pronto, LP no ar, SDR treinado).
+
+### Alertas e critérios de pausa
+
+| Métrica | Limite de alerta | Ação imediata |
+CPL, CTR, ROAS, CPC, Frequência, Budget diário.
+
+### Critérios de escala
+
+| Métrica | Limite para escalar | Ação |
+
+### Disclaimer
+
+Variáveis que podem impactar: qualidade dos criativos, velocidade de aprovação, sazonalidade, tempo de resposta aos leads, mudanças de algoritmo, concorrência, qualidade da LP.
+
+### Exportação para Google Sheets
+
+```bash
+gog sheets create --title "Forecast Mídia - {NOME_CLIENTE}" --no-input
+```
+5 abas: Modelagem Financeira (6 meses), Distribuição, Cronograma 6 Meses, Alertas/Critérios, Assumptions/Premissas.
+
+## Auto-validação
+
+Antes de mostrar ao operador, verifique:
+
+- [ ] Mencionou o cliente pelo nome?
+- [ ] Usou dados reais do client.json (não inventou)?
+- [ ] Nenhum item genérico (ex: "quer crescer", "qualidade e compromisso")?
+- [ ] Schema da skill validou?
+- [ ] Todos os campos do schema preenchidos (ou com `null` + `unavailable_reason` no pai)?
+- [ ] Nenhuma string vazia (`""`) — substituí por `null` + reason quando o dado não existe?
+- [ ] Estimativas marcadas com `estimated: true` ou `[E]`?
+- [ ] Consistente com outputs anteriores (diagnóstico de mídia)?
+- [ ] Premissas têm fonte (não "números mágicos")?
+- [ ] Cenário pessimista é realista (não assustador demais)?
+- [ ] Disclaimer é honesto sobre variáveis de risco?
+
+Se falhou → regenere silenciosamente. Não avise o operador.
+
+## Apresentação e decisões
+
+Apresente o output COMPLETO ao operador.
+
+Revise o output. O que está errado, exagerado ou faltando?
+
+- "O budget mensal de R$ {BUDGET_MENSAL} está confirmado?"
+- "O ticket médio de R$ {TICKET_MEDIO} está correto?"
+- "A taxa de conversão é realista para o processo comercial atual?"
+- "O cronograma é factível com os recursos disponíveis?"
+- "Os limites de alerta são adequados?"
+- "O disclaimer é honesto? O cliente vai entender que forecast não é garantia?"
+
+## Finalização
+
+Operador aprova (com ou sem ajustes).
+1. Salve em `squads/{squad}/clientes/{cliente}/outputs/gt-forecast-midia.json` (com campo `summary` no topo, incluindo link Sheets)
+2. Atualize `client.json`: progress.skills → completed, version++, append em history[]
+3. Salve também uma versão Markdown do entregável na mesma pasta de outputs.
+4. Sugira próxima skill do dependency_graph
+
+## Formato do output (gt-forecast-midia.json)
+
+```json
+{
+  "financial_model": [{ "month": 1, "label": "Ramp-up", "budget": 0, "cpl": 0, "leads": 0, "conversion_rate": 0, "sales": 0, "revenue": 0, "roas": 0 }],
+  "assumptions": ["string"],
+  "scenarios": { "optimistic": {}, "realistic": {}, "pessimistic": {} },
+  "platform_distribution": [{ "platform": "Meta Ads", "percentage": 0, "monthly_value": 0, "objective": "string" }],
+  "funnel_distribution": [{ "phase": "Topo", "percentage": 0, "objective": "string" }],
+  "timeline": [{ "month": 1, "focus": "Ramp-up", "weekly_actions": ["string"], "goal": "string" }],
+  "alerts": [{ "metric": "CPL", "threshold": "> R$ X", "action": "string" }],
+  "scale_criteria": [{ "metric": "ROAS", "threshold": "> Xx", "action": "string" }],
+  "disclaimer": ["string"],
+  "sheets_url": "string"
+}
+```
+
+
+## Campo obrigatório: summary
+
+Sempre inclua no JSON de saída:
+```json
+"summary": "Resumo de 1-2 frases do forecast de mídia: investimento total, leads projetados e ROAS esperado. Seja específico — mencione o cliente, números reais e a conclusão principal."
+```
+
+Este campo alimenta o Resumo Executivo do portal de entregas. Deve ser objetivo, com dados reais, sem genéricos.

--- a/.claude/skills/gt-forecast-midia/references/benchmarks-forecast.md
+++ b/.claude/skills/gt-forecast-midia/references/benchmarks-forecast.md
@@ -1,0 +1,280 @@
+# Benchmarks de CPL, ROAS e Métricas por Segmento — Brasil 2025-2026
+
+Referência para calibrar premissas do forecast de mídia. Dados compilados de benchmarks públicos, relatórios de mercado e médias operacionais da V4 Company.
+
+**IMPORTANTE:** Benchmarks são referência, não garantia. O CPL real depende de qualidade dos criativos, LP, processo comercial e mercado local. Sempre use dados históricos do próprio cliente quando disponíveis.
+
+---
+
+## Metodologia
+
+- CPL = custo por lead (formulário, WhatsApp, ligação)
+- ROAS = faturamento gerado / budget de mídia investido
+- CAC = custo de aquisição de cliente (budget + operação)
+- CTR = taxa de clique (cliques / impressões)
+- CVR = taxa de conversão (leads / cliques)
+- Ticket = valor médio de uma venda
+
+Faixas: Baixo (bottom 25%) | Médio (mediana) | Alto (top 25%)
+
+---
+
+## Saúde e Bem-Estar (Clínicas, Estéticas, Academias)
+
+### Meta Ads
+| Métrica | Baixo | Médio | Alto |
+|---------|-------|-------|------|
+| CPL | R$ 25 | R$ 45 | R$ 80 |
+| CTR | 0.8% | 1.5% | 2.5% |
+| CVR LP | 8% | 15% | 25% |
+| CPC | R$ 1.50 | R$ 3.00 | R$ 6.00 |
+
+### Google Ads (Search)
+| Métrica | Baixo | Médio | Alto |
+|---------|-------|-------|------|
+| CPL | R$ 35 | R$ 70 | R$ 150 |
+| CTR | 3% | 6% | 12% |
+| CPC | R$ 2.00 | R$ 5.00 | R$ 12.00 |
+
+### Métricas de negócio
+| Métrica | Valor típico |
+|---------|-------------|
+| Ticket médio | R$ 200-800 (procedimento) / R$ 100-250 (mensalidade) |
+| Conversão lead→venda | 15-30% |
+| ROAS esperado | 3x-8x |
+| Ciclo de venda | 3-14 dias |
+
+### Notas do segmento
+- Procedimentos estéticos: CPL mais alto, ticket mais alto, compensação por ROAS
+- Academias: CPL mais baixo, ticket menor, foco em volume
+- Clínicas médicas: restrições de anúncio (CFM), CPL alto em Search
+- Sazonalidade: janeiro (promessas de ano novo), março-abril (pré-inverno estético)
+
+---
+
+## Alimentação e Gastronomia (Restaurantes, Delivery, Food)
+
+### Meta Ads
+| Métrica | Baixo | Médio | Alto |
+|---------|-------|-------|------|
+| CPL | R$ 5 | R$ 15 | R$ 30 |
+| CTR | 1.5% | 3.0% | 5.0% |
+| CVR LP | 12% | 20% | 35% |
+| CPC | R$ 0.50 | R$ 1.50 | R$ 3.00 |
+
+### Google Ads (Search)
+| Métrica | Baixo | Médio | Alto |
+|---------|-------|-------|------|
+| CPL | R$ 10 | R$ 25 | R$ 50 |
+| CTR | 4% | 8% | 15% |
+| CPC | R$ 1.00 | R$ 3.00 | R$ 7.00 |
+
+### Métricas de negócio
+| Métrica | Valor típico |
+|---------|-------------|
+| Ticket médio | R$ 40-120 (delivery) / R$ 80-300 (presencial) |
+| Conversão lead→pedido | 20-40% |
+| ROAS esperado | 5x-15x |
+| Ciclo de decisão | Imediato a 3 dias |
+
+### Notas do segmento
+- CPL baixo mas ticket baixo — precisa de volume
+- Instagram Stories performa muito bem (comida é visual)
+- Google Maps/GMB é essencial (busca local)
+- Sazonalidade: datas comemorativas, feriados, finais de semana
+
+---
+
+## Tecnologia e SaaS (Software, Plataformas, Tools)
+
+### Meta Ads
+| Métrica | Baixo | Médio | Alto |
+|---------|-------|-------|------|
+| CPL | R$ 30 | R$ 80 | R$ 200 |
+| CTR | 0.5% | 1.2% | 2.0% |
+| CVR LP | 5% | 12% | 20% |
+| CPC | R$ 2.00 | R$ 5.00 | R$ 15.00 |
+
+### Google Ads (Search)
+| Métrica | Baixo | Médio | Alto |
+|---------|-------|-------|------|
+| CPL | R$ 50 | R$ 120 | R$ 300 |
+| CTR | 2% | 5% | 10% |
+| CPC | R$ 3.00 | R$ 8.00 | R$ 25.00 |
+
+### Métricas de negócio
+| Métrica | Valor típico |
+|---------|-------------|
+| Ticket médio | R$ 99-999/mês (SaaS) / R$ 5K-50K (projeto) |
+| Conversão lead→trial | 20-35% |
+| Conversão trial→paying | 10-25% |
+| ROAS esperado | 3x-10x (depende muito do LTV) |
+| Ciclo de venda | 14-90 dias |
+
+### Notas do segmento
+- CPL alto mas LTV alto — avaliar por CAC/LTV, não ROAS imediato
+- Google Search é rei (intenção de compra)
+- LinkedIn Ads pode ser mais eficiente para B2B tech (não coberto aqui)
+- Free trial / freemium reduz CPL mas dilui conversão
+
+---
+
+## Educação e Cursos (Infoprodutos, Mentorias, Escolas)
+
+### Meta Ads
+| Métrica | Baixo | Médio | Alto |
+|---------|-------|-------|------|
+| CPL | R$ 5 | R$ 20 | R$ 60 |
+| CTR | 1.0% | 2.5% | 4.0% |
+| CVR LP | 10% | 22% | 40% |
+| CPC | R$ 0.50 | R$ 2.00 | R$ 5.00 |
+
+### Google Ads (Search)
+| Métrica | Baixo | Médio | Alto |
+|---------|-------|-------|------|
+| CPL | R$ 15 | R$ 40 | R$ 100 |
+| CTR | 3% | 7% | 14% |
+| CPC | R$ 1.50 | R$ 4.00 | R$ 10.00 |
+
+### Métricas de negócio
+| Métrica | Valor típico |
+|---------|-------------|
+| Ticket médio | R$ 97-997 (curso) / R$ 3K-15K (mentoria) |
+| Conversão lead→venda | 2-8% (lançamento) / 5-15% (perpétuo) |
+| ROAS esperado | 3x-12x |
+| Ciclo de venda | 7-30 dias (lançamento) / imediato (perpétuo low-ticket) |
+
+### Notas do segmento
+- Lançamentos: budget concentrado em janela curta, CPL cai durante campanha
+- Perpétuo: budget constante, otimização contínua
+- YouTube Ads pode ter CPL 40% menor que Meta para educação
+- Webinar como funil intermediário reduz CPL mas adiciona etapa
+
+---
+
+## Serviços B2B / Consultoria (Contabilidade, Jurídico, Marketing)
+
+### Meta Ads
+| Métrica | Baixo | Médio | Alto |
+|---------|-------|-------|------|
+| CPL | R$ 40 | R$ 90 | R$ 200 |
+| CTR | 0.5% | 1.0% | 1.8% |
+| CVR LP | 5% | 10% | 18% |
+| CPC | R$ 3.00 | R$ 8.00 | R$ 20.00 |
+
+### Google Ads (Search)
+| Métrica | Baixo | Médio | Alto |
+|---------|-------|-------|------|
+| CPL | R$ 60 | R$ 150 | R$ 350 |
+| CTR | 2% | 5% | 9% |
+| CPC | R$ 5.00 | R$ 15.00 | R$ 40.00 |
+
+### Métricas de negócio
+| Métrica | Valor típico |
+|---------|-------------|
+| Ticket médio | R$ 500-5K/mês (recorrente) / R$ 5K-50K (projeto) |
+| Conversão lead→reunião | 20-40% |
+| Conversão reunião→venda | 15-35% |
+| ROAS esperado | 5x-20x (por causa do LTV alto) |
+| Ciclo de venda | 15-60 dias |
+
+### Notas do segmento
+- CPL alto mas ticket alto — ROAS compensatório
+- Google Search > Meta para serviços de necessidade (contabilidade, jurídico)
+- Meta > Google para serviços de oportunidade (consultoria, coaching)
+- Material rico (ebook, diagnóstico gratuito) reduz CPL em 30-50%
+
+---
+
+## Beleza e Estética (Salões, Clínicas, E-commerce de Cosméticos)
+
+### Meta Ads
+| Métrica | Baixo | Médio | Alto |
+|---------|-------|-------|------|
+| CPL | R$ 8 | R$ 25 | R$ 50 |
+| CTR | 1.2% | 2.5% | 4.0% |
+| CVR LP | 10% | 18% | 30% |
+| CPC | R$ 0.80 | R$ 2.50 | R$ 5.00 |
+
+### Métricas de negócio
+| Métrica | Valor típico |
+|---------|-------------|
+| Ticket médio | R$ 80-400 (serviço) / R$ 50-200 (produto) |
+| Conversão lead→agendamento | 25-45% |
+| ROAS esperado | 4x-10x |
+| Ciclo de decisão | 1-7 dias |
+
+---
+
+## Imóveis e Construção
+
+### Meta Ads
+| Métrica | Baixo | Médio | Alto |
+|---------|-------|-------|------|
+| CPL | R$ 30 | R$ 80 | R$ 200 |
+| CTR | 0.5% | 1.2% | 2.2% |
+| CPC | R$ 2.00 | R$ 6.00 | R$ 15.00 |
+
+### Google Ads (Search)
+| Métrica | Baixo | Médio | Alto |
+|---------|-------|-------|------|
+| CPL | R$ 50 | R$ 130 | R$ 300 |
+| CTR | 2% | 5% | 9% |
+| CPC | R$ 4.00 | R$ 12.00 | R$ 30.00 |
+
+### Métricas de negócio
+| Métrica | Valor típico |
+|---------|-------------|
+| Ticket médio | R$ 200K-2M (imóvel) / R$ 50K-500K (reforma) |
+| Conversão lead→visita | 10-25% |
+| Conversão visita→venda | 5-15% |
+| ROAS esperado | 20x-100x (ticket altíssimo compensa CPL alto) |
+| Ciclo de venda | 30-180 dias |
+
+---
+
+## Fitness e Esportes
+
+### Meta Ads
+| Métrica | Baixo | Médio | Alto |
+|---------|-------|-------|------|
+| CPL | R$ 10 | R$ 30 | R$ 60 |
+| CTR | 1.0% | 2.2% | 3.5% |
+| CVR LP | 8% | 15% | 28% |
+
+### Métricas de negócio
+| Métrica | Valor típico |
+|---------|-------------|
+| Ticket médio | R$ 100-300/mês (academia) / R$ 200-500/mês (personal) |
+| Conversão lead→matrícula | 15-30% |
+| ROAS esperado | 3x-8x |
+| Churn mensal | 5-15% |
+
+---
+
+## Tabela Resumo — CPL Médio por Segmento (Meta Ads)
+
+| Segmento | CPL Médio | Ticket Médio | ROAS Típico |
+|----------|----------|-------------|-------------|
+| Alimentação | R$ 15 | R$ 80 | 8x |
+| Educação | R$ 20 | R$ 400 | 6x |
+| Beleza | R$ 25 | R$ 200 | 6x |
+| Fitness | R$ 30 | R$ 200 | 5x |
+| Saúde | R$ 45 | R$ 400 | 5x |
+| Tecnologia | R$ 80 | R$ 500 | 5x |
+| Imóveis | R$ 80 | R$ 500K | 50x |
+| B2B | R$ 90 | R$ 2K | 10x |
+
+---
+
+## Regras para Usar Benchmarks no Forecast
+
+1. **Sempre use dados do próprio cliente quando disponíveis** — benchmark é fallback
+2. **Mês 1 = CPL 20-30% acima do benchmark** — fase de aprendizado do algoritmo
+3. **Mês 2 = benchmark** — otimizações começam a fazer efeito
+4. **Mês 3 = CPL 10-15% abaixo do benchmark** — anúncios otimizados, público refinado
+5. **Budget < R$ 2K/mês = CPL 30-50% acima** — pouco volume para otimizar
+6. **Budget > R$ 10K/mês = CPL pode ser 10-20% abaixo** — mais dados = mais otimização
+7. **Cidades pequenas = CPL geralmente menor** (menos concorrência) mas menos volume
+8. **Capitais / SP+RJ = CPL geralmente maior** (mais concorrência) mas mais volume
+9. **Nunca use benchmarks como garantia para o cliente** — sempre apresente como estimativa com disclaimer

--- a/.claude/skills/gt-forecast-midia/schema.json
+++ b/.claude/skills/gt-forecast-midia/schema.json
@@ -1,0 +1,405 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Forecast de Mídia",
+  "description": "Forecast operacional de 6 meses com split de canais, plano de campanhas, métricas de tracking e evolução mensal projetada. Baseline conservador — não modela ROAS/receita financeira.",
+  "type": "object",
+  "required": [
+    "client_name",
+    "summary",
+    "summary_headline",
+    "horizon",
+    "currency",
+    "scenario_stance",
+    "channel_split",
+    "campaigns",
+    "tracking_metrics",
+    "forecast_6_months",
+    "assumptions_and_dependencies",
+    "summary_highlights",
+    "summary_key_findings"
+  ],
+  "properties": {
+    "client_name": {
+      "type": "string",
+      "description": "Nome do cliente — sempre presente em todo output."
+    },
+    "summary": {
+      "type": "string",
+      "description": "Resumo em 1-2 parágrafos com o veredito do forecast. Específico, com números reais."
+    },
+    "summary_headline": {
+      "type": "string",
+      "description": "Manchete em 1 linha (~120 chars) com o veredito principal."
+    },
+    "summary_highlights": {
+      "type": "array",
+      "description": "KPIs em destaque (4-6 itens). Categorias: maturidade | janela | oportunidade | risco | competicao | posicao.",
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "label",
+          "value",
+          "tone"
+        ],
+        "properties": {
+          "category": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "subtext": {
+            "type": "string"
+          },
+          "tone": {
+            "type": "string",
+            "enum": [
+              "green",
+              "yellow",
+              "red",
+              "blue",
+              "gray"
+            ]
+          }
+        }
+      }
+    },
+    "summary_key_findings": {
+      "type": "array",
+      "description": "3-5 achados categorizados (vantagem | contexto | ameaca | acao).",
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "text"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "vantagem",
+              "contexto",
+              "ameaca",
+              "acao"
+            ]
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "horizon": {
+      "type": "string",
+      "description": "Janela temporal coberta (ex: 'Maio/2026 — Outubro/2026 (6 meses)')."
+    },
+    "currency": {
+      "type": "string",
+      "description": "Moeda base — normalmente 'BRL'."
+    },
+    "scenario_stance": {
+      "type": "string",
+      "description": "Postura do cenário (ULTRA conservador / Conservador / Realista / Otimista) com justificativa."
+    },
+    "channel_split": {
+      "type": "object",
+      "required": [
+        "total_monthly_budget",
+        "rationale",
+        "channels"
+      ],
+      "properties": {
+        "total_monthly_budget": {
+          "type": "number"
+        },
+        "rationale": {
+          "type": "string"
+        },
+        "channels": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": [
+              "channel",
+              "percentage",
+              "monthly_value",
+              "primary_intent"
+            ],
+            "properties": {
+              "channel": {
+                "type": "string"
+              },
+              "percentage": {
+                "type": "number"
+              },
+              "monthly_value": {
+                "type": "number"
+              },
+              "primary_intent": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "campaigns": {
+      "type": "object",
+      "description": "Plano de campanhas concentradas por canal. Estrutura aberta — varia conforme split.",
+      "required": [
+        "concentration_note"
+      ],
+      "properties": {
+        "concentration_note": {
+          "type": "string"
+        }
+      }
+    },
+    "tracking_metrics": {
+      "type": "object",
+      "required": [
+        "description",
+        "metrics"
+      ],
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "metrics": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": [
+              "id",
+              "metric",
+              "definition",
+              "source",
+              "frequency"
+            ],
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "metric": {
+                "type": "string"
+              },
+              "definition": {
+                "type": "string"
+              },
+              "source": {
+                "type": "string"
+              },
+              "frequency": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "forecast_6_months": {
+      "type": "object",
+      "required": [
+        "description",
+        "evolution_logic",
+        "monthly_evolution",
+        "totals_6_months"
+      ],
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "evolution_logic": {
+          "type": "string"
+        },
+        "monthly_evolution": {
+          "type": "array",
+          "minItems": 6,
+          "maxItems": 6,
+          "items": {
+            "type": "object",
+            "required": [
+              "month",
+              "label",
+              "phase",
+              "impressions",
+              "clicks",
+              "leads",
+              "cpl"
+            ],
+            "properties": {
+              "month": {
+                "type": "integer"
+              },
+              "label": {
+                "type": "string"
+              },
+              "phase": {
+                "type": "string"
+              },
+              "impressions": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "clicks": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "ctr_pct": {
+                "type": "number"
+              },
+              "cpc": {
+                "type": "number"
+              },
+              "leads": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "cpl": {
+                "type": "number"
+              },
+              "mql_rate_pct": {
+                "type": "number"
+              },
+              "mqls": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "appointments": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "show_rate_pct": {
+                "type": "number"
+              },
+              "served_clients": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "cac_media": {
+                "type": "number"
+              }
+            }
+          }
+        },
+        "totals_6_months": {
+          "type": "object",
+          "properties": {
+            "total_investment": {
+              "type": "number"
+            },
+            "total_impressions": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "total_clicks": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "avg_ctr_pct": {
+              "type": "number"
+            },
+            "avg_cpc": {
+              "type": "number"
+            },
+            "total_leads": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "avg_cpl": {
+              "type": "number"
+            },
+            "avg_mql_rate_pct": {
+              "type": "number"
+            },
+            "total_mqls": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "total_appointments": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "avg_show_rate_pct": {
+              "type": "number"
+            },
+            "total_served_clients": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "avg_cac_media": {
+              "type": "number"
+            }
+          }
+        }
+      }
+    },
+    "assumptions_and_dependencies": {
+      "type": "array",
+      "description": "Premissas, dependências e disclaimers explícitos do forecast.",
+      "minItems": 3,
+      "items": {
+        "type": "string"
+      }
+    },
+    "_metadata": {
+      "type": "object",
+      "properties": {
+        "skill": {
+          "type": "string"
+        },
+        "version": {
+          "type": [
+            "integer",
+            "number"
+          ]
+        },
+        "generated_at": {
+          "type": "string"
+        },
+        "version_notes": {
+          "type": "string"
+        },
+        "depends_on": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "next_iteration": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## O que é

Cinco diagnósticos e um forecast, pra gestão de tráfego.

| Skill | Faz |
|---|---|
| `gt-diagnostico-maturidade-digital` | Score nos 5 pilares (mídia, orgânico, criativos, CRM, CRO), benchmark setorial e sequência de turnaround |
| `gt-diagnostico-midia-paga` | Métricas atuais contra benchmark, top 3 problemas e plano de 30 dias; puxa dado real do V4MOS |
| `gt-diagnostico-criativos` | Análise multimodal dos criativos: matriz de avaliação, padrões, concorrentes e briefing de produção |
| `gt-diagnostico-cro` | Análise técnica da LP, auditoria de copy, hipóteses de teste e wireframe de melhorias |
| `gt-diagnostico-organico-instagram` | Cliente contra 2 concorrentes nos últimos 90 dias via Instagram Graph API |
| `gt-forecast-midia` | Forecast de 6 meses: modelagem evolutiva, distribuição por plataforma e funil, campanhas em TECR, cronograma e assumptions explícitas |

O forecast sai pro Google Sheets. As assumptions ficam declaradas no output de propósito — número de plano de mídia sem premissa visível não dá pra defender em call.

## Checagens

- Duplo-write verificado
- `REGISTRY.md` fora do PR — a Action regenera no merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)